### PR TITLE
Rewrite creation flow: working generator, docs match reality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,20 +1,43 @@
-# Claude.md - Memory File
+# CLAUDE.md — Pedro Marconato CV
 
-## Pipeline MCP Requirements
+Site estático (GitHub Pages) com versões do CV personalizadas por empresa-alvo,
+em EN e PT.
 
-**IMPORTANTE - NO FALLBACKS OR SIMULATIONS:**
-- User explicitly does NOT want any fallback mechanisms in step1_brand_research.py
-- User explicitly does NOT want any simulations or fake data
-- User wants Claude CLI to work properly within step1
-- Focus on fixing the actual Claude CLI integration, not creating workarounds
+## Mapa do projeto
 
-## Current Issues
-- Claude CLI timeout in step1_brand_research.py when called from venv environment
-- Need to resolve Claude CLI execution without fallbacks
-- Must make the real Claude CLI work within the pipeline
+- `index.html` — home com busca por empresa (objeto `companyMappings` no próprio arquivo)
+- `templates/companies/[empresa].html` + `[empresa]_pt.html` — páginas por empresa
+- `cv_styles/cv_[empresa]_style_EN.html` + `_PT.html` — versões de impressão
+  (somente sufixos `_EN`/`_PT`; o padrão legado sem sufixo foi extinto)
+- `assets/js/cv-texts.js` — **fonte única de todo o conteúdo do CV**
+  (textos, experiências, skills, projetos, nos dois idiomas). Nunca duplicar.
+- `assets/js/dynamic-favicon.js`, `brands-config.js`, `fallback-script.js`
+- `create-new-template.py` — único gerador de novas empresas (gera as 4 páginas,
+  atualiza brands-config.js e o companyMappings do index)
+- `validate-project.py` — validação (roda no pre-commit)
 
-## User Preferences
-- No fallbacks allowed
-- No simulations allowed  
-- Fix the real problem, don't work around it
-- Pipeline must use actual Claude CLI successfully
+## Regras essenciais
+
+1. Leia `REGRAS_PROJETO.md` antes de modificar qualquer coisa.
+2. Novo template: **sempre** via `python create-new-template.py` — nunca copiar
+   HTML de outra empresa.
+3. Conteúdo do CV (novo emprego, idade, skills): editar **apenas**
+   `assets/js/cv-texts.js`. Estilos de impressão antigos com conteúdo estático
+   precisam de atualização manual; os gerados atualmente são dinâmicos.
+4. API de inicialização real: `initializeBasicContent(lang)`,
+   `renderSkills(containerId, categoria, lang)`, `renderExperienceTimeline(lang)`,
+   `renderEducation(lang)`, `renderProjects(lang)`, `initializeModalTexts(lang)`.
+   **`initializeContent()` não existe** — não use nem gere código com ela.
+5. Botão de impressão abre o `cv_styles` do **mesmo idioma** da página.
+6. Caminhos relativos: templates usam `../../assets/...`; arquivos em
+   `cv_styles/` usam `../assets/...`. Nunca caminhos absolutos (`/assets/...`)
+   — quebram no subpath do GitHub Pages.
+7. Antes de commit: `python validate-project.py`.
+
+## Verificação rápida de renderização
+
+```bash
+python3 -m http.server 8777 &
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --headless \
+  --dump-dom http://localhost:8777/templates/companies/general.html | grep -c experience-item
+```

--- a/REGRAS_PROJETO.md
+++ b/REGRAS_PROJETO.md
@@ -1,7 +1,7 @@
 # 🛡️ REGRAS DO PROJETO - PEDRO MARCONATO CV
 
-**Versão:** 1.0  
-**Data:** 28 de julho de 2025  
+**Versão:** 2.0
+**Data:** 03 de julho de 2026
 **Status:** OBRIGATÓRIO PARA TODAS AS MODIFICAÇÕES
 
 ---
@@ -22,6 +22,7 @@
 
 #### ✅ **PROCESSO OBRIGATÓRIO:**
 1. **SEMPRE** usar o script oficial: `python create-new-template.py`
+   (interativo, ou `python create-new-template.py <Empresa> <#primaria> <#secundaria> <#destaque>`)
 2. **CONSULTAR:** TEMPLATE_PADRAO.md antes de começar
 3. **VERIFICAR:** Se a empresa já tem template
 4. **PEDIR AUTORIZAÇÃO:** Não criar sem aprovação
@@ -31,89 +32,110 @@
 - Copiar templates existentes e modificar
 - Pular o processo de validação
 
-#### 📝 **PADRÃO OBRIGATÓRIO:**
+#### 📝 **ARQUIVOS GERADOS PARA CADA EMPRESA (padrão obrigatório):**
 ```
-templates/companies/[EMPRESA].html (versão EN)
-templates/companies/[EMPRESA]_pt.html (versão PT)
-cv_styles/cv_[EMPRESA]_style_EN.html (impressão EN)
-cv_styles/cv_[EMPRESA]_style_PT.html (impressão PT)
+templates/companies/[empresa].html        (página EN)
+templates/companies/[empresa]_pt.html     (página PT)
+cv_styles/cv_[empresa]_style_EN.html      (impressão EN — dinâmica)
+cv_styles/cv_[empresa]_style_PT.html      (impressão PT — dinâmica)
 ```
+O script também atualiza `assets/js/brands-config.js` e o
+`companyMappings` do `index.html` (sem isso a empresa não aparece na busca da home).
+
+**Não existem mais** arquivos `cv_[empresa]_style.html` sem sufixo de idioma —
+esse padrão legado foi removido. Todo estilo de impressão tem sufixo `_EN` ou `_PT`.
 
 #### 🔧 **ELEMENTOS OBRIGATÓRIOS EM TODO TEMPLATE:**
 ```html
 <!-- ESTRUTURA BASE -->
 <!DOCTYPE html>
 <html lang="en"> <!-- ou lang="pt-BR" para PT -->
-<head>
-    <!-- Meta básico -->
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pedro Marconato - [EMPRESA]</title>
-</head>
 
-<!-- IDs OBRIGATÓRIOS -->
-<h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
-<div id="cv-role">Gestão de CRM e Inteligência de Dados</div>
-<span id="cv-email">pedrohmarconato@gmail.com</span>
-<span id="cv-phone">+55 (55) 981147758</span>
-<span id="cv-location">Cachoeira do Sul, RS</span>
-<a id="cv-linkedin">LinkedIn</a>
-<a id="cv-repository">Repository</a>
-<p id="cv-profile">[conteúdo perfil]</p>
+<!-- IDs OBRIGATÓRIOS (preenchidos por initializeBasicContent) -->
+<h1 id="cv-name">, <h2 id="cv-role">, <span id="cv-email">, <span id="cv-phone">,
+<span id="cv-location">, <a id="cv-linkedin">, <a id="cv-repository">, <p id="cv-profile">
 
 <!-- SEÇÕES OBRIGATÓRIAS -->
-<h2 id="section-skills">SKILLS & TOOLS</h2>
-<h2 id="section-experience">PROFESSIONAL EXPERIENCE</h2>
-<h2 id="section-education">EDUCATION</h2>
-<h2 id="section-projects">PROJECTS & INNOVATION</h2>
+<h2 id="section-skills">, <h2 id="section-experience">,
+<h2 id="section-education">, <h2 id="section-projects">
 
-<!-- SCRIPTS OBRIGATÓRIOS -->
-<script src="../../cv-texts.js"></script>
+<!-- CONTAINERS DE CONTEÚDO DINÂMICO -->
+<div id="skills-strategic">, <div id="skills-tools">, <div id="skills-emerging">
+<div id="experience-container">, <div id="education-container">, <div id="projects-container">
+
+<!-- SCRIPTS OBRIGATÓRIOS (sempre em assets/js/) -->
+<script src="../../assets/js/cv-texts.js"></script>
 <script src="../../assets/js/dynamic-favicon.js"></script>
-<script>
-    document.addEventListener('DOMContentLoaded', function() {
-        initializeContent('en'); // ou 'pt' para versão PT
-    });
-</script>
 ```
+
+#### ⚙️ **INICIALIZAÇÃO DE CONTEÚDO — API REAL do cv-texts.js:**
+```javascript
+document.addEventListener('DOMContentLoaded', function() {
+    var lang = 'en'; // ou 'pt' na versão PT
+    initializeBasicContent(lang);                      // nome, cargo, contatos, perfil
+    renderSkills('skills-strategic', 'strategic', lang); // skills por categoria
+    renderSkills('skills-tools', 'tools', lang);
+    renderSkills('skills-emerging', 'emerging', lang);
+    renderExperienceTimeline(lang);                    // #experience-container
+    renderEducation(lang);                             // #education-container
+    renderProjects(lang);                              // #projects-container
+    initializeModalTexts(lang);                        // modais (se existirem)
+});
+```
+> ⚠️ **NÃO existe** função `initializeContent()`. Documentos e scripts antigos
+> que a mencionavam estavam errados — chamadas a ela falham silenciosamente
+> e deixam a página vazia. Use as funções acima.
 
 ### 🎨 **PADRÃO DE CORES E CSS**
 
