### PR TITLE
Update theme key lookup

### DIFF
--- a/sand-transition.js
+++ b/sand-transition.js
@@ -43,9 +43,9 @@ window.sandTransition = (function() {
 
   // Encontra o tema de destino baseado no href
   function getThemeForHref(href) {
-    if (href.includes('cv_general.html')) return THEMES['cv_general.html'];
-    if (href.includes('sicredi.html')) return THEMES['sicredi.html'];
-    return THEMES['cv_general.html'];
+    if (href.includes('cv_general.html')) return THEMES['cv_general'];
+    if (href.includes('sicredi.html')) return THEMES['sicredi'];
+    return THEMES['cv_general'];
   }
 
   // Cria e executa a animação de areia


### PR DESCRIPTION
## Summary
- fix theme lookup in `getThemeForHref`

## Testing
- `node - <<'NODE'
const fs=require('fs');
const code=fs.readFileSync('sand-transition.js','utf8');
const match=code.match(/function getThemeForHref\(href\) {[^}]+}/);
const vm=require('vm');
const ctx={THEMES:{cv_general:{primary:'blue'},sicredi:{primary:'green'}},res1:null,res2:null};
vm.createContext(ctx);
vm.runInContext(match[0]+"\nres1=getThemeForHref('cv_general.html');res2=getThemeForHref('sicredi.html');",ctx);
console.log('cv_general', ctx.res1);
console.log('sicredi', ctx.res2);
NODE

------
https://chatgpt.com/codex/tasks/task_e_6843a8c481988324894566c55f824185