### PR TITLE
Update age from 33 to 35 across all CV pages

### DIFF
--- a/cv_styles/cv_act_style_EN.html
+++ b/cv_styles/cv_act_style_EN.html
@@ -507,7 +507,7 @@
 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 33 years old
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
                     </div>
 
                     <div class="contact-item">

--- a/cv_styles/cv_act_style_PT.html
+++ b/cv_styles/cv_act_style_PT.html
@@ -507,7 +507,7 @@
 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 35 anos
                     </div>
 
                     <div class="contact-item">

--- a/cv_styles/cv_allos_style.html
+++ b/cv_styles/cv_allos_style.html
@@ -706,7 +706,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_allos_style_EN.html
+++ b/cv_styles/cv_allos_style_EN.html
@@ -608,7 +608,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 33 years old
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_banco-bv_style.html
+++ b/cv_styles/cv_banco-bv_style.html
@@ -608,7 +608,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_banco-bv_style_EN.html
+++ b/cv_styles/cv_banco-bv_style_EN.html
@@ -608,7 +608,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 33 years old
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_boticario_style.html
+++ b/cv_styles/cv_boticario_style.html
@@ -469,7 +469,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_boticario_style_EN.html
+++ b/cv_styles/cv_boticario_style_EN.html
@@ -469,7 +469,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 33 years old
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_boticario_style_PT.html
+++ b/cv_styles/cv_boticario_style_PT.html
@@ -469,7 +469,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_bradesco_style_EN.html
+++ b/cv_styles/cv_bradesco_style_EN.html
@@ -608,7 +608,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 33 years old
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_bradesco_style_PT.html
+++ b/cv_styles/cv_bradesco_style_PT.html
@@ -608,7 +608,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_cadastra_style.html
+++ b/cv_styles/cv_cadastra_style.html
@@ -610,7 +610,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_cadastra_style_EN.html
+++ b/cv_styles/cv_cadastra_style_EN.html
@@ -610,7 +610,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 33 years old
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_cadastra_style_PT.html
+++ b/cv_styles/cv_cadastra_style_PT.html
@@ -610,7 +610,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_cielo_style_EN.html
+++ b/cv_styles/cv_cielo_style_EN.html
@@ -608,7 +608,7 @@
 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 33 years old
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
                     </div>
 
                     <div class="contact-item">

--- a/cv_styles/cv_cielo_style_PT.html
+++ b/cv_styles/cv_cielo_style_PT.html
@@ -608,7 +608,7 @@
 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 35 anos
                     </div>
 
                     <div class="contact-item">

--- a/cv_styles/cv_contaazul_style.html
+++ b/cv_styles/cv_contaazul_style.html
@@ -608,7 +608,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_contaazul_style_EN.html
+++ b/cv_styles/cv_contaazul_style_EN.html
@@ -608,7 +608,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 33 years old
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_general_style.html
+++ b/cv_styles/cv_general_style.html
@@ -608,7 +608,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_general_style_EN.html
+++ b/cv_styles/cv_general_style_EN.html
@@ -608,7 +608,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 33 years old
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_grupofleury_style_EN.html
+++ b/cv_styles/cv_grupofleury_style_EN.html
@@ -652,7 +652,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 33 years old
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_grupofleury_style_PT.html
+++ b/cv_styles/cv_grupofleury_style_PT.html
@@ -1128,7 +1128,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_hyland_style.html
+++ b/cv_styles/cv_hyland_style.html
@@ -623,7 +623,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_hyland_style_EN.html
+++ b/cv_styles/cv_hyland_style_EN.html
@@ -622,7 +622,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 33 years old
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_hyland_style_PT.html
+++ b/cv_styles/cv_hyland_style_PT.html
@@ -623,7 +623,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_ifood_style.html
+++ b/cv_styles/cv_ifood_style.html
@@ -654,7 +654,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_ifood_style_EN.html
+++ b/cv_styles/cv_ifood_style_EN.html
@@ -653,7 +653,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 33 years old
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_lisinski-law-firm_style.html
+++ b/cv_styles/cv_lisinski-law-firm_style.html
@@ -608,7 +608,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_lisinski-law-firm_style_EN.html
+++ b/cv_styles/cv_lisinski-law-firm_style_EN.html
@@ -670,7 +670,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 33 years old
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_lisinski-law-firm_style_PT.html
+++ b/cv_styles/cv_lisinski-law-firm_style_PT.html
@@ -670,7 +670,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_magazineluiza_style_EN.html
+++ b/cv_styles/cv_magazineluiza_style_EN.html
@@ -611,7 +611,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 33 years old
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_magazineluiza_style_PT.html
+++ b/cv_styles/cv_magazineluiza_style_PT.html
@@ -611,7 +611,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_meutudo_style_EN.html
+++ b/cv_styles/cv_meutudo_style_EN.html
@@ -456,7 +456,7 @@
                     
                     <div class="contact-info">
                         <div class="contact-item">
