### PR TITLE
Fix user-facing bugs: print targets, lang attrs, favicons, missing print button

### DIFF
--- a/cv_styles/cv_completebari_style_EN.html
+++ b/cv_styles/cv_completebari_style_EN.html
@@ -8,14 +8,15 @@
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
         
         :root {
+            
             /* Complete Bari Brand Colors */
             --primary-color: #4F9E8F;
             --secondary-color: #367C64;
             --accent-color: #6BBAA3;
-            --light-accent: #F8FBFA;
-            --dark-accent: #2D5A4F;
+            --light-accent: #ecf0f1;
+            --dark-accent: #1a252f;
             --text-color: #2c3e50;
-            --border-color: rgba(79, 158, 143, 0.2);
+            --border-color: rgba(52, 73, 94, 0.2);
             --background-gradient: linear-gradient(135deg, #4F9E8F 0%, #367C64 100%);
         }
         
@@ -48,217 +49,417 @@
         .header {
             background: var(--background-gradient);
             padding: 50px 50px 55px 50px;
-            text-align: center;
-            color: white;
             position: relative;
             overflow: hidden;
         }
-
+        
         .header::before {
             content: '';
             position: absolute;
-            top: -50%;
-            left: -50%;
-            width: 200%;
-            height: 200%;
-            background: repeating-linear-gradient(
-                45deg,
-                transparent,
-                transparent 2px,
-                rgba(255, 255, 255, 0.03) 2px,
-                rgba(255, 255, 255, 0.03) 4px
-            );
-            animation: subtle-move 20s linear infinite;
-            pointer-events: none;
+            top: 0;
+            left: -100%;
+            width: 100%;
+            height: 100%;
+            background: linear-gradient(90deg, transparent, rgba(52, 152, 219, 0.2), transparent);
+            animation: shimmer 8s infinite;
         }
 
-        @keyframes subtle-move {
-            0% { transform: translate(-50%, -50%) rotate(0deg); }
-            100% { transform: translate(-50%, -50%) rotate(360deg); }
+        @keyframes shimmer {
+            0% { left: -100%; }
+            50%, 100% { left: 100%; }
         }
 
-        .profile-img {
-            width: 150px;
-            height: 150px;
-            border-radius: 50%;
-            border: 5px solid rgba(255, 255, 255, 0.9);
-            object-fit: cover;
-            margin-bottom: 25px;
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+        .header-content {
             position: relative;
-            z-index: 2;
+            z-index: 1;
         }
-
-        .name {
-            font-size: 48px;
+        
+        .header h1 {
+            font-size: 32px;
             font-weight: 700;
-            margin-bottom: 10px;
-            text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
-            position: relative;
-            z-index: 2;
+            color: white;
+            margin-bottom: 8px;
+            letter-spacing: -0.5px;
+            text-transform: uppercase;
         }
 
-        .title {
-            font-size: 22px;
+        .header-tagline {
+            font-size: 17px;
             font-weight: 400;
-            opacity: 0.95;
-            margin-bottom: 15px;
-            position: relative;
-            z-index: 2;
+            color: rgba(255, 255, 255, 0.95);
+            margin-top: 22px;
+            margin-bottom: 28px;
+            font-style: italic;
+            letter-spacing: 0.5px;
         }
-
+        
         .contact-info {
             display: flex;
-            justify-content: center;
-            flex-wrap: wrap;
-            gap: 25px;
-            margin-top: 20px;
-            position: relative;
-            z-index: 2;
-        }
-
-        .contact-item {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            font-size: 14px;
-            opacity: 0.95;
-        }
-
-        .contact-item svg {
-            width: 16px;
-            height: 16px;
-        }
-
-        /* Content Section */
-        .content {
-            padding: 50px;
-        }
-
-        .section {
-            margin-bottom: 45px;
-        }
-
-        .section:last-child {
-            margin-bottom: 0;
-        }
-
-        .section-title {
-            font-size: 26px;
-            font-weight: 600;
-            color: var(--primary-color);
-            margin-bottom: 25px;
-            padding-bottom: 8px;
-            border-bottom: 3px solid var(--primary-color);
-            position: relative;
-        }
-
-        .section-title::after {
-            content: '';
-            position: absolute;
-            bottom: -3px;
-            left: 0;
-            width: 50px;
-            height: 3px;
-            background: var(--secondary-color);
-        }
-
-        .experience-item,
-        .education-item,
-        .project-item {
-            margin-bottom: 30px;
-            padding: 20px;
-            background: linear-gradient(135deg, #ffffff 0%, var(--light-accent) 100%);
-            border-radius: 12px;
-            border-left: 4px solid var(--primary-color);
-            box-shadow: 0 3px 15px rgba(79, 158, 143, 0.08);
-        }
-
-        .item-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: flex-start;
-            margin-bottom: 12px;
             flex-wrap: wrap;
             gap: 10px;
-        }
-
-        .item-title {
-            font-size: 18px;
-            font-weight: 600;
-            color: var(--text-color);
-            margin-bottom: 5px;
-        }
-
-        .item-company,
-        .item-institution {
-            font-size: 16px;
-            color: var(--primary-color);
-            font-weight: 500;
-        }
-
-        .item-period {
-            font-size: 12px;
-            color: var(--secondary-color);
-            font-weight: 500;
-            background: rgba(79, 158, 143, 0.1);
-            padding: 4px 10px;
-            border-radius: 12px;
-            white-space: nowrap;
-        }
-
-        .item-description {
-            color: var(--text-color);
-            line-height: 1.7;
+            align-items: center;
             margin-top: 12px;
+        }
+        
+        .contact-item {
+            display: inline-flex;
+            align-items: center;
+            background: rgba(255, 255, 255, 0.2);
+            backdrop-filter: blur(10px);
+            border-radius: 10px;
+            padding: 8px 14px;
+            color: white;
+            font-size: 12.5px;
+            font-weight: 500;
+            border: 1px solid rgba(255, 255, 255, 0.2);
+        }
+        
+        .contact-item i {
+            margin-right: 6px;
+            font-size: 12px;
+        }
+        
+        /* Section Styles */
+        .section {
+            padding: 25px 50px;
+            position: relative;
+        }
+
+        .section:not(:last-child)::after {
+            content: '';
+            position: absolute;
+            bottom: 0;
+            left: 50px;
+            right: 50px;
+            height: 1px;
+            background: linear-gradient(to right, transparent, var(--border-color), transparent);
+        }
+        
+        .section-title {
+            background: var(--background-gradient);
+            color: white;
+            font-size: 15px;
+            font-weight: 600;
+            margin-bottom: 18px;
+            padding: 8px 16px;
+            border-radius: 12px;
+            letter-spacing: 0.3px;
+            box-shadow: 0 4px 12px rgba(44, 62, 80, 0.2);
+            display: inline-block;
+            position: relative;
+            overflow: hidden;
+            text-transform: uppercase;
+        }
+
+        .section-title::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: -100%;
+            width: 100%;
+            height: 100%;
+            background: linear-gradient(90deg, transparent, rgba(52, 152, 219, 0.3), transparent);
+            animation: titleShimmer 6s infinite;
+        }
+
+        @keyframes titleShimmer {
+            0% { left: -100%; }
+            50%, 100% { left: 100%; }
+        }
+
+        /* Área de Atuação Section */
+        .area-section {
+            background: linear-gradient(135deg, rgba(236, 240, 241, 0.8), rgba(189, 195, 199, 0.5));
+            padding: 20px;
+            border-radius: 16px;
+            border: 1px solid rgba(52, 73, 94, 0.1);
+            margin-bottom: 20px;
+        }
+
+        .area-title {
+            font-size: 20px;
+            font-weight: 700;
+            color: var(--primary-color);
+            text-align: center;
+            margin-bottom: 12px;
+            text-transform: uppercase;
+        }
+
+        .area-subtitle {
             font-size: 14px;
+            font-weight: 500;
+            color: var(--text-color);
+            text-align: center;
         }
 
-        .item-description ul {
-            margin-left: 18px;
-            margin-top: 8px;
+        /* Resumo de Qualificações */
+        .qualifications-list {
+            list-style: none;
+            padding: 0;
         }
 
-        .item-description li {
-            margin-bottom: 6px;
+        .qualifications-list li {
+            position: relative;
+            padding-left: 28px;
+            margin-bottom: 14px;
+            font-size: 13.5px;
+            line-height: 1.7;
+            color: var(--text-color);
         }
 
-        /* Skills Section */
+        .qualifications-list li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+            font-size: 20px;
+            top: -2px;
+        }
+        
+        /* Skills & Tools Grid */
         .skills-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            grid-template-columns: 1fr 1fr;
             gap: 20px;
         }
 
-        .skill-category {
-            background: linear-gradient(135deg, #ffffff 0%, var(--light-accent) 100%);
-            padding: 20px;
-            border-radius: 12px;
-            border-top: 3px solid var(--primary-color);
-            box-shadow: 0 3px 15px rgba(79, 158, 143, 0.08);
+        .skills-section {
+            background: linear-gradient(135deg, rgba(236, 240, 241, 0.8), rgba(189, 195, 199, 0.5));
+            padding: 16px;
+            border-radius: 14px;
+            border: 1px solid rgba(52, 73, 94, 0.1);
         }
 
-        .skill-category h4 {
+        .skills-section h3 {
+            font-size: 12px;
             color: var(--primary-color);
-            font-size: 16px;
+            margin-bottom: 10px;
             font-weight: 600;
-            margin-bottom: 12px;
+            text-transform: uppercase;
         }
 
-        .skill-tags {
+        .skill-items {
             display: flex;
             flex-wrap: wrap;
             gap: 6px;
         }
 
         .skill-tag {
-            background: rgba(79, 158, 143, 0.1);
-            color: var(--secondary-color);
+            background: rgba(52, 152, 219, 0.15);
+            color: var(--primary-color);
             padding: 4px 10px;
-            border-radius: 15px;
-            font-size: 11px;
+            border-radius: 12px;
+            font-size: 10.5px;
             font-weight: 500;
-            border: 1px solid rgba(79, 158, 143, 0.2);
+            border: 1px solid rgba(52, 152, 219, 0.3);
+        }
+
+        /* Cursos Complementares */
+        .courses-section {
+            margin-top: 10px;
+        }
+
+        .course-item {
+            padding: 8px 0;
+            border-bottom: 1px solid rgba(52, 73, 94, 0.1);
+            font-size: 11px;
+        }
+
+        .course-item:last-child {
+            border-bottom: none;
+        }
+
+        .course-name {
+            color: var(--text-color);
+            font-weight: 500;
+            display: block;
+            margin-bottom: 2px;
+        }
+
+        .course-info {
+            color: var(--accent-color);
+            font-size: 10px;
+            font-style: italic;
+        }
+        
+        /* Experience Timeline */
+        .experience-timeline {
+            position: relative;
+            margin-left: 20px;
+            padding-left: 30px;
+        }
+        
+        .experience-timeline::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            top: 0;
+            bottom: 0;
+            width: 3px;
+            background: linear-gradient(to bottom, var(--primary-color), var(--accent-color));
+            border-radius: 3px;
+        }
+        
+        .experience-item {
+            margin-bottom: 25px;
+            position: relative;
+            padding: 18px;
+            border-radius: 14px;
+            background: linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(248, 250, 247, 0.9));
+            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
+            border: 1px solid rgba(52, 73, 94, 0.1);
+            transition: all 0.3s ease;
+        }
+
+        .experience-item:hover {
+            transform: translateX(5px);
+            box-shadow: 0 4px 20px rgba(52, 73, 94, 0.08);
+            border-color: rgba(52, 152, 219, 0.2);
+        }
+        
+        .experience-item::before {
+            content: "";
+            position: absolute;
+            left: -36px;
+            top: 25px;
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background: var(--accent-color);
+            border: 3px solid white;
+            box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.2);
+            z-index: 1;
+        }
+        
+        .job-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-bottom: 10px;
+        }
+
+        .job-title {
+            font-weight: 600;
+            font-size: 16px;
+            color: var(--primary-color);
+            margin-bottom: 4px;
+        }
+        
+        .company {
+            font-weight: 500;
+            font-size: 13px;
+            color: var(--accent-color);
+        }
+        
+        .period {
+            font-size: 12px;
+            color: var(--secondary-color);
+            font-weight: 600;
+            text-align: right;
+        }
+        
+        .job-description {
+            font-size: 12px;
+            line-height: 1.6;
+            color: var(--text-color);
+            margin-bottom: 12px;
+        }
+
+        .job-bullets {
+            list-style: none;
+            padding: 0;
+        }
+
+        .job-bullets li {
+            position: relative;
+            padding-left: 20px;
+            margin-bottom: 8px;
+            font-size: 12px;
+            line-height: 1.5;
+            color: var(--text-color);
+        }
+
+        .job-bullets li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+        }
+        
+        /* Education */
+        .education-tech-container {
+            display: grid;
+            grid-template-columns: 1fr 2fr;
+            gap: 25px;
+        }
+        
+        .education-section {
+            background: linear-gradient(135deg, rgba(236, 240, 241, 0.8), rgba(189, 195, 199, 0.5));
+            padding: 20px;
+            border-radius: 14px;
+            border: 1px solid rgba(52, 73, 94, 0.1);
+        }
+
+        .education-item {
+            margin-bottom: 12px;
+            padding-bottom: 12px;
+            border-bottom: 1px solid rgba(52, 73, 94, 0.1);
+        }
+
+        .education-item:last-child {
+            margin-bottom: 0;
+            padding-bottom: 0;
+            border-bottom: none;
+        }
+        
+        .degree {
+            font-weight: 600;
+            font-size: 13px;
+            color: var(--primary-color);
+            margin-bottom: 3px;
+        }
+        
+        .university {
+            font-size: 11px;
+            color: var(--text-color);
+            margin-bottom: 2px;
+        }
+        
+        .edu-period {
+            font-size: 10px;
+            color: var(--secondary-color);
+            font-style: italic;
+        }
+
+        .tech-skills-container {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 15px;
+        }
+
+        /* Languages */
+        .language-container {
+            display: flex;
+            justify-content: center;
+            gap: 30px;
+        }
+
+        .language-item {
+            text-align: center;
+        }
+
+        .language-name {
+            font-weight: 600;
+            color: var(--primary-color);
+            font-size: 13px;
+            margin-bottom: 2px;
+        }
+
+        .language-level {
+            font-size: 11px;
+            color: var(--text-color);
         }
 
         /* Print Styles */
@@ -267,100 +468,132 @@
                 background: white;
                 margin: 0;
                 padding: 0;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
             }
-            
+
             .cv-container {
-                max-width: none;
-                width: 100%;
+                max-width: 100%;
+                margin: 0;
                 box-shadow: none;
-                margin: 0;
-                padding: 0;
             }
-            
+
             .header {
-                padding: 40px 30px 35px 30px;
+                background: var(--background-gradient) !important;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+                padding: 25px 35px !important;
+                page-break-after: avoid;
             }
-            
-            .content {
-                padding: 30px;
+
+            .section-title {
+                background: var(--primary-color) !important;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+                color: white !important;
+                page-break-after: avoid;
             }
-            
+
             .section {
-                margin-bottom: 25px;
+                padding: 15px 35px;
                 page-break-inside: avoid;
             }
-            
-            .experience-item,
-            .education-item,
-            .project-item {
-                page-break-inside: avoid;
-                margin-bottom: 20px;
-                padding: 15px;
-            }
-            
-            .name {
-                font-size: 36px;
-            }
-            
-            .title {
-                font-size: 18px;
-            }
-            
-            .section-title {
-                font-size: 22px;
-            }
-            
-            .contact-info {
-                gap: 15px;
-            }
-            
-            .contact-item {
-                font-size: 12px;
-            }
-        }
 
-        /* Responsive Design */
-        @media (max-width: 768px) {
-            .cv-container {
-                margin: 0;
-                border-radius: 0;
+            .experience-item {
+                page-break-inside: avoid;
+            }
+
+            /* Reduce font sizes for better fit */
+            .header h1 {
+                font-size: 22px !important;
             }
 
             .header {
-                padding: 30px 20px 25px;
+                padding: 20px 30px 25px 30px !important;
             }
 
-            .name {
-                font-size: 32px;
-            }
-
-            .title {
-                font-size: 18px;
-            }
-
-            .contact-info {
-                flex-direction: column;
-                gap: 12px;
-            }
-
-            .content {
-                padding: 25px 20px;
+            .contact-item {
+                font-size: 9px !important;
+                padding: 3px 6px !important;
             }
 
             .section-title {
-                font-size: 22px;
+                font-size: 12px !important;
+                padding: 4px 10px !important;
+                margin-bottom: 10px !important;
             }
 
-            .item-header {
-                flex-direction: column;
-                align-items: flex-start;
+            .section {
+                padding: 12px 30px !important;
             }
 
-            .skills-grid {
-                grid-template-columns: 1fr;
+            .job-title {
+                font-size: 13px !important;
+            }
+
+            .job-description, .job-bullets li {
+                font-size: 10px !important;
+                line-height: 1.4 !important;
+            }
+
+            .qualifications-list li {
+                font-size: 11px !important;
+                margin-bottom: 8px !important;
+                line-height: 1.5 !important;
+                padding-left: 20px !important;
+            }
+
+            .experience-item {
+                padding: 12px !important;
+                margin-bottom: 12px !important;
+            }
+
+            .skills-section {
+                padding: 8px !important;
+            }
+
+            .skill-tag {
+                font-size: 8px !important;
+                padding: 2px 6px !important;
+            }
+
+            .degree {
+                font-size: 11px !important;
+            }
+
+            .university {
+                font-size: 9px !important;
+            }
+
+            .course-name {
+                font-size: 9px !important;
+            }
+
+            .course-info {
+                font-size: 8px !important;
+            }
+
+            /* Hide animations */
+            * {
+                animation: none !important;
+            }
+
+            /* Adjust margins */
+            .experience-item {
+                margin-bottom: 15px !important;
+            }
+
+            .section:not(:last-child)::after {
+                display: none;
+            }
+
+            @page {
+                size: A4;
+                margin: 8mm;
             }
         }
     </style>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <!-- Favicon Meta Tags -->
     <meta name="theme-color" content="#1a4b84">
     <meta name="msapplication-TileColor" content="#1a4b84">
@@ -369,202 +602,200 @@
 <body>
     <div class="cv-container">
         <header class="header">
-            <img src="../assets/images/Pedro.jfif" alt="Pedro Marconato" class="profile-img">
-            <h1 class="name">Pedro Marconato</h1>
-            <p class="title">Data Analyst | BI Specialist | Python & SQL Expert</p>
-            <div class="contact-info">
-                <div class="contact-item">
-                    <svg fill="currentColor" viewBox="0 0 24 24">
-                        <path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/>
-                    </svg>
-                    pedro.marconato@outlook.com
-                </div>
-                <div class="contact-item">
-                    <svg fill="currentColor" viewBox="0 0 24 24">
-                        <path d="M6.62 10.79c1.44 2.83 3.76 5.14 6.59 6.59l2.2-2.2c.27-.27.67-.36 1.02-.24 1.12.37 2.33.57 3.57.57.55 0 1 .45 1 1V20c0 .55-.45 1-1 1-9.39 0-17-7.61-17-17 0-.55.45-1 1-1h3.5c.55 0 1 .45 1 1 0 1.25.2 2.45.57 3.57.11.35.03.74-.25 1.02l-2.2 2.2z"/>
-                    </svg>
-                    +55 11 99999-9999
-                </div>
-                <div class="contact-item">
-                    <svg fill="currentColor" viewBox="0 0 24 24">
-                        <path d="M20.94 11c-.46-4.17-3.77-7.48-7.94-7.94V1h-2v2.06C6.83 3.52 3.52 6.83 3.06 11H1v2h2.06c.46 4.17 3.77 7.48 7.94 7.94V23h2v-2.06c4.17-.46 7.48-3.77 7.94-7.94H23v-2h-2.06zM12 19c-3.87 0-7-3.13-7-7s3.13-7 7-7 7 3.13 7 7-3.13 7-7 7z"/>
-                    </svg>
-                    linkedin.com/in/pedrohmarconato
+            <div class="header-content">
+                <h1>PEDRO HENRIQUE MARCONATO</h1>
+                
+                <div class="header-tagline">CRM | ANALYTICS | BUSINESS INTELLIGENCE | LTV | SQL</div>
+                
+                <div class="contact-info">
+                    <div class="contact-item">
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-phone"></i> +55 (55) 98114-7758
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-envelope"></i> pedrohmarconato@gmail.com
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fab fa-linkedin"></i> linkedin.com/in/pedrohmarconato
+                    </div>
                 </div>
             </div>
         </header>
-
-        <main class="content">
-            <section class="section">
-                <h2 class="section-title">Professional Summary</h2>
-                <p class="item-description">
-                    Experienced Data Analyst with 3+ years of expertise in Business Intelligence, 
-                    statistical analysis, and developing solutions using Python and SQL. Specialist in 
-                    transforming complex data into actionable insights that drive strategic business 
-                    decisions. Proven track record in large-scale projects and technical team leadership.
-                </p>
-            </section>
-
-            <section class="section">
-                <h2 class="section-title">Professional Experience</h2>
+        
+        <section class="section" style="padding-top: 35px;">
+            <h2 class="section-title">PROFESSIONAL SUMMARY</h2>
+            <ul class="qualifications-list">
+                <li>Master's in Business Administration, with Analytics background, combining data intelligence, CRM, analytical visualization and automation to generate business value</li>
+                <li>Experience in large and highly complex companies, such as RBS Group, Realize CFI (Lojas Renner S.A. Group) and Rede Globo, leading strategic projects in CRM, business intelligence and marketing performance</li>
+                <li>Expertise with data applied to marketing, channels, credit, control and operations, connecting areas and translating technical needs into high-impact analytical solutions</li>
+                <li>Highlights in visualization, segmentation and consumer behavior projects, with mastery of tools such as Databricks, SQL, Responsys, Power BI, Python, Salesforce, Mailchimp, Tableau, SAS, Mix Agents and Kanbanize</li>
+                <li>Knowledge in agile methodologies (Scrum, Kanban), working on backlog prioritization, squad structuring and delivery acceleration with customer focus</li>
+                <li>Experience with multi-source data integration, pipeline construction, predictive analytics and behavior mapping to support strategic decisions</li>
+                <li>Differential in combining analytical capacity, strategic thinking and technical knowledge, with recognized performance as leadership even in consultative structures</li>
+                <li>People management, leading multidisciplinary teams focused on development, autonomy and consistent results generation</li>
+            </ul>
+        </section>
+        
+        <section class="section">
+            <h2 class="section-title">EDUCATION & TECHNOLOGY</h2>
+            <div class="education-tech-container">
+                <div class="education-section">
+                    <h3 style="font-size: 12px; color: var(--primary-color); margin-bottom: 12px; font-weight: 600;">EDUCATION</h3>
+                    <div class="education-item">
+                        <div class="degree">Master's in Business Administration</div>
+                        <div class="university">Federal University of Santa Maria - UFSM</div>
+                        <div class="edu-period">Completed: 2019</div>
+                    </div>
+                    
+                    <div class="education-item">
+                        <div class="degree">Bachelor's in Business Administration</div>
+                        <div class="university">Federal University of Santa Maria - UFSM</div>
+                        <div class="edu-period">Completed: 2015</div>
+                    </div>
+                </div>
                 
-                <div class="experience-item">
-                    <div class="item-header">
-                        <div>
-                            <h3 class="item-title">Senior Data Analyst</h3>
-                            <p class="item-company">Complete Bari</p>
-                        </div>
-                        <span class="item-period">Jan 2022 - Present</span>
-                    </div>
-                    <div class="item-description">
-                        <ul>
-                            <li>Lead BI projects that resulted in 25% increase in operational efficiency</li>
-                            <li>Develop interactive dashboards in Power BI and Tableau for executive stakeholders</li>
-                            <li>Implement automated data pipelines using Python and Apache Airflow</li>
-                            <li>Perform predictive analysis that generated $2M+ in cost savings</li>
-                            <li>Mentor team of 3 junior analysts in advanced analytical techniques</li>
-                        </ul>
-                    </div>
-                </div>
-
-                <div class="experience-item">
-                    <div class="item-header">
-                        <div>
-                            <h3 class="item-title">BI Analyst</h3>
-                            <p class="item-company">TechCorp Solutions</p>
-                        </div>
-                        <span class="item-period">Mar 2020 - Dec 2021</span>
-                    </div>
-                    <div class="item-description">
-                        <ul>
-                            <li>Created automated reports that reduced analysis time by 60%</li>
-                            <li>Developed machine learning models for customer segmentation</li>
-                            <li>Optimized complex SQL queries on large volume databases</li>
-                            <li>Collaborated with product teams to define strategic KPIs</li>
-                        </ul>
-                    </div>
-                </div>
-
-                <div class="experience-item">
-                    <div class="item-header">
-                        <div>
-                            <h3 class="item-title">Junior Data Analyst</h3>
-                            <p class="item-company">DataInsights</p>
-                        </div>
-                        <span class="item-period">Jun 2019 - Feb 2020</span>
-                    </div>
-                    <div class="item-description">
-                        <ul>
-                            <li>Exploratory data analysis using Python (Pandas, NumPy, Matplotlib)</li>
-                            <li>Created visualizations in Tableau and Power BI</li>
-                            <li>Supported data warehouse implementation projects</li>
-                            <li>Documented analysis processes and methodologies</li>
-                        </ul>
-                    </div>
-                </div>
-            </section>
-
-            <section class="section">
-                <h2 class="section-title">Education</h2>
-                
-                <div class="education-item">
-                    <div class="item-header">
-                        <div>
-                            <h3 class="item-title">MBA in Data Science & Analytics</h3>
-                            <p class="item-institution">FGV - Fundação Getúlio Vargas</p>
-                        </div>
-                        <span class="item-period">2021 - 2023</span>
-                    </div>
-                    <div class="item-description">
-                        Specialization in Machine Learning, Big Data, and Data-Driven Business Strategies.
-                        Final project: E-commerce Recommendation System with 94% accuracy.
-                    </div>
-                </div>
-
-                <div class="education-item">
-                    <div class="item-header">
-                        <div>
-                            <h3 class="item-title">Bachelor's in Statistics</h3>
-                            <p class="item-institution">University of São Paulo (USP)</p>
-                        </div>
-                        <span class="item-period">2015 - 2018</span>
-                    </div>
-                    <div class="item-description">
-                        Solid foundation in statistical methods, probability, and quantitative analysis.
-                        Thesis: "Predictive Models for Credit Risk Analysis".
-                    </div>
-                </div>
-            </section>
-
-            <section class="section">
-                <h2 class="section-title">Technical Skills</h2>
-                <div class="skills-grid">
-                    <div class="skill-category">
-                        <h4>Programming Languages</h4>
-                        <div class="skill-tags">
-                            <span class="skill-tag">Python</span>
+                <div class="tech-skills-container">
+                    <div class="skills-section">
+                        <h3>TOOLS & PLATFORMS</h3>
+                        <div class="skill-items">
+                            <span class="skill-tag">Databricks</span>
                             <span class="skill-tag">SQL</span>
-                            <span class="skill-tag">R</span>
-                            <span class="skill-tag">JavaScript</span>
-                        </div>
-                    </div>
-                    <div class="skill-category">
-                        <h4>BI Tools</h4>
-                        <div class="skill-tags">
                             <span class="skill-tag">Power BI</span>
+                            <span class="skill-tag">Python</span>
+                            <span class="skill-tag">Oracle Responsys</span>
+                            <span class="skill-tag">Kanbanize</span>
+                            <span class="skill-tag">Mailchimp</span>
+                            <span class="skill-tag">Mix Agents</span>
+                            <span class="skill-tag">SAS</span>
                             <span class="skill-tag">Tableau</span>
-                            <span class="skill-tag">QlikView</span>
-                            <span class="skill-tag">Looker</span>
+                            <span class="skill-tag">Salesforce CRM</span>
                         </div>
                     </div>
-                    <div class="skill-category">
-                        <h4>Databases</h4>
-                        <div class="skill-tags">
-                            <span class="skill-tag">PostgreSQL</span>
-                            <span class="skill-tag">MySQL</span>
-                            <span class="skill-tag">MongoDB</span>
-                            <span class="skill-tag">Oracle</span>
-                        </div>
-                    </div>
-                    <div class="skill-category">
-                        <h4>Cloud & Big Data</h4>
-                        <div class="skill-tags">
-                            <span class="skill-tag">AWS</span>
-                            <span class="skill-tag">Azure</span>
-                            <span class="skill-tag">Spark</span>
-                            <span class="skill-tag">Hadoop</span>
+                    
+                    <div class="skills-section">
+                        <h3>CERTIFICATIONS & COURSES</h3>
+                        <div class="courses-section">
+                            <div class="course-item">
+                                <span class="course-name">Statement of Accomplishment - Intermediate R Course</span>
+                                <span class="course-info">Marketing Analytics In Practice - Coursera</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Marketing Analytics in R</span>
+                                <span class="course-info">PPGA - Graduate Program in Business Administration</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Problem Solving Fundamentals</span>
+                                <span class="course-info">Marketing in a Digital World - Illinois University</span>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </section>
-
-            <section class="section">
-                <h2 class="section-title">Featured Projects</h2>
+            </div>
+        </section>
+        
+        <section class="section">
+            <h2 class="section-title">PROFESSIONAL EXPERIENCE</h2>
+            
+            <div class="experience-timeline">
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">CADASTRA (Digital Marketing and Performance Agency)</div>
+                        </div>
+                        <div class="period">2025-Present</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">Data Analytics Coordinator</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">Sep/2025-Present</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Leading Data Analytics and AI operations for enterprise clients in technology, retail and education sectors, managing multidisciplinary team (DataViz, Data Engineering, Web Analytics)</li>
+                        <li>Simultaneous management of strategic accounts with direct interface to C-level stakeholders and business areas (Performance, E-commerce, Commercial)</li>
+                        <li>Data architecture and governance definition for Business Intelligence, Real-Time Analytics and AI applications projects</li>
+                        <li>Technical diagnosis and restructuring of legacy data environments, including infrastructure migration (AWS→GCP) with projected 40% reduction in processing costs</li>
+                        <li>Data operations restructuring with team expansion (+67%) and scope extension to multiple LATAM business units</li>
+                        <li>Stabilization of critical data environments, achieving 20% savings in operational processing costs (Airflow/DAGs)</li>
+                        <li>Development of automations with n8n and AI Agents (LLMs), including automated Status Report with AI-generated executive summaries</li>
+                        <li>Leadership of first generative AI initiatives in client operations, positioning the area as innovation reference</li>
+                    </ul>
+                </div>
                 
-                <div class="project-item">
-                    <div class="item-header">
-                        <h3 class="item-title">Real-Time Analytics System</h3>
-                        <span class="item-period">2023</span>
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">LOJAS RENNER | REALIZE CFI (National Financial Services Company)</div>
+                        </div>
+                        <div class="period">2020-2025</div>
                     </div>
-                    <div class="item-description">
-                        Development of real-time analytics platform using Apache Kafka, Python and Redis. 
-                        System processes 100K+ events per second and provides instant insights for 
-                        marketing and sales teams.
-                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">CRM Manager</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2021-2025</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for leading the strategic CRM front, focusing on area evolution, customer base growth and business value generation</li>
+                        <li>Definition and monitoring of area OKRs, connecting business goals to relationship indicators</li>
+                        <li>Planning, execution and optimization of multichannel relationship campaigns (email, SMS, push, among others), applying intelligent segmentations and automations to increase usage frequency and sales</li>
+                        <li>Building personalized journeys based on customer behavior and profile, promoting lifecycle evolution and loyalty in financial products (cards, loans, insurance and consumption in the Renner ecosystem)</li>
+                        <li>Management of agile rhythm (daily, planning, reviews and retrospectives), using frameworks such as Scrum and Kanban to maintain delivery pace, priority visibility and impact focus</li>
+                        <li>Area backlog management, with mapping, prioritization and organization of demands according to incremental value and alignment with the commercial team</li>
+                        <li>Strategic management of suppliers and technology partners, including CRM, automation and data enrichment platforms, ensuring delivery quality and alignment with area guidelines</li>
+                        <li>Continuous interface with key areas (IT, Products, Analytics, Marketing, Stores and Commercial), promoting alignment between CRM initiatives and corporate objectives</li>
+                        <li>Technical and operational management of tools such as Oracle Responsys, Databricks and Power BI, enabling automated segmentations, data processing and performance dashboards</li>
+                        <li>Monitoring and analysis of KPIs and campaign indicators, using data to guide decisions, validate hypotheses and promote continuous improvement</li>
+                        <li>Leadership of projects and strategic initiatives for active customer base expansion and new communication channel activation</li>
+                    </ul>
+                    
+                    <div class="job-title" style="margin-top: 15px; margin-bottom: 8px;">Analytics Specialist</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2020-2021</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for creating dashboards and strategic indicators for areas such as Marketing, CRM, Credit and Channels, delivering an integrated and real-time view to support business decisions</li>
+                        <li>Development of segmented databases and automated reports focused on the CRM team, focusing on efficiency gains, analysis agility and revenue generation through more precise actions</li>
+                        <li>Organization and integration of operational, behavioral and transactional data, consolidating multiple sources into a reliable base for complete customer lifecycle analyses</li>
+                        <li>Practical use of tools such as SQL, BigQuery, Python and Power BI for exploratory analyses, routine automations and development of predictive models applied to business</li>
+                        <li>Close collaboration with Marketing, Products, Risk and Operations areas, translating strategic needs into applicable analyses, focusing on action direction and decision making</li>
+                    </ul>
                 </div>
-
-                <div class="project-item">
-                    <div class="item-header">
-                        <h3 class="item-title">Customer Churn Prediction Model</h3>
-                        <span class="item-period">2022</span>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Analytics Specialist</div>
+                            <div class="company">DBC COMPANY (National IT Consulting Company)</div>
+                        </div>
+                        <div class="period">2020-2021</div>
                     </div>
-                    <div class="item-description">
-                        Creation of machine learning model for customer churn prediction with 91% accuracy. 
-                        Implementation resulted in 15% reduction in cancellation rate and $800K in retained revenue.
-                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for supporting the strategic restructuring of the CRM area at client Realize, implementing agile methodologies (Kanban) and defining processes that reduced campaign time-to-market and increased operational efficiency</li>
+                    </ul>
                 </div>
-            </section>
-        </main>
+                
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Business Intelligence Analyst</div>
+                            <div class="company">RBS GROUP (National Media Company)</div>
+                        </div>
+                        <div class="period">2019 - 2020</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for structuring and analyzing commercial performance, audience and market behavior data, supporting leadership in strategic decision making for client Rede Globo</li>
+                        <li>Development of segmentation studies and consumption potential mapping, using data to guide decisions, validate hypotheses and promote sales and prospecting actions</li>
+                        <li>Creation of analytical reports and dashboards in real time to support business decisions</li>
+                        <li>Direct interface with leadership, translating market data into action plans and growth opportunities</li>
+                        <li>Analysis of KPIs and campaign indicators, using data to guide decisions, validate hypotheses and promote continuous improvement</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
     </div>
     <!-- Dynamic Favicon System -->
     <script src="../../assets/js/dynamic-favicon.js"></script>

--- a/templates/companies/completebari_pt.html
+++ b/templates/companies/completebari_pt.html
@@ -788,7 +788,7 @@
     <div class="cv-container">
         <header class="header">
             <div class="pdf-export">
-                <button class="pdf-btn" onclick="var win = window.open('../../cv_styles/cv_completebari_style.html', '_blank'); win.focus();">
+                <button class="pdf-btn" onclick="var win = window.open('../../cv_styles/cv_completebari_style_PT.html', '_blank'); win.focus();">
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
                         <polyline points="14,2 14,8 20,8"/>

--- a/templates/companies/hyland_pt.html
+++ b/templates/companies/hyland_pt.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="pt-BR">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/templates/companies/lisinski-law-firm.html
+++ b/templates/companies/lisinski-law-firm.html
@@ -1293,11 +1293,39 @@
         }
 
         /* Print styles */
+        /* Print button */
+        .print-button {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: linear-gradient(135deg, var(--primary-blue) 0%, var(--accent-blue) 100%);
+            color: white;
+            border: 1px solid rgba(74, 144, 226, 0.4);
+            border-radius: 50%;
+            width: 60px;
+            height: 60px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            cursor: pointer;
+            box-shadow: 0 4px 20px rgba(26, 75, 132, 0.4);
+            transition: all 0.3s ease;
+            z-index: 100;
+        }
+
+        .print-button:hover {
+            transform: scale(1.1);
+            box-shadow: 0 6px 30px rgba(26, 75, 132, 0.5);
+        }
+
+        .print-button i { font-size: 24px; color: white; }
+
         @media print {
             body {
                 background: white;
             }
 
+            .print-button,
             .animated-bg,
             .shape,
             .language-toggle,
@@ -1428,6 +1456,11 @@
         </section>
     </div>
     
+    <!-- Print button -->
+    <button class="print-button" title="Print CV" onclick="var win = window.open('../../cv_styles/cv_lisinski-law-firm_style_EN.html', '_blank'); win.onload = function() { win.print(); }">
+        <i class="fas fa-file-pdf"></i>
+    </button>
+
     <!-- Language toggle button -->
     <div class="language-toggle">
         <a href="lisinski-law-firm.html" class="language-option active">

--- a/templates/companies/lisinski-law-firm_pt.html
+++ b/templates/companies/lisinski-law-firm_pt.html
@@ -1293,11 +1293,39 @@
         }
 
         /* Print styles */
+        /* Print button */
+        .print-button {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: linear-gradient(135deg, var(--primary-blue) 0%, var(--accent-blue) 100%);
+            color: white;
+            border: 1px solid rgba(74, 144, 226, 0.4);
+            border-radius: 50%;
+            width: 60px;
+            height: 60px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            cursor: pointer;
+            box-shadow: 0 4px 20px rgba(26, 75, 132, 0.4);
+            transition: all 0.3s ease;
+            z-index: 100;
+        }
+
+        .print-button:hover {
+            transform: scale(1.1);
+            box-shadow: 0 6px 30px rgba(26, 75, 132, 0.5);
+        }
+
+        .print-button i { font-size: 24px; color: white; }
+
         @media print {
             body {
                 background: white;
             }
 
+            .print-button,
             .animated-bg,
             .shape,
             .language-toggle,
@@ -1428,6 +1456,11 @@
         </section>
     </div>
     
+    <!-- Print button -->
+    <button class="print-button" title="Imprimir CV" onclick="var win = window.open('../../cv_styles/cv_lisinski-law-firm_style_PT.html', '_blank'); win.onload = function() { win.print(); }">
+        <i class="fas fa-file-pdf"></i>
+    </button>
+
     <!-- Language toggle button -->
     <div class="language-toggle">
         <a href="lisinski-law-firm.html" class="language-option">

--- a/templates/companies/meutudo.html
+++ b/templates/companies/meutudo.html
@@ -1083,7 +1083,7 @@
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <script src="../../cv-texts.js"></script>
-    <script src="../../dynamic-favicon.js"></script>
+    <script src="../../assets/js/dynamic-favicon.js"></script>
 </head>
 <body>
     <!-- MeuTudo Illustration Background -->

--- a/templates/companies/meutudo_pt.html
+++ b/templates/companies/meutudo_pt.html
@@ -1082,7 +1082,7 @@
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <script src="../../cv-texts.js"></script>
-    <script src="../../dynamic-favicon.js"></script>
+    <script src="../../assets/js/dynamic-favicon.js"></script>
 </head>
 <body>
     <!-- MeuTudo Illustration Background -->

--- a/templates/companies/quintoandar_pt.html
+++ b/templates/companies/quintoandar_pt.html
@@ -1350,6 +1350,7 @@
     
     <script src="../../cv-texts.js"></script>
     <script src="../../assets/js/brands-config.js"></script>
+    <script src="../../assets/js/dynamic-favicon.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>

--- a/templates/companies/sicredi_pt.html
+++ b/templates/companies/sicredi_pt.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="pt-BR">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -2436,7 +2436,7 @@
     </div>
     
     <!-- Print button -->
-    <button class="print-button" onclick="var win = window.open('../../cv_styles/cv_sicredi_style_EN.html', '_blank'); win.onload = function() { win.print(); }">
+    <button class="print-button" onclick="var win = window.open('../../cv_styles/cv_sicredi_style_PT.html', '_blank'); win.onload = function() { win.print(); }">
         <i class="fas fa-file-pdf"></i>
     </button>
     

--- a/templates/companies/the-heineken-company.html
+++ b/templates/companies/the-heineken-company.html
@@ -1673,7 +1673,7 @@
     </div>
     
     <!-- Print button -->
-    <button class="print-button" onclick="var win = window.open('../../cv_styles/cv_the-heineken-company_style.html', '_blank'); win.onload = function() { win.print(); }">
+    <button class="print-button" onclick="var win = window.open('../../cv_styles/cv_the-heineken-company_style_EN.html', '_blank'); win.onload = function() { win.print(); }">
         <i class="fas fa-file-pdf"></i>
     </button>
     

--- a/templates/companies/the-heineken-company_pt.html
+++ b/templates/companies/the-heineken-company_pt.html
@@ -1684,7 +1684,7 @@
     </div>
     
     <!-- Print button -->
-    <button class="print-button" onclick="var win = window.open('../../cv_styles/cv_the-heineken-company_style.html', '_blank'); win.onload = function() { win.print(); }">
+    <button class="print-button" onclick="var win = window.open('../../cv_styles/cv_the-heineken-company_style_PT.html', '_blank'); win.onload = function() { win.print(); }">
         <i class="fas fa-file-pdf"></i>
     </button>
     


### PR DESCRIPTION
## Correções (7 bugs visíveis)

1. **the-heineken-company (EN)** — botão de imprimir abria o CV em **português** (`cv_..._style.html`); agora abre `_EN.html`. A versão PT agora abre `_PT.html`.
2. **sicredi_pt** — botão de imprimir abria o CV em **inglês**; agora abre `_PT.html`.
3. **sicredi_pt e hyland_pt** — `<html lang="en">` corrigido para `pt-BR`.
4. **completebari** — `cv_completebari_style_EN.html` estava estático e desatualizado (última experiência ~2023) e continha um cargo **fabricado** ("Senior Data Analyst at Complete Bari"). Regenerado a partir do `cv_general_style_EN.html` atual (mesmas cores da marca, conteúdo real com Cadastra 2025–presente). O template PT agora imprime o `_PT.html` atualizado.
5. **meutudo (EN/PT)** — `dynamic-favicon.js` carregado de caminho inexistente (`../../dynamic-favicon.js` → 404); corrigido para `assets/js/`.
6. **quintoandar_pt** — não carregava `dynamic-favicon.js` (erro apontado pelo próprio `validate-project.py`); adicionado.
7. **lisinski-law-firm (EN/PT)** — páginas sem botão de impressão (os `cv_styles` existiam mas eram inalcançáveis); adicionado botão PDF flutuante nas cores da marca, oculto na impressão.

## Verificação

- Smoke test com Chrome headless: as 4 páginas alteradas renderizam com conteúdo populado (experiências presentes, cargo atual CADASTRA visível) e botão presente.
- `validate-project.py`: erro crítico do favicon do quintoandar_pt eliminado.
- Auditoria de links de impressão: todos os alvos apontam para arquivo existente no idioma correto (restam 13 templates PT apontando para estilos legados — tratados no próximo PR de deduplicação).

🤖 Generated with [Claude Code](https://claude.com/claude-code)