-#### ✅ **VARIÁVEIS CSS CORRETAS:**
 ```css
 :root {
     /* Cores específicas da empresa */
-    --[EMPRESA]-primary: #XXXXXX;
-    --[EMPRESA]-secondary: #XXXXXX;
-    --[EMPRESA]-accent: #XXXXXX;
-    
+    --[empresa]-primary: #XXXXXX;
+    --[empresa]-secondary: #XXXXXX;
+    --[empresa]-accent: #XXXXXX;
+
     /* NUNCA usar variáveis de outras empresas */
     /* ❌ ERRADO: --sicredi-green quando não é Sicredi */
 }
 ```
+Variáveis adicionais com o prefixo da própria empresa são permitidas
+(ex.: `--ifood-light-gray` dentro do template do iFood).
 
 ### 📁 **ESTRUTURA DE ARQUIVOS**
+
+#### ✅ **LOCAIS CORRETOS:**
+- **Templates:** `templates/companies/`
+- **Estilos de impressão:** `cv_styles/` (somente `_EN`/`_PT`)
+- **Scripts JS:** `assets/js/` (cv-texts.js, dynamic-favicon.js, brands-config.js, fallback-script.js)
+- **Imagens:** `assets/images/`
+- **Documentação:** Raiz do projeto (arquivos .md)
 
 #### 🚫 **PROIBIDO CRIAR:**
 - Arquivos de backup com sufixo `_backup`
 - Arquivos temporários em `templates/companies/`
 - Scripts de desenvolvimento em `templates/`
-- Arquivos de teste na raiz do projeto
+- Arquivos de teste ou páginas soltas na raiz do projeto
+- Cópias de cv-texts.js fora de `assets/js/` (fonte única!)
 
-#### ✅ **LOCAIS CORRETOS:**
-- **Templates:** `templates/companies/`
-- **Estilos de impressão:** `cv_styles/`
-- **Scripts:** `assets/js/`
-- **Imagens:** `assets/images/`
-- **Documentação:** Raiz do projeto (arquivos .md)
+### 🖨️ **BOTÃO DE IMPRESSÃO**
+
+Toda página DEVE ter um botão que abre o estilo de impressão **do mesmo idioma**:
+```javascript
+// página EN -> cv_..._style_EN.html | página PT -> cv_..._style_PT.html
+var win = window.open('../../cv_styles/cv_[empresa]_style_EN.html', '_blank');
+win.onload = function() { win.print(); }
+```
 
 ### 🔗 **INTEGRAÇÃO CV-TEXTS.JS**
 
-#### ✅ **OBRIGATÓRIO EM TODOS OS TEMPLATES:**
-1. Referência ao script: `<script src="../../cv-texts.js"></script>`
-2. Todos os IDs básicos: cv-name, cv-role, cv-email, etc.
-3. Todos os IDs de seção: section-skills, section-experience, etc.
-4. Sistema de inicialização automática
+1. Fonte única: `assets/js/cv-texts.js` (nunca duplicar)
+2. Referência nos templates: `../../assets/js/cv-texts.js`
+3. Referência nos cv_styles dinâmicos: `../assets/js/cv-texts.js`
+4. Todos os IDs básicos e de seção presentes
+5. Ao atualizar o CV (novo emprego, idade etc.), editar **somente** o cv-texts.js;
+   estilos de impressão estáticos antigos precisam ser atualizados manualmente —
+   prefira os dinâmicos gerados pelo script atual
 
 ---
 
@@ -125,11 +147,12 @@ cv_styles/cv_[EMPRESA]_style_PT.html (impressão PT)
 3. **Alterar** estrutura de diretórios sem autorização
 4. **Criar** arquivos fora dos locais especificados
 5. **Usar** variáveis CSS de outras empresas
+6. **Duplicar** o cv-texts.js
 
 ### ✅ **SEMPRE FAZER:**
 1. **Validar** com script antes de commit
 2. **Testar** template em ambos os idiomas
-3. **Verificar** se impressão funciona (cv_styles)
+3. **Verificar** se impressão funciona (cv_styles do idioma correto)
 4. **Documentar** mudanças no log
 5. **Seguir** convenções de nomenclatura
 
@@ -137,26 +160,12 @@ cv_styles/cv_[EMPRESA]_style_PT.html (impressão PT)
 
 ## 📋 CHECKLIST PRE-COMMIT
 
-### ☑️ **ANTES DE QUALQUER COMMIT:**
 - [ ] Executei `python validate-project.py`
 - [ ] Consultei REGRAS_PROJETO.md
 - [ ] Testei em ambos idiomas (PT/EN)
-- [ ] Verifiquei impressão (cv_styles)
+- [ ] Verifiquei impressão (cv_styles `_EN` e `_PT`)
 - [ ] Atualizei documentação se necessário
 - [ ] Não criei arquivos desnecessários
-
----
-
-## 🔄 PROCESSO DE MODIFICAÇÃO
-
-### 📋 **FLUXO OBRIGATÓRIO:**
-1. **Consultar** este arquivo de regras
-2. **Executar** validação: `python validate-project.py`
-3. **Pedir autorização** para mudanças estruturais
-4. **Implementar** seguindo padrões
-5. **Validar** novamente
-6. **Documentar** no log de atividades
-7. **Commit** com mensagem descritiva
 
 ---
 
@@ -181,15 +190,16 @@ cv_styles/cv_[EMPRESA]_style_PT.html (impressão PT)
 
 ## 📊 VERSIONAMENTO
 
-**v1.0** - 28/07/2025 - Versão inicial  
-**Próxima revisão:** Conforme evolução do projeto
+**v1.0** - 28/07/2025 - Versão inicial
+**v2.0** - 03/07/2026 - Estrutura deduplicada: fonte única do cv-texts.js em
+`assets/js/`, estilos de impressão somente `_EN`/`_PT`, API real de inicialização
+documentada (initializeBasicContent + render*), `add_new_brand.py` aposentado,
+`create-new-template.py` reescrito (gera estilos dinâmicos e atualiza o index)
 
 ---
 
 ## 🎯 OBJETIVO
 
-Manter **consistência**, **qualidade** e **padrões** em todas as modificações do projeto, garantindo que:
-- Todos os templates funcionem corretamente
-- Estrutura permaneça organizada  
-- Documentação esteja sempre atualizada
-- Novas IAs sigam os mesmos padrões
+Manter **consistência**, **qualidade** e **padrões** em todas as modificações,
+garantindo que todos os templates funcionem, a estrutura permaneça organizada,
+a documentação reflita a realidade do código e novas IAs sigam os mesmos padrões.

--- a/TEMPLATE_PADRAO.md
+++ b/TEMPLATE_PADRAO.md
@@ -1,17 +1,45 @@
 # 📋 TEMPLATE PADRÃO - PEDRO MARCONATO CV
 
-**Versão:** 2.0  
-**Data:** 28 de julho de 2025  
+**Versão:** 3.0
+**Data:** 03 de julho de 2026
 **Status:** OBRIGATÓRIO PARA NOVOS TEMPLATES
 
 ---
 
-## 🎯 **PADRÃO VISUAL APROVADO**
+## 🎯 FONTE DA VERDADE
 
-### 📏 **Container Principal:**
+O template oficial **vive dentro do gerador**: `create-new-template.py`
+(constantes `PAGE_TEMPLATE` e `PRINT_TEMPLATE`). Este documento descreve o
+padrão; o gerador o materializa. **Nunca crie template copiando HTML deste
+arquivo ou de outra empresa** — rode o script:
+
+```bash
+# interativo
+python create-new-template.py
+
+# não-interativo
+python create-new-template.py "Nome Da Empresa" "#0066CC" "#004499" "#87CEEB"
+```
+
+O script cria/atualiza automaticamente:
+
+```
+templates/companies/[empresa].html        # página EN
+templates/companies/[empresa]_pt.html     # página PT
+cv_styles/cv_[empresa]_style_EN.html      # impressão EN (dinâmica)
+cv_styles/cv_[empresa]_style_PT.html      # impressão PT (dinâmica)
+assets/js/brands-config.js                # cores/gradiente da marca
+index.html                                # companyMappings (busca da home)
+```
+
+---
+
+## 📏 PADRÃO VISUAL APROVADO
+
+### Container Principal
 ```css
 .cv-container {
-    max-width: 1000px;      /* Largura fixa */
+    max-width: 1000px;      /* Largura fixa — NÃO alterar */
     margin: 30px auto;      /* Centralizado */
     background: rgba(255, 255, 255, 0.98);
     backdrop-filter: blur(20px);
@@ -22,18 +50,18 @@
 }
 ```
 
-### 🎨 **Estrutura de Cores (Exemplo):**
+### Estrutura de Cores
 ```css
 :root {
     /* Cores da Empresa */
-    --[EMPRESA]-primary: #XXXXXX;
-    --[EMPRESA]-secondary: #XXXXXX;
-    --[EMPRESA]-accent: #XXXXXX;
-    
+    --[empresa]-primary: #XXXXXX;
+    --[empresa]-secondary: #XXXXXX;
+    --[empresa]-accent: #XXXXXX;
+
     /* Cores Aplicadas */
-    --primary-color: var(--[EMPRESA]-primary);
-    --secondary-color: var(--[EMPRESA]-secondary);
-    --accent-color: var(--[EMPRESA]-accent);
+    --primary-color: var(--[empresa]-primary);
+    --secondary-color: var(--[empresa]-secondary);
+    --accent-color: var(--[empresa]-accent);
     --text-color: #2c3e50;
     --border-color: rgba(0, 0, 0, 0.1);
 }
@@ -41,321 +69,82 @@
 
 ---
 
-## 📄 **TEMPLATE BASE - VERSÃO EN**
+## 🧩 ANATOMIA DO TEMPLATE GERADO
 
-```html
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pedro Marconato - [EMPRESA]</title>
-    <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
-        
-        :root {
-            /* [EMPRESA] Official Colors */
-            --[EMPRESA]-primary: #XXXXXX;
-            --[EMPRESA]-secondary: #XXXXXX;
-            --[EMPRESA]-accent: #XXXXXX;
-            
-            /* Applied Colors */
-            --primary-color: var(--[EMPRESA]-primary);
-            --secondary-color: var(--[EMPRESA]-secondary);
-            --accent-color: var(--[EMPRESA]-accent);
-            --text-color: #2c3e50;
-            --border-color: rgba(0, 0, 0, 0.1);
-            --background-gradient: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
-        }
-        
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-        
-        body {
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            color: var(--text-color);
-            line-height: 1.6;
-            background: #f8f9fa;
-            min-height: 100vh;
-            position: relative;
-            overflow-x: hidden;
-        }
-        
-        /* Animated background */
-        .animated-bg {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 50%, #f8f9fa 100%);
-            background-size: 400% 400%;
-            animation: gradientShift 20s ease infinite;
-            z-index: -2;
-        }
-        
-        @keyframes gradientShift {
-            0% { background-position: 0% 50%; }
-            50% { background-position: 100% 50%; }
-            100% { background-position: 0% 50%; }
-        }
-        
-        /* Container PADRÃO - 1000px centralizado */
-        .cv-container {
-            max-width: 1000px;
-            margin: 30px auto;
-            background: rgba(255, 255, 255, 0.98);
-            backdrop-filter: blur(20px);
-            -webkit-backdrop-filter: blur(20px);
-            border-radius: 20px;
-            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.1);
-            overflow: hidden;
-            position: relative;
-            border: 1px solid var(--border-color);
-        }
-        
-        /* Header */
-        .header {
-            background: var(--background-gradient);
-            color: white;
-            padding: 60px 50px;
-            text-align: center;
-            position: relative;
-        }
-        
-        /* Content sections */
-        .content {
-            padding: 50px;
-        }
-        
-        .section {
-            margin-bottom: 40px;
-        }
-        
-        .section-title {
-            font-size: 1.5em;
-            font-weight: 700;
-            color: var(--primary-color);
-            margin-bottom: 20px;
-            padding-bottom: 10px;
-            border-bottom: 2px solid var(--border-color);
-        }
-        
-        /* Print button */
-        .print-button {
-            position: absolute;
-            top: 20px;
-            right: 20px;
-            background: rgba(255, 255, 255, 0.2);
-            border: 1px solid rgba(255, 255, 255, 0.3);
-            color: white;
-            padding: 8px 16px;
-            border-radius: 8px;
-            cursor: pointer;
-            transition: all 0.3s ease;
-        }
-        
-        .print-button:hover {
-            background: rgba(255, 255, 255, 0.3);
-        }
-        
-        /* Responsive */
-        @media (max-width: 768px) {
-            .cv-container {
-                margin: 10px;
-                border-radius: 15px;
-            }
-            
-            .header {
-                padding: 40px 30px;
-            }
-            
-            .content {
-                padding: 30px;
-            }
-        }
-        
-        /* Print styles */
-        @media print {
-            body {
-                background: white;
-            }
-            
-            .animated-bg,
-            .print-button {
-                display: none;
-            }
-            
-            .cv-container {
-                margin: 0;
-                box-shadow: none;
-                border: none;
-            }
-        }
-    </style>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-</head>
-<body>
-    <div class="animated-bg"></div>
-    
-    <div class="cv-container">
-        <header class="header">
-            <button class="print-button" onclick="window.open('../../cv_styles/cv_[EMPRESA]_style_EN.html', '_blank')">
-                <i class="fas fa-print"></i> Print CV
-            </button>
-            
-            <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
-            <h2 id="cv-role">CRM Management and Data Intelligence</h2>
-            
-            <div class="contact-info">
-                <span id="cv-email">pedrohmarconato@gmail.com</span> | 
-                <span id="cv-phone">+55 (55) 981147758</span> | 
-                <span id="cv-location">Cachoeira do Sul, RS</span>
-                <div>
-                    <a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin">LinkedIn</a> | 
-                    <a href="https://github.com/pedrohmarconato" id="cv-repository">Repository</a>
-                </div>
-            </div>
-        </header>
-        
-        <div class="content">
-            <section class="section">
-                <h2 class="section-title">Professional Profile</h2>
-                <p id="cv-profile">Professional profile content will be loaded here...</p>
-            </section>
-            
-            <section class="section">
-                <h2 class="section-title" id="section-skills">Skills & Tools</h2>
-                <div id="skills-container">
-                    <!-- Skills will be loaded by cv-texts.js -->
-                </div>
-            </section>
-            
-            <section class="section">
-                <h2 class="section-title" id="section-experience">Professional Experience</h2>
-                <div id="experience-container">
-                    <!-- Experience will be loaded by cv-texts.js -->
-                </div>
-            </section>
-            
-            <section class="section">
-                <h2 class="section-title" id="section-education">Education</h2>
-                <div id="education-container">
-                    <!-- Education will be loaded by cv-texts.js -->
-                </div>
-            </section>
-            
-            <section class="section">
-                <h2 class="section-title" id="section-projects">Projects & Innovation</h2>
-                <div id="projects-container">
-                    <!-- Projects will be loaded by cv-texts.js -->
-                </div>
-            </section>
-        </div>
-    </div>
-    
-    <!-- SCRIPTS OBRIGATÓRIOS -->
-    <script src="../../cv-texts.js"></script>
-    <script src="../../assets/js/dynamic-favicon.js"></script>
-    <script>
-        // Initialize content when page loads
-        document.addEventListener('DOMContentLoaded', function() {
-            // Initialize with English content
-            if (typeof initializeContent !== 'undefined') {
-                initializeContent('en');
-            }
-            
-            // Initialize dynamic favicon
-            if (typeof DynamicFavicon !== 'undefined') {
-                DynamicFavicon.init();
-            }
-        });
-    </script>
-</body>
-</html>
+1. **Header** com gradiente da marca contendo:
+   - Language toggle (EN ↔ PT, canto superior esquerdo)
+   - Print button (canto superior direito) que abre o
+     `cv_styles/cv_[empresa]_style_[EN|PT].html` do **mesmo idioma** e aciona `print()`
+   - IDs de identidade: `cv-name`, `cv-role`, `cv-email`, `cv-phone`,
+     `cv-location`, `cv-linkedin`, `cv-repository`
+2. **Seções** com títulos identificados (`section-profile`, `section-skills`,
+   `section-experience`, `section-education`, `section-projects`)
+3. **Containers dinâmicos** preenchidos pelo cv-texts.js:
+   `skills-strategic`, `skills-tools`, `skills-emerging`,
+   `experience-container`, `education-container`, `projects-container`
+4. **Scripts obrigatórios** no fim do body:
+   ```html
+   <script src="../../assets/js/cv-texts.js"></script>
+   <script src="../../assets/js/dynamic-favicon.js"></script>
+   ```
+
+## ⚙️ INICIALIZAÇÃO — API REAL
+
+```javascript
+document.addEventListener('DOMContentLoaded', function() {
+    var lang = 'en'; // 'pt' na versão PT
+    initializeBasicContent(lang);
+    renderSkills('skills-strategic', 'strategic', lang);
+    renderSkills('skills-tools', 'tools', lang);
+    renderSkills('skills-emerging', 'emerging', lang);
+    renderExperienceTimeline(lang);
+    renderEducation(lang);
+    renderProjects(lang);
+    initializeModalTexts(lang);
+});
 ```
 
+> ⚠️ A função `initializeContent()` **não existe** e nunca deve ser usada.
+> Versões antigas deste documento e do gerador a mencionavam — páginas geradas
+> assim ficavam com as seções vazias sem nenhum erro no console.
+
+## 🖨️ ESTILO DE IMPRESSÃO (cv_styles)
+
+Os arquivos de impressão gerados são **dinâmicos**: carregam
+`../assets/js/cv-texts.js` e renderizam o conteúdo com as mesmas funções da
+página. Assim, quando o CV muda (novo cargo, nova skill), a impressão de todas
+as empresas atualiza junto — sem retrabalho manual e sem risco de imprimir
+conteúdo desatualizado.
+
 ---
 
-## 📄 **TEMPLATE BASE - VERSÃO PT**
+## 🎯 CHECKLIST PARA NOVO TEMPLATE
 
-Para a versão PT, use o mesmo template com estas mudanças:
-1. `<html lang="pt-BR">`
-2. `initializeContent('pt');`
-3. Textos dos botões em português
-4. Nome do arquivo: `[EMPRESA]_pt.html`
+### Antes de criar
+- [ ] Verificar se empresa já existe (`templates/companies/`)
+- [ ] Obter cores oficiais da marca (primária, secundária, destaque)
+- [ ] Preparar logo em `assets/images/` (opcional)
 
----
+### Criar
+- [ ] Rodar `python create-new-template.py`
+- [ ] Conferir os 4 arquivos gerados + brands-config + index
 
-## 🎯 **CHECKLIST PARA NOVO TEMPLATE**
-
-### ☑️ **Antes de criar:**
-- [ ] Verificar se empresa já existe
-- [ ] Obter cores oficiais da marca
-- [ ] Preparar logo (se houver)
-
-### ☑️ **Ao criar:**
-- [ ] Usar este template como base
-- [ ] Substituir [EMPRESA] pelo nome real
-- [ ] Adicionar cores corretas
-- [ ] Container DEVE ser 1000px centralizado
-- [ ] Incluir todos os IDs obrigatórios
-- [ ] Adicionar scripts cv-texts.js e dynamic-favicon.js
-
-### ☑️ **Elementos obrigatórios:**
-- [ ] IDs básicos: cv-name, cv-role, cv-email, cv-phone, cv-location, cv-linkedin, cv-repository
-- [ ] IDs de seção: section-skills, section-experience, section-education, section-projects
-- [ ] Container: cv-container com max-width: 1000px
-- [ ] Scripts: cv-texts.js e dynamic-favicon.js
-- [ ] Language Toggle: Botão EN/PT no canto superior direito
-- [ ] Print Button: Botão PDF que abre cv_styles em nova aba e aciona print
-- [ ] Email Modal: Modal para envio de email via Formspree
-- [ ] Phone Modal: Modal com opções de contato (telefone/WhatsApp)
-- [ ] Tooltips: Sistema de tooltips nas experiências (renderTooltip function)
-
-### ☑️ **Após criar:**
+### Depois de criar
 - [ ] Executar `python validate-project.py`
-- [ ] Testar em ambos idiomas
-- [ ] Verificar impressão
+- [ ] Abrir página EN e PT no navegador — todas as seções populadas
+- [ ] Testar o botão de impressão nos dois idiomas
+- [ ] Personalizar detalhes visuais da marca se necessário (sem quebrar IDs)
 
 ---
 
-## 🚫 **PROIBIDO**
+## 🚫 PROIBIDO
 
 1. **NÃO** alterar largura do container (sempre 1000px)
-2. **NÃO** remover IDs obrigatórios
-3. **NÃO** esquecer scripts essenciais
+2. **NÃO** remover IDs obrigatórios nem containers dinâmicos
+3. **NÃO** esquecer scripts essenciais (`assets/js/cv-texts.js` + `dynamic-favicon.js`)
 4. **NÃO** usar variáveis CSS de outras empresas
-5. **NÃO** criar sem consultar este template
-
----
-
-## 📊 **ESTRUTURA DE ARQUIVOS**
-
-Para cada nova empresa, criar:
-```
-templates/companies/
-├── [empresa].html          # Versão EN
-└── [empresa]_pt.html       # Versão PT
-
-cv_styles/
-├── cv_[empresa]_style_EN.html   # Impressão EN
-└── cv_[empresa]_style_PT.html   # Impressão PT
-```
-
----
-
-## 🔄 **PROCESSO COMPLETO**
-
-1. **Copiar** este template
-2. **Substituir** [EMPRESA] e cores
-3. **Salvar** com nome correto
-4. **Validar** com script
-5. **Testar** funcionalidades
-6. **Documentar** no log
+5. **NÃO** criar template copiando arquivos — sempre pelo gerador
+6. **NÃO** criar estilos de impressão sem sufixo de idioma (`_EN`/`_PT`)
 
 ---
 

--- a/create-new-template.py
+++ b/create-new-template.py
@@ -1,54 +1,52 @@
 #!/usr/bin/env python3
 """
-🎯 CRIADOR DE NOVO TEMPLATE - PEDRO MARCONATO CV
-Cria automaticamente novos templates seguindo o padrão oficial
+CRIADOR DE NOVO TEMPLATE - PEDRO MARCONATO CV
+Cria automaticamente novos templates seguindo o padrão oficial.
 
-Uso: python create-new-template.py
+Uso interativo:      python create-new-template.py
+Uso não-interativo:  python create-new-template.py <Empresa> <#primaria> <#secundaria> <#destaque>
+
+Arquivos gerados/atualizados para cada empresa:
+  templates/companies/<empresa>.html      (página EN)
+  templates/companies/<empresa>_pt.html   (página PT)
+  cv_styles/cv_<empresa>_style_EN.html    (impressão EN, dinâmica via cv-texts.js)
+  cv_styles/cv_<empresa>_style_PT.html    (impressão PT, dinâmica via cv-texts.js)
+  assets/js/brands-config.js              (cores/gradiente da marca)
+  index.html                              (companyMappings — busca da home)
 """
 
-import os
 import re
+import sys
 from pathlib import Path
-from datetime import datetime
+from string import Template
 
-class TemplateCreator:
-    def __init__(self):
-        self.project_root = Path(__file__).parent
-        self.templates_dir = self.project_root / 'templates/companies'
-        self.cv_styles_dir = self.project_root / 'cv_styles'
-        
-        # Template base (versão simplificada)
-        self.base_template = '''<!DOCTYPE html>
-<html lang="{lang}">
+PAGE_TEMPLATE = Template('''<!DOCTYPE html>
+<html lang="$lang">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pedro Marconato - {empresa_display}</title>
+    <title>Pedro Marconato - $empresa_display</title>
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
-        
-        :root {{
-            /* {empresa_display} Official Colors */
-            --{empresa_lower}-primary: {primary_color};
-            --{empresa_lower}-secondary: {secondary_color};
-            --{empresa_lower}-accent: {accent_color};
-            
+
+        :root {
+            /* $empresa_display Official Colors */
+            --$empresa_lower-primary: $primary_color;
+            --$empresa_lower-secondary: $secondary_color;
+            --$empresa_lower-accent: $accent_color;
+
             /* Applied Colors */
-            --primary-color: var(--{empresa_lower}-primary);
-            --secondary-color: var(--{empresa_lower}-secondary);
-            --accent-color: var(--{empresa_lower}-accent);
+            --primary-color: var(--$empresa_lower-primary);
+            --secondary-color: var(--$empresa_lower-secondary);
+            --accent-color: var(--$empresa_lower-accent);
             --text-color: #2c3e50;
             --border-color: rgba(0, 0, 0, 0.1);
             --background-gradient: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
-        }}
-        
-        * {{
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }}
-        
-        body {{
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
             font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             color: var(--text-color);
             line-height: 1.6;
@@ -56,29 +54,25 @@ class TemplateCreator:
             min-height: 100vh;
             position: relative;
             overflow-x: hidden;
-        }}
-        
-        /* Animated background */
-        .animated-bg {{
+        }
+
+        .animated-bg {
             position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
+            top: 0; left: 0; width: 100%; height: 100%;
             background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 50%, #f8f9fa 100%);
             background-size: 400% 400%;
             animation: gradientShift 20s ease infinite;
             z-index: -2;
-        }}
-        
-        @keyframes gradientShift {{
-            0% {{ background-position: 0% 50%; }}
-            50% {{ background-position: 100% 50%; }}
-            100% {{ background-position: 0% 50%; }}
-        }}
-        
+        }
+
+        @keyframes gradientShift {
+            0% { background-position: 0% 50%; }
+            50% { background-position: 100% 50%; }
+            100% { background-position: 0% 50%; }
+        }
+
         /* Container PADRÃO - 1000px centralizado */
-        .cv-container {{
+        .cv-container {
             max-width: 1000px;
             margin: 30px auto;
             background: rgba(255, 255, 255, 0.98);
@@ -89,71 +83,191 @@ class TemplateCreator:
             overflow: hidden;
             position: relative;
             border: 1px solid var(--border-color);
-        }}
-        
-        /* Header */
-        .header {{
+        }
+
+        .header {
             background: var(--background-gradient);
             color: white;
             padding: 60px 50px;
             text-align: center;
             position: relative;
-        }}
-        
-        .header h1 {{
-            font-size: 2.5em;
-            font-weight: 700;
-            margin-bottom: 10px;
-            letter-spacing: -0.5px;
-        }}
-        
-        .header h2 {{
-            font-size: 1.2em;
-            font-weight: 400;
-            opacity: 0.9;
-            margin-bottom: 20px;
-        }}
-        
-        .contact-info {{
-            font-size: 0.95em;
-            opacity: 0.9;
-            line-height: 1.8;
-        }}
-        
-        .contact-info a {{
+        }
+
+        .header h1 { font-size: 2.5em; font-weight: 700; margin-bottom: 10px; letter-spacing: -0.5px; }
+        .header h2 { font-size: 1.2em; font-weight: 400; opacity: 0.9; margin-bottom: 20px; }
+
+        .contact-info { font-size: 0.95em; opacity: 0.9; line-height: 1.8; }
+        .contact-info a {
             color: white;
             text-decoration: none;
             border-bottom: 1px solid rgba(255, 255, 255, 0.3);
             transition: border-color 0.3s ease;
-        }}
-        
-        .contact-info a:hover {{
-            border-bottom-color: white;
-        }}
-        
-        /* Content sections */
-        .content {{
-            padding: 50px;
-        }}
-        
-        .section {{
-            margin-bottom: 40px;
-        }}
-        
-        .section-title {{
+        }
+        .contact-info a:hover { border-bottom-color: white; }
+
+        .content { padding: 50px; }
+        .section { margin-bottom: 40px; }
+
+        .section-title {
             font-size: 1.5em;
             font-weight: 700;
             color: var(--primary-color);
             margin-bottom: 20px;
             padding-bottom: 10px;
             border-bottom: 2px solid var(--border-color);
-        }}
-        
-        /* Print button */
-        .print-button {{
+        }
+
+        /* Skills (markup gerado por renderSkills) */
+        .skills-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+            gap: 30px;
+        }
+        .tool-item { margin-bottom: 14px; }
+        .tool-name {
+            display: flex;
+            justify-content: space-between;
+            font-weight: 500;
+            margin-bottom: 5px;
+        }
+        .tool-percentage { color: var(--accent-color); font-size: 0.85em; font-weight: 600; }
+        .dots-container { display: flex; gap: 4px; }
+        .dot {
+            width: 10px; height: 10px;
+            border-radius: 50%;
+            background: var(--border-color);
+        }
+        .dot.filled { background: var(--primary-color); }
+
+        /* Experiência (markup gerado por renderExperienceTimeline) */
+        .experience-item {
+            position: relative;
+            padding: 25px 25px 25px 70px;
+            margin-bottom: 25px;
+            background: rgba(0, 0, 0, 0.02);
+            border-radius: 12px;
+            border-left: 4px solid var(--primary-color);
+        }
+        .job-title {
+            font-size: 1.15em;
+            font-weight: 700;
+            color: var(--primary-color);
+            margin-bottom: 4px;
+        }
+        .job-number {
             position: absolute;
-            top: 20px;
-            right: 20px;
+            left: 20px; top: 25px;
+            width: 34px; height: 34px;
+            border-radius: 50%;
+            background: var(--background-gradient);
+            color: white;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 0.9em;
+            font-weight: 700;
+        }
+        .experience-item .company { font-weight: 600; }
+        .experience-item .period { font-size: 0.9em; color: var(--accent-color); margin-bottom: 10px; }
+        .job-description { margin-bottom: 15px; }
+
+        .achievements-container {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+            gap: 12px;
+        }
+        .achievement-item {
+            display: flex;
+            gap: 10px;
+            padding: 12px;
+            background: white;
+            border: 1px solid var(--border-color);
+            border-radius: 8px;
+        }
+        .achievement-icon { color: var(--primary-color); font-size: 1.1em; padding-top: 2px; }
+        .achievement-title { font-weight: 600; font-size: 0.92em; }
+        .achievement-description { font-size: 0.85em; }
+
+        /* Tooltips das experiências (markup gerado por renderTooltip) */
+        .tooltip { position: relative; display: inline-block; margin-left: 6px; }
+        .tooltip-icon { color: var(--accent-color); font-size: 0.8em; cursor: help; }
+        .tooltip-text {
+            visibility: hidden;
+            opacity: 0;
+            position: absolute;
+            z-index: 50;
+            top: 24px; left: 50%;
+            transform: translateX(-50%);
+            width: 340px;
+            max-width: 80vw;
+            background: white;
+            color: var(--text-color);
+            border: 1px solid var(--border-color);
+            border-radius: 10px;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.15);
+            padding: 15px;
+            font-size: 0.8em;
+            font-weight: 400;
+            text-align: left;
+            transition: opacity 0.2s ease;
+        }
+        .tooltip:hover .tooltip-text { visibility: visible; opacity: 1; }
+        .tooltip-header {
+            font-weight: 700;
+            color: var(--primary-color);
+            margin-bottom: 8px;
+        }
+        .tooltip-section { margin-bottom: 8px; }
+        .tooltip-section-title { font-weight: 600; margin-bottom: 3px; }
+        .tooltip-list { padding-left: 18px; }
+
+        /* Educação (markup gerado por renderEducation) */
+        .education-item {
+            padding: 20px;
+            margin-bottom: 15px;
+            background: rgba(0, 0, 0, 0.02);
+            border-radius: 12px;
+            border-left: 4px solid var(--accent-color);
+        }
+        .degree { font-weight: 700; color: var(--primary-color); }
+        .university { font-weight: 500; }
+        .thesis { font-size: 0.9em; margin-top: 4px; }
+
+        /* Projetos (markup gerado por renderProjects) */
+        .project-item {
+            padding: 20px;
+            margin-bottom: 15px;
+            background: rgba(0, 0, 0, 0.02);
+            border-radius: 12px;
+            border-left: 4px solid var(--secondary-color);
+        }
+        .project-title { font-weight: 700; color: var(--primary-color); margin-bottom: 6px; }
+        .tech-tag {
+            display: inline-block;
+            padding: 3px 10px;
+            margin: 3px 4px 0 0;
+            background: var(--background-gradient);
+            color: white;
+            border-radius: 12px;
+            font-size: 0.75em;
+            font-weight: 500;
+        }
+
+        .cta-button {
+            display: inline-block;
+            margin-top: 10px;
+            padding: 8px 14px;
+            background: var(--background-gradient);
+            color: white;
+            border-radius: 8px;
+            text-decoration: none;
+            font-size: 0.85em;
+        }
+
+        /* Print button */
+        .print-button {
+            position: absolute;
+            top: 20px; right: 20px;
             background: rgba(255, 255, 255, 0.2);
             border: 1px solid rgba(255, 255, 255, 0.3);
             color: white;
@@ -162,332 +276,398 @@ class TemplateCreator:
             cursor: pointer;
             transition: all 0.3s ease;
             font-size: 0.9em;
-        }}
-        
-        .print-button:hover {{
-            background: rgba(255, 255, 255, 0.3);
-        }}
-        
+        }
+        .print-button:hover { background: rgba(255, 255, 255, 0.3); }
+
+        /* Language toggle */
+        .language-toggle {
+            position: absolute;
+            top: 20px; left: 20px;
+            display: flex;
+            gap: 4px;
+            background: rgba(255, 255, 255, 0.2);
+            border: 1px solid rgba(255, 255, 255, 0.3);
+            border-radius: 8px;
+            padding: 4px;
+        }
+        .language-option {
+            color: white;
+            text-decoration: none;
+            padding: 4px 10px;
+            border-radius: 6px;
+            font-size: 0.85em;
+        }
+        .language-option.active { background: rgba(255, 255, 255, 0.3); font-weight: 700; }
+
         /* Responsive */
-        @media (max-width: 768px) {{
-            .cv-container {{
-                margin: 10px;
-                border-radius: 15px;
-            }}
-            
-            .header {{
-                padding: 40px 30px;
-            }}
-            
-            .header h1 {{
-                font-size: 2em;
-            }}
-            
-            .content {{
-                padding: 30px;
-            }}
-        }}
-        
+        @media (max-width: 768px) {
+            .cv-container { margin: 10px; border-radius: 15px; }
+            .header { padding: 70px 30px 40px; }
+            .header h1 { font-size: 2em; }
+            .content { padding: 30px; }
+        }
+
         /* Print styles */
-        @media print {{
-            body {{
-                background: white;
-            }}
-            
-            .animated-bg,
-            .print-button {{
-                display: none;
-            }}
-            
-            .cv-container {{
-                margin: 0;
-                box-shadow: none;
-                border: none;
-            }}
-        }}
+        @media print {
+            body { background: white; }
+            .animated-bg, .print-button, .language-toggle { display: none; }
+            .cv-container { margin: 0; box-shadow: none; border: none; }
+        }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-    <!-- Favicon Meta Tags -->
-    <meta name="theme-color" content="{primary_color}">
-    <meta name="msapplication-TileColor" content="{primary_color}">
+    <meta name="theme-color" content="$primary_color">
+    <meta name="msapplication-TileColor" content="$primary_color">
 </head>
 <body>
     <div class="animated-bg"></div>
-    
+
     <div class="cv-container">
         <header class="header">
-            <button class="print-button" onclick="window.open('../../cv_styles/cv_{empresa_lower}_style_{lang_upper}.html', '_blank')">
-                <i class="fas fa-print"></i> {print_text}
+            <div class="language-toggle">
+                <a href="$en_filename" class="language-option $en_active">EN</a>
+                <a href="$pt_filename" class="language-option $pt_active">PT</a>
+            </div>
+
+            <button class="print-button" onclick="var win = window.open('../../cv_styles/cv_${empresa_lower}_style_$lang_upper.html', '_blank'); win.onload = function() { win.print(); }">
+                <i class="fas fa-print"></i> $print_text
             </button>
-            
+
             <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
-            <h2 id="cv-role">{role_text}</h2>
-            
+            <h2 id="cv-role">$role_text</h2>
+
             <div class="contact-info">
                 <div>
-                    <span id="cv-email">pedrohmarconato@gmail.com</span> | 
-                    <span id="cv-phone">+55 (55) 981147758</span> | 
-                    <span id="cv-location">Cachoeira do Sul, RS</span>
+                    <span id="cv-email">pedrohmarconato@gmail.com</span> |
+                    <span id="cv-phone">+55 (55) 981147758</span> |
+                    <span id="cv-location"><span>Cachoeira do Sul, RS</span></span>
                 </div>
                 <div>
-                    <a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin">LinkedIn</a> | 
-                    <a href="https://github.com/pedrohmarconato/Pedro-Marconato-CV" id="cv-repository">{repo_text}</a>
+                    <a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin">LinkedIn</a> |
+                    <a href="https://github.com/pedrohmarconato" id="cv-repository">$repo_text</a>
                 </div>
             </div>
         </header>
-        
+
         <div class="content">
             <section class="section">
-                <h2 class="section-title">{profile_title}</h2>
-                <p id="cv-profile">{profile_text}</p>
+                <h2 class="section-title" id="section-profile">$profile_title</h2>
+                <p id="cv-profile">$profile_text</p>
             </section>
-            
+
             <section class="section">
-                <h2 class="section-title" id="section-skills">{skills_title}</h2>
-                <div id="skills-container">
-                    <!-- Skills will be loaded by cv-texts.js -->
+                <h2 class="section-title" id="section-skills">$skills_title</h2>
+                <div class="skills-grid">
+                    <div id="skills-strategic"></div>
+                    <div id="skills-tools"></div>
+                    <div id="skills-emerging"></div>
                 </div>
             </section>
-            
+
             <section class="section">
-                <h2 class="section-title" id="section-experience">{experience_title}</h2>
-                <div id="experience-container">
-                    <!-- Experience will be loaded by cv-texts.js -->
-                </div>
+                <h2 class="section-title" id="section-experience">$experience_title</h2>
+                <div id="experience-container"></div>
             </section>
-            
+
             <section class="section">
-                <h2 class="section-title" id="section-education">{education_title}</h2>
-                <div id="education-container">
-                    <!-- Education will be loaded by cv-texts.js -->
-                </div>
+                <h2 class="section-title" id="section-education">$education_title</h2>
+                <div id="education-container"></div>
             </section>
-            
+
             <section class="section">
-                <h2 class="section-title" id="section-projects">{projects_title}</h2>
-                <div id="projects-container">
-                    <!-- Projects will be loaded by cv-texts.js -->
-                </div>
+                <h2 class="section-title" id="section-projects">$projects_title</h2>
+                <div id="projects-container"></div>
             </section>
         </div>
     </div>
-    
+
     <!-- SCRIPTS OBRIGATÓRIOS -->
     <script src="../../assets/js/cv-texts.js"></script>
     <script src="../../assets/js/dynamic-favicon.js"></script>
     <script>
-        // Initialize content when page loads
-        document.addEventListener('DOMContentLoaded', function() {{
-            // Initialize with {lang_display} content
-            if (typeof initializeContent !== 'undefined') {{
-                initializeContent('{lang_code}');
-            }}
-            
-            // Initialize dynamic favicon
-            if (typeof DynamicFavicon !== 'undefined') {{
-                DynamicFavicon.init();
-            }}
-        }});
+        document.addEventListener('DOMContentLoaded', function() {
+            var lang = '$lang_code';
+            initializeBasicContent(lang);
+            renderSkills('skills-strategic', 'strategic', lang);
+            renderSkills('skills-tools', 'tools', lang);
+            renderSkills('skills-emerging', 'emerging', lang);
+            renderExperienceTimeline(lang);
+            renderEducation(lang);
+            renderProjects(lang);
+            initializeModalTexts(lang);
+        });
     </script>
 </body>
-</html>'''
+</html>
+''')
 
-    def log(self, message, level='info'):
-        icons = {'info': 'ℹ️', 'success': '✅', 'warning': '⚠️', 'error': '❌', 'input': '📝'}
-        print(f"{icons.get(level, 'ℹ️')} {message}")
-        
-    def validate_color(self, color):
-        """Valida formato de cor hexadecimal"""
-        if re.match(r'^#[0-9A-Fa-f]{6}$', color):
-            return True
-        return False
-        
-    def get_user_input(self):
-        """Obtém informações do usuário"""
-        print("🎯 CRIADOR DE NOVO TEMPLATE")
-        print("="*50)
-        print("Este assistente criará um novo template seguindo o padrão oficial")
-        print("="*50)
-        print()
-        
-        # Nome da empresa
-        while True:
-            empresa = input("📝 Nome da empresa (ex: Google, Microsoft): ").strip()
-            if empresa:
-                empresa_lower = empresa.lower().replace(' ', '')
-                # Verificar se já existe
-                if (self.templates_dir / f"{empresa_lower}.html").exists():
-                    self.log(f"Template para {empresa} já existe!", 'error')
-                    continue
-                break
-            self.log("Nome da empresa é obrigatório", 'error')
-            
-        # Cores
-        print("\n🎨 Cores da marca (formato hexadecimal #XXXXXX)")
-        
-        while True:
-            primary = input("📝 Cor primária (ex: #0066CC): ").strip()
-            if self.validate_color(primary):
-                break
-            self.log("Formato inválido. Use #XXXXXX", 'error')
-            
-        while True:
-            secondary = input("📝 Cor secundária (ex: #004499): ").strip()
-            if self.validate_color(secondary):
-                break
-            self.log("Formato inválido. Use #XXXXXX", 'error')
-            
-        while True:
-            accent = input("📝 Cor de destaque (ex: #87CEEB): ").strip()
-            if self.validate_color(accent):
-                break
-            self.log("Formato inválido. Use #XXXXXX", 'error')
-            
-        return {
-            'empresa': empresa,
-            'empresa_lower': empresa_lower,
-            'empresa_display': empresa,
-            'primary_color': primary,
-            'secondary_color': secondary,
-            'accent_color': accent
-        }
-        
-    def create_template(self, data, lang='en'):
-        """Cria um template específico"""
-        # Configurações por idioma
-        if lang == 'en':
-            lang_config = {
-                'lang': 'en',
-                'lang_code': 'en',
-                'lang_upper': 'EN',
-                'lang_display': 'English',
-                'print_text': 'Print CV',
-                'role_text': 'CRM Management and Data Intelligence',
-                'repo_text': 'Repository',
-                'profile_title': 'Professional Profile',
-                'profile_text': 'Professional profile content will be loaded here...',
-                'skills_title': 'Skills & Tools',
-                'experience_title': 'Professional Experience',
-                'education_title': 'Education',
-                'projects_title': 'Projects & Innovation'
-            }
-            filename = f"{data['empresa_lower']}.html"
-        else:
-            lang_config = {
-                'lang': 'pt-BR',
-                'lang_code': 'pt',
-                'lang_upper': 'PT',
-                'lang_display': 'Portuguese',
-                'print_text': 'Imprimir CV',
-                'role_text': 'Gestão de CRM e Inteligência de Dados',
-                'repo_text': 'Repositório',
-                'profile_title': 'Perfil Profissional',
-                'profile_text': 'O conteúdo do perfil profissional será carregado aqui...',
-                'skills_title': 'Habilidades e Ferramentas',
-                'experience_title': 'Experiência Profissional',
-                'education_title': 'Formação Acadêmica',
-                'projects_title': 'Projetos e Inovação'
-            }
-            filename = f"{data['empresa_lower']}_pt.html"
-            
-        # Combinar dados
-        template_data = {**data, **lang_config}
-        
-        # Gerar conteúdo
-        content = self.base_template.format(**template_data)
-        
-        # Salvar arquivo
-        file_path = self.templates_dir / filename
-        with open(file_path, 'w', encoding='utf-8') as f:
-            f.write(content)
-            
-        return file_path
-        
-    def create_cv_style(self, data, lang='EN'):
-        """Cria arquivo cv_style básico"""
-        cv_style_content = f'''<!DOCTYPE html>
-<html lang="{lang.lower()}">
+# Estilo de impressão DINÂMICO: renderiza o conteúdo a partir do cv-texts.js,
+# então nunca fica desatualizado quando o CV muda.
+PRINT_TEMPLATE = Template('''<!DOCTYPE html>
+<html lang="$lang">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pedro Henrique Marconato - CV</title>
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
-        
-        :root {{
-            /* {data['empresa_display']} Colors */
-            --primary-color: {data['primary_color']};
-            --secondary-color: {data['secondary_color']};
-            --accent-color: {data['accent_color']};
+
+        :root {
+            /* $empresa_display Colors */
+            --primary-color: $primary_color;
+            --secondary-color: $secondary_color;
+            --accent-color: $accent_color;
             --text-color: #2c3e50;
-            --border-color: rgba(0, 0, 0, 0.1);
-        }}
-        
-        * {{
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }}
-        
-        body {{
+            --border-color: rgba(0, 0, 0, 0.15);
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
             font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             color: var(--text-color);
-            line-height: 1.6;
+            line-height: 1.5;
             background: white;
-        }}
-        
-        /* CV container for print */
-        .cv-container {{
-            max-width: 210mm;
-            margin: 0 auto;
-            padding: 20mm;
-            background: white;
-        }}
-        
-        /* Basic styles for print */
-        @media print {{
-            body {{
-                margin: 0;
-                padding: 0;
-            }}
-            
-            .cv-container {{
-                margin: 0;
-                padding: 15mm;
-            }}
-        }}
+            font-size: 12px;
+        }
+
+        .cv-container { max-width: 210mm; margin: 0 auto; padding: 14mm; background: white; }
+
+        .header { border-bottom: 3px solid var(--primary-color); padding-bottom: 12px; margin-bottom: 16px; }
+        .header h1 { font-size: 22px; color: var(--primary-color); }
+        .header h2 { font-size: 13px; font-weight: 500; margin-bottom: 6px; }
+        .contact-info { font-size: 11px; }
+        .contact-info a { color: var(--text-color); text-decoration: none; }
+
+        .section { margin-bottom: 14px; }
+        .section-title {
+            font-size: 14px;
+            font-weight: 700;
+            color: var(--primary-color);
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 3px;
+            margin-bottom: 8px;
+            text-transform: uppercase;
+        }
+
+        .skills-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 14px; }
+        .tool-item { margin-bottom: 6px; }
+        .tool-name { display: flex; justify-content: space-between; font-weight: 500; font-size: 11px; }
+        .tool-percentage { color: var(--accent-color); font-size: 10px; font-weight: 600; }
+        .dots-container { display: flex; gap: 2px; margin-top: 2px; }
+        .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--border-color); }
+        .dot.filled { background: var(--primary-color); }
+
+        .experience-item {
+            padding: 8px 0 8px 14px;
+            border-left: 2px solid var(--primary-color);
+            margin-bottom: 10px;
+            page-break-inside: avoid;
+        }
+        .job-title { font-size: 13px; font-weight: 700; color: var(--primary-color); }
+        .job-number { display: none; }
+        .experience-item .company { font-weight: 600; font-size: 12px; }
+        .experience-item .period { font-size: 11px; color: var(--accent-color); margin-bottom: 4px; }
+        .job-description { font-size: 11px; margin-bottom: 6px; }
+        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
+        .achievement-item { display: flex; gap: 6px; font-size: 10.5px; }
+        .achievement-icon { color: var(--primary-color); padding-top: 1px; }
+        .achievement-title { font-weight: 600; }
+        .tooltip { display: none; }
+
+        .education-item { margin-bottom: 8px; page-break-inside: avoid; }
+        .degree { font-weight: 700; color: var(--primary-color); font-size: 12px; }
+        .university { font-size: 11px; }
+        .thesis { font-size: 10.5px; }
+        .cta-button { display: none; }
+
+        .project-item { margin-bottom: 8px; page-break-inside: avoid; }
+        .project-title { font-weight: 700; color: var(--primary-color); font-size: 12px; }
+        .project-description { font-size: 11px; }
+        .tech-tag {
+            display: inline-block;
+            padding: 1px 7px;
+            margin: 2px 3px 0 0;
+            border: 1px solid var(--primary-color);
+            color: var(--primary-color);
+            border-radius: 8px;
+            font-size: 9.5px;
+        }
+
+        @media print {
+            body { margin: 0; padding: 0; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+            .cv-container { margin: 0; padding: 10mm; max-width: none; }
+        }
     </style>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 </head>
 <body>
     <div class="cv-container">
-        <h1>Pedro Henrique Lima Marconato</h1>
-        <p>CRM Management and Data Intelligence</p>
-        <!-- CV content will be populated here -->
+        <header class="header">
+            <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
+            <h2 id="cv-role">$role_text</h2>
+            <div class="contact-info">
+                <span id="cv-email">pedrohmarconato@gmail.com</span> |
+                <span id="cv-phone">+55 (55) 981147758</span> |
+                <span id="cv-location"><span>Cachoeira do Sul, RS</span></span> |
+                <a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin">LinkedIn</a>
+            </div>
+        </header>
+
+        <section class="section">
+            <h2 class="section-title" id="section-profile">$profile_title</h2>
+            <p id="cv-profile"></p>
+        </section>
+
+        <section class="section">
+            <h2 class="section-title" id="section-skills">$skills_title</h2>
+            <div class="skills-grid">
+                <div id="skills-strategic"></div>
+                <div id="skills-tools"></div>
+                <div id="skills-emerging"></div>
+            </div>
+        </section>
+
+        <section class="section">
+            <h2 class="section-title" id="section-experience">$experience_title</h2>
+            <div id="experience-container"></div>
+        </section>
+
+        <section class="section">
+            <h2 class="section-title" id="section-education">$education_title</h2>
+            <div id="education-container"></div>
+        </section>
+
+        <section class="section">
+            <h2 class="section-title" id="section-projects">$projects_title</h2>
+            <div id="projects-container"></div>
+        </section>
     </div>
+
+    <script src="../assets/js/cv-texts.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            var lang = '$lang_code';
+            initializeBasicContent(lang);
+            renderSkills('skills-strategic', 'strategic', lang);
+            renderSkills('skills-tools', 'tools', lang);
+            renderSkills('skills-emerging', 'emerging', lang);
+            renderExperienceTimeline(lang);
+            renderEducation(lang);
+            renderProjects(lang);
+        });
+    </script>
 </body>
-</html>'''
-        
-        filename = f"cv_{data['empresa_lower']}_style_{lang}.html"
-        file_path = self.cv_styles_dir / filename
-        
-        with open(file_path, 'w', encoding='utf-8') as f:
-            f.write(cv_style_content)
-            
+</html>
+''')
+
+LANG_CONFIG = {
+    'en': {
+        'lang': 'en',
+        'lang_code': 'en',
+        'lang_upper': 'EN',
+        'print_text': 'Print CV',
+        'role_text': 'CRM Management and Data Intelligence',
+        'repo_text': 'Repository',
+        'profile_title': 'Professional Profile',
+        'profile_text': 'Loading professional profile...',
+        'skills_title': 'Skills & Tools',
+        'experience_title': 'Professional Experience',
+        'education_title': 'Education',
+        'projects_title': 'Projects & Innovation',
+        'en_active': 'active',
+        'pt_active': '',
+    },
+    'pt': {
+        'lang': 'pt-BR',
+        'lang_code': 'pt',
+        'lang_upper': 'PT',
+        'print_text': 'Imprimir CV',
+        'role_text': 'Gestão de CRM e Inteligência de Dados',
+        'repo_text': 'Repositório',
+        'profile_title': 'Perfil Profissional',
+        'profile_text': 'Carregando perfil profissional...',
+        'skills_title': 'Habilidades e Ferramentas',
+        'experience_title': 'Experiência Profissional',
+        'education_title': 'Formação Acadêmica',
+        'projects_title': 'Projetos e Inovação',
+        'en_active': '',
+        'pt_active': 'active',
+    },
+}
+
+
+class TemplateCreator:
+    def __init__(self):
+        self.project_root = Path(__file__).parent
+        self.templates_dir = self.project_root / 'templates/companies'
+        self.cv_styles_dir = self.project_root / 'cv_styles'
+        self.index_path = self.project_root / 'index.html'
+
+    def log(self, message, level='info'):
+        icons = {'info': 'ℹ️', 'success': '✅', 'warning': '⚠️', 'error': '❌', 'input': '📝'}
+        print(f"{icons.get(level, 'ℹ️')} {message}")
+
+    def validate_color(self, color):
+        return bool(re.match(r'^#[0-9A-Fa-f]{6}$', color))
+
+    def build_data(self, empresa, primary, secondary, accent):
+        empresa_lower = empresa.lower().replace(' ', '-')
+        for color in (primary, secondary, accent):
+            if not self.validate_color(color):
+                raise ValueError(f"Cor inválida: {color} (use #XXXXXX)")
+        if (self.templates_dir / f"{empresa_lower}.html").exists():
+            raise ValueError(f"Template para {empresa} já existe!")
+        return {
+            'empresa': empresa,
+            'empresa_lower': empresa_lower,
+            'empresa_display': empresa,
+            'primary_color': primary,
+            'secondary_color': secondary,
+            'accent_color': accent,
+            'en_filename': f"{empresa_lower}.html",
+            'pt_filename': f"{empresa_lower}_pt.html",
+        }
+
+    def get_user_input(self):
+        print("🎯 CRIADOR DE NOVO TEMPLATE")
+        print("=" * 50)
+        while True:
+            empresa = input("📝 Nome da empresa (ex: Google): ").strip()
+            if not empresa:
+                self.log("Nome da empresa é obrigatório", 'error')
+                continue
+            print("\n🎨 Cores da marca (formato #XXXXXX)")
+            primary = input("📝 Cor primária: ").strip()
+            secondary = input("📝 Cor secundária: ").strip()
+            accent = input("📝 Cor de destaque: ").strip()
+            try:
+                return self.build_data(empresa, primary, secondary, accent)
+            except ValueError as e:
+                self.log(str(e), 'error')
+
+    def create_template(self, data, lang):
+        content = PAGE_TEMPLATE.substitute({**data, **LANG_CONFIG[lang]})
+        filename = data['pt_filename'] if lang == 'pt' else data['en_filename']
+        file_path = self.templates_dir / filename
+        file_path.write_text(content, encoding='utf-8')
         return file_path
-        
+
+    def create_cv_style(self, data, lang):
+        content = PRINT_TEMPLATE.substitute({**data, **LANG_CONFIG[lang]})
+        filename = f"cv_{data['empresa_lower']}_style_{LANG_CONFIG[lang]['lang_upper']}.html"
+        file_path = self.cv_styles_dir / filename
+        file_path.write_text(content, encoding='utf-8')
+        return file_path
+
     def update_brands_config(self, data):
-        """Adiciona nova marca ao brands-config.js"""
         brands_config_path = self.project_root / 'assets/js/brands-config.js'
-        
         if not brands_config_path.exists():
             self.log("brands-config.js não encontrado", 'warning')
             return
-            
-        # Ler arquivo atual
-        with open(brands_config_path, 'r', encoding='utf-8') as f:
-            content = f.read()
-            
-        # Criar configuração da nova marca
+        content = brands_config_path.read_text(encoding='utf-8')
+        if re.search(rf"^\s*{re.escape(data['empresa_lower'])}:", content, re.M):
+            self.log(f"{data['empresa_lower']} já existe no brands-config.js", 'warning')
+            return
         new_brand_config = f'''
     {data['empresa_lower']}: {{
         name: '{data['empresa_display']}',
@@ -509,75 +689,85 @@ class TemplateCreator:
         shapes: 'circles',
         animations: 'standard'
     }},'''
-        
-        # Inserir antes do fechamento do objeto
         insert_position = content.rfind('};')
-        if insert_position > 0:
-            # Remover vírgula do último item atual
-            last_comma = content.rfind('},', 0, insert_position)
-            if last_comma > 0:
-                content = content[:last_comma+2] + content[last_comma+2:]
-                
-            # Inserir nova configuração
-            new_content = content[:insert_position] + new_brand_config + '\n' + content[insert_position:]
-            
-            # Salvar arquivo atualizado
-            with open(brands_config_path, 'w', encoding='utf-8') as f:
-                f.write(new_content)
-                
-            self.log("brands-config.js atualizado", 'success')
-        else:
+        if insert_position < 0:
             self.log("Não foi possível atualizar brands-config.js", 'error')
-            
-    def run(self):
-        """Executa o processo completo"""
-        # Obter dados do usuário
-        data = self.get_user_input()
-        
-        print("\n" + "="*50)
+            return
+        new_content = content[:insert_position] + new_brand_config + '\n' + content[insert_position:]
+        brands_config_path.write_text(new_content, encoding='utf-8')
+        self.log("brands-config.js atualizado", 'success')
+
+    def update_index_mappings(self, data):
+        """Adiciona a empresa ao companyMappings do index.html (busca da home)."""
+        if not self.index_path.exists():
+            self.log("index.html não encontrado", 'warning')
+            return
+        content = self.index_path.read_text(encoding='utf-8')
+        anchor = 'const companyMappings = {'
+        if anchor not in content:
+            self.log("companyMappings não encontrado no index.html", 'error')
+            return
+        en_path = f"templates/companies/{data['en_filename']}"
+        pt_path = f"templates/companies/{data['pt_filename']}"
+        if en_path in content:
+            self.log(f"{en_path} já está no index.html", 'warning')
+            return
+        keywords_en = sorted({data['empresa_lower'], data['en_filename'],
+                              data['empresa'].lower()})
+        keywords_pt = sorted({f"{data['empresa_lower']}_pt", data['pt_filename']})
+        entry = (f'{anchor}\n'
+                 f'  "{en_path}": {keywords_en},\n'
+                 f'  "{pt_path}": {keywords_pt},').replace("'", '"')
+        content = content.replace(anchor, entry, 1)
+        self.index_path.write_text(content, encoding='utf-8')
+        self.log("index.html (companyMappings) atualizado", 'success')
+
+    def run(self, data=None):
+        if data is None:
+            data = self.get_user_input()
+
+        print("\n" + "=" * 50)
         print("📋 CRIANDO TEMPLATES...")
-        print("="*50)
-        
-        try:
-            # Criar template EN
-            en_file = self.create_template(data, 'en')
-            self.log(f"Template EN criado: {en_file.name}", 'success')
-            
-            # Criar template PT
-            pt_file = self.create_template(data, 'pt')
-            self.log(f"Template PT criado: {pt_file.name}", 'success')
-            
-            # Criar cv_styles
-            cv_en = self.create_cv_style(data, 'EN')
-            self.log(f"CV Style EN criado: {cv_en.name}", 'success')
-            
-            cv_pt = self.create_cv_style(data, 'PT')
-            self.log(f"CV Style PT criado: {cv_pt.name}", 'success')
-            
-            # Atualizar brands-config.js
-            self.update_brands_config(data)
-            
-            print("\n" + "="*50)
-            print("🎉 TEMPLATES CRIADOS COM SUCESSO!")
-            print("="*50)
-            print("\n📋 Próximos passos:")
-            print("   1. Execute 'python validate-project.py' para validar")
-            print("   2. Teste os templates nos dois idiomas")
-            print("   3. Personalize o conteúdo específico da empresa")
-            print("   4. Adicione logo se disponível")
-            print("\n✅ Arquivos criados:")
-            print(f"   - templates/companies/{data['empresa_lower']}.html")
-            print(f"   - templates/companies/{data['empresa_lower']}_pt.html")
-            print(f"   - cv_styles/cv_{data['empresa_lower']}_style_EN.html")
-            print(f"   - cv_styles/cv_{data['empresa_lower']}_style_PT.html")
-            
-        except Exception as e:
-            self.log(f"Erro ao criar templates: {str(e)}", 'error')
-            
+        print("=" * 50)
+
+        en_file = self.create_template(data, 'en')
+        self.log(f"Template EN criado: {en_file.name}", 'success')
+        pt_file = self.create_template(data, 'pt')
+        self.log(f"Template PT criado: {pt_file.name}", 'success')
+        cv_en = self.create_cv_style(data, 'en')
+        self.log(f"CV Style EN criado: {cv_en.name}", 'success')
+        cv_pt = self.create_cv_style(data, 'pt')
+        self.log(f"CV Style PT criado: {cv_pt.name}", 'success')
+        self.update_brands_config(data)
+        self.update_index_mappings(data)
+
+        print("\n" + "=" * 50)
+        print("🎉 TEMPLATES CRIADOS COM SUCESSO!")
+        print("=" * 50)
+        print("\n📋 Próximos passos:")
+        print("   1. Execute 'python validate-project.py' para validar")
+        print("   2. Teste os templates nos dois idiomas (página e impressão)")
+        print("   3. Ajuste cores/detalhes visuais específicos da marca se necessário")
+        print("\n✅ Arquivos criados/atualizados:")
+        print(f"   - templates/companies/{data['en_filename']}")
+        print(f"   - templates/companies/{data['pt_filename']}")
+        print(f"   - cv_styles/cv_{data['empresa_lower']}_style_EN.html")
+        print(f"   - cv_styles/cv_{data['empresa_lower']}_style_PT.html")
+        print("   - assets/js/brands-config.js")
+        print("   - index.html (companyMappings)")
+
+
 def main():
-    """Função principal"""
     creator = TemplateCreator()
-    creator.run()
+    if len(sys.argv) == 5:
+        data = creator.build_data(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])
+        creator.run(data)
+    elif len(sys.argv) == 1:
+        creator.run()
+    else:
+        print(__doc__)
+        sys.exit(1)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## O problema

O fluxo de criação de novas páginas estava quebrado em três pontos:
1. O gerador emitia `initializeContent()` — função que **não existe** no cv-texts.js — dentro de um guard `typeof !== 'undefined'`, então páginas novas nasciam com todas as seções **silenciosamente vazias**.
2. Os estilos de impressão gerados eram stubs quase vazios ("CV content will be populated here") — a origem dos stubs de 2KB removidos no PR #10.
3. O `index.html` não era atualizado — a empresa nova não aparecia na busca da home.

## As mudanças

**`create-new-template.py` reescrito**
- Páginas geradas usam a API real: `initializeBasicContent`, `renderSkills` (3 categorias), `renderExperienceTimeline`, `renderEducation`, `renderProjects`, `initializeModalTexts` — sem guard silencioso
- Estilos de impressão agora são **dinâmicos** (renderizam do cv-texts.js): nunca desatualizam quando o CV muda
- Atualiza também o `companyMappings` do index.html
- Novo modo não-interativo: `python create-new-template.py <Empresa> <#primaria> <#secundaria> <#destaque>`
- Template gerado inclui language toggle, botão de impressão do idioma correto e CSS completo para o markup das funções de render

**Documentação alinhada com a realidade**
- `REGRAS_PROJETO.md` v2.0 — API real, `assets/js` como casa única dos JS, nomenclatura só `_EN`/`_PT`
- `TEMPLATE_PADRAO.md` v3.0 — gerador como fonte da verdade
- `CLAUDE.md` — substituído conteúdo obsoleto (notas de debug de pipeline MCP) por mapa real do projeto

## Verificação

Gerador testado de ponta a ponta em cópia isolada do repo (empresa fictícia TestCorp): as 4 páginas geradas renderizam 100% populadas via Chrome headless (16 skills, 4 experiências, formação, projetos, nos 2 idiomas), screenshots conferidos visualmente, index e brands-config atualizados, validador sem erros novos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)