-                            <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 33 years old
+                            <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
                         </div>
                         
                         <div class="contact-item">

--- a/cv_styles/cv_meutudo_style_PT.html
+++ b/cv_styles/cv_meutudo_style_PT.html
@@ -456,7 +456,7 @@
                     
                     <div class="contact-info">
                         <div class="contact-item">
-                            <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 33 anos
+                            <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 35 anos
                         </div>
                         
                         <div class="contact-item">

--- a/cv_styles/cv_neogroup_style.html
+++ b/cv_styles/cv_neogroup_style.html
@@ -486,7 +486,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_neogroup_style_EN.html
+++ b/cv_styles/cv_neogroup_style_EN.html
@@ -417,7 +417,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 33 years old
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_nuvemshop_style_EN.html
+++ b/cv_styles/cv_nuvemshop_style_EN.html
@@ -630,7 +630,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 33 years old
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_nuvemshop_style_PT.html
+++ b/cv_styles/cv_nuvemshop_style_PT.html
@@ -673,7 +673,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_quintoandar_style_EN.html
+++ b/cv_styles/cv_quintoandar_style_EN.html
@@ -486,7 +486,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 33 years old
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_quintoandar_style_PT.html
+++ b/cv_styles/cv_quintoandar_style_PT.html
@@ -486,7 +486,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_raio_style.html
+++ b/cv_styles/cv_raio_style.html
@@ -609,7 +609,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado e 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado e 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_raio_style_EN.html
+++ b/cv_styles/cv_raio_style_EN.html
@@ -609,7 +609,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 33 years old
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_rdstation_style.html
+++ b/cv_styles/cv_rdstation_style.html
@@ -628,7 +628,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_rdstation_style_EN.html
+++ b/cv_styles/cv_rdstation_style_EN.html
@@ -628,7 +628,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 33 years old
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_recarga-pay_style.html
+++ b/cv_styles/cv_recarga-pay_style.html
@@ -608,7 +608,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_recarga-pay_style_EN.html
+++ b/cv_styles/cv_recarga-pay_style_EN.html
@@ -614,7 +614,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 33 years old
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_recarga-pay_style_PT.html
+++ b/cv_styles/cv_recarga-pay_style_PT.html
@@ -614,7 +614,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_sicredi_style.html
+++ b/cv_styles/cv_sicredi_style.html
@@ -640,7 +640,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_sicredi_style_EN.html
+++ b/cv_styles/cv_sicredi_style_EN.html
@@ -640,7 +640,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 33 years old
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_stone-co_style.html
+++ b/cv_styles/cv_stone-co_style.html
@@ -618,7 +618,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado e 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado e 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_stone-co_style_EN.html
+++ b/cv_styles/cv_stone-co_style_EN.html
@@ -608,7 +608,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 33 years old
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_stone-co_style_PT.html
+++ b/cv_styles/cv_stone-co_style_PT.html
@@ -618,7 +618,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado e 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado e 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_the-heineken-company_style.html
+++ b/cv_styles/cv_the-heineken-company_style.html
@@ -608,7 +608,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_the-heineken-company_style_EN.html
+++ b/cv_styles/cv_the-heineken-company_style_EN.html
@@ -637,7 +637,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 33 years old
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_tke_style_EN.html
+++ b/cv_styles/cv_tke_style_EN.html
@@ -506,7 +506,7 @@
 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 33 years old
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
                     </div>
 
                     <div class="contact-item">

--- a/cv_styles/cv_tke_style_PT.html
+++ b/cv_styles/cv_tke_style_PT.html
@@ -506,7 +506,7 @@
 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 35 anos
                     </div>
 
                     <div class="contact-item">

--- a/cv_styles/cv_vibrafood_style_EN.html
+++ b/cv_styles/cv_vibrafood_style_EN.html
@@ -414,7 +414,7 @@
                     <div style="display: flex; flex-direction: column; gap: 8px; font-size: 13px; font-weight: 400; color: var(--text-color);">
                         <div style="display: flex; align-items: center; gap: 8px;"><i class="fas fa-envelope" style="color: var(--verde-agua);"></i> pedrohmarconato@gmail.com</div>
                         <div style="display: flex; align-items: center; gap: 8px;"><i class="fas fa-phone" style="color: var(--verde-agua);"></i> +55 (55) 98114-7758</div>
-                        <div style="display: flex; align-items: center; gap: 8px;"><i class="fas fa-map-marker-alt" style="color: var(--verde-agua);"></i> Brazilian, Married, 33 years old</div>
+                        <div style="display: flex; align-items: center; gap: 8px;"><i class="fas fa-map-marker-alt" style="color: var(--verde-agua);"></i> Brazilian, Married, 35 years old</div>
                         <div style="display: flex; align-items: center; gap: 8px;"><i class="fab fa-linkedin" style="color: var(--verde-agua);"></i> linkedin.com/in/pedrohmarconato</div>
                     </div>
                 </div>

--- a/cv_styles/cv_wehandle_style.html
+++ b/cv_styles/cv_wehandle_style.html
@@ -607,7 +607,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado e 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado e 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_wehandle_style_EN.html
+++ b/cv_styles/cv_wehandle_style_EN.html
@@ -589,7 +589,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 33 years old
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_willbank_style.html
+++ b/cv_styles/cv_willbank_style.html
@@ -607,7 +607,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 33 anos
+                        <i class="fas fa-map-marker-alt"></i> Brasileira, Casado e 35 anos
                     </div>
                     
                     <div class="contact-item">

--- a/cv_styles/cv_willbank_style_EN.html
+++ b/cv_styles/cv_willbank_style_EN.html
@@ -607,7 +607,7 @@
                 
                 <div class="contact-info">
                     <div class="contact-item">
-                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 33 years old
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
                     </div>
                     
                     <div class="contact-item">

--- a/templates/companies/raio.html
+++ b/templates/companies/raio.html
@@ -1183,7 +1183,7 @@
                 
                 <div class="contact-item">
                     <i class="fas fa-map-marker-alt"></i>
-                    <span>Brazilian, Married, 33 years old</span>
+                    <span>Brazilian, Married, 35 years old</span>
                 </div>
                 
                 <a href="https://linkedin.com/in/pedrohmarconato" target="_blank" class="contact-item" title="Click to visit LinkedIn" id="cv-linkedin">

--- a/templates/companies/raio_pt.html
+++ b/templates/companies/raio_pt.html
@@ -1183,7 +1183,7 @@
                 
                 <div class="contact-item">
                     <i class="fas fa-info-circle"></i>
-                    <span>Brasileiro, Casado, 33 anos</span>
+                    <span>Brasileiro, Casado, 35 anos</span>
                 </div>
                 
                 <a href="https://linkedin.com/in/pedrohmarconato" target="_blank" class="contact-item" title="Clique para visitar o LinkedIn" id="cv-linkedin">

--- a/templates/companies/wehandle.html
+++ b/templates/companies/wehandle.html
@@ -933,7 +933,7 @@
                 
                 <div class="contact-item">
                     <i class="fas fa-info-circle"></i>
-                    <span>Brazilian, Married, 33 years old</span>
+                    <span>Brazilian, Married, 35 years old</span>
                 </div>
                 
                 <a href="https://linkedin.com/in/pedrohmarconato" target="_blank" class="contact-item" title="Click to visit LinkedIn" id="cv-linkedin">

--- a/templates/companies/wehandle_pt.html
+++ b/templates/companies/wehandle_pt.html
@@ -933,7 +933,7 @@
                 
                 <div class="contact-item">
                     <i class="fas fa-info-circle"></i>
-                    <span>Brasileiro, Casado, 33 anos</span>
+                    <span>Brasileiro, Casado, 35 anos</span>
                 </div>
                 
                 <a href="https://linkedin.com/in/pedrohmarconato" target="_blank" class="contact-item" title="Clique para visitar o LinkedIn" id="cv-linkedin">


### PR DESCRIPTION
## Summary
- Pedro was born in 1991 — updates the hardcoded age shown in the print/PDF CV header across every company template (65 files: all `cv_styles/cv_*_style_*.html` print pages plus `templates/companies/raio*.html` and `wehandle*.html`, which are the only interactive templates that also hardcode it).
- Purely a one-line text change per file (`33 years old` → `35 years old`, `33 anos` → `35 anos`); no structural changes.

## Test plan
- [x] `grep` confirms zero remaining "33 years old"/"33 anos" occurrences repo-wide, 65 files now show "35"
- [x] `python3 validate-project.py` — same pre-existing 19 issues, no new errors/warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)