### PR TITLE
Harden validator, fix brands-config logos, standardize cv-profile ids

### DIFF
--- a/assets/js/brands-config.js
+++ b/assets/js/brands-config.js
@@ -75,7 +75,7 @@ const BRANDS_CONFIG = {
             border: 'rgba(255, 215, 0, 0.2)'
         },
         gradient: 'linear-gradient(135deg, #FFD700 0%, #F7DC00 100%)',
-        logo: '../assets/images/willbank_will-bank.svg',
+        logo: '../../assets/images/willbank_will-bank.svg',
         tagline: {
             en: 'Banking Made Simple',
             pt: 'Banco Digital Simples'
@@ -96,7 +96,7 @@ const BRANDS_CONFIG = {
             border: 'rgba(216, 27, 96, 0.2)'
         },
         gradient: 'linear-gradient(135deg, #1C2D4B 0%, #D81B60 100%)',
-        logo: '../assets/images/wehandle_logo.svg',
+        logo: '../../assets/images/wehandle.webp',
         tagline: {
             en: 'Let\'s Handle Success Together',
             pt: 'Vamos Lidar com o Sucesso Juntos'
@@ -117,7 +117,7 @@ const BRANDS_CONFIG = {
             border: 'rgba(234, 29, 44, 0.2)'
         },
         gradient: 'linear-gradient(135deg, #EA1D2C 0%, #FF6B35 100%)',
-        logo: '../assets/images/ifood_logo.svg',
+        logo: '../../assets/images/IFood_logo_c.svg',
         tagline: {
             en: 'Connecting People Through Food',
             pt: 'Conectando Pessoas Através da Comida'
@@ -138,7 +138,7 @@ const BRANDS_CONFIG = {
             border: 'rgba(0, 168, 89, 0.2)'
         },
         gradient: 'linear-gradient(135deg, #00A859 0%, #4CAF50 100%)',
-        logo: '../assets/images/sicredi_logo.svg',
+        logo: '../../assets/images/sicredi.svg',
         tagline: {
             en: 'Growing Together Cooperatively',
             pt: 'Crescendo Juntos de Forma Cooperativa'
@@ -159,7 +159,7 @@ const BRANDS_CONFIG = {
             border: 'rgba(139, 69, 19, 0.2)'
         },
         gradient: 'linear-gradient(135deg, #8B4513 0%, #D2691E 100%)',
-        logo: '../assets/images/boticario_logo.svg',
+        logo: '../../assets/images/boticario.svg',
         tagline: {
             en: 'Beauty in Every Detail',
             pt: 'Beleza em Cada Detalhe'
@@ -180,7 +180,7 @@ const BRANDS_CONFIG = {
             border: 'rgba(0, 102, 204, 0.2)'
         },
         gradient: 'linear-gradient(135deg, #0066CC 0%, #4A90E2 100%)',
-        logo: '../assets/images/contaazul_logo.svg',
+        logo: '../../assets/images/logo_conta_azul.svg',
         tagline: {
             en: 'Simplifying Business Management',
             pt: 'Simplificando a Gestão do Negócio'
@@ -201,7 +201,7 @@ const BRANDS_CONFIG = {
             border: 'rgba(46, 139, 87, 0.2)'
         },
         gradient: 'linear-gradient(135deg, #2E8B57 0%, #3CB371 100%)',
-        logo: '../assets/images/allos_logo.svg',
+        logo: '../../assets/images/allos.png',
         tagline: {
             en: 'Strategic Consulting Excellence',
             pt: 'Excelência em Consultoria Estratégica'
@@ -222,7 +222,7 @@ const BRANDS_CONFIG = {
             border: 'rgba(75, 0, 130, 0.2)'
         },
         gradient: 'linear-gradient(135deg, #4B0082 0%, #663399 100%)',
-        logo: '../assets/images/completebari_logo.svg',
+        logo: '../../assets/images/complete_bari.png',
         tagline: {
             en: 'Complete Bariatric Solutions',
             pt: 'Soluções Bariátricas Completas'
@@ -273,7 +273,7 @@ const BRANDS_CONFIG = {
             border: 'rgba(255, 69, 0, 0.2)'
         },
         gradient: 'linear-gradient(135deg, #FF4500 0%, #FF6347 100%)',
-        logo: '../assets/images/neogroup_logo.svg',
+        logo: '../../assets/images/neo_group.png',
         tagline: {
             en: 'Innovation at Every Step',
             pt: 'Inovação a Cada Passo'
@@ -294,7 +294,7 @@ const BRANDS_CONFIG = {
             border: 'rgba(46, 204, 113, 0.2)'
         },
         gradient: 'linear-gradient(135deg, #2ECC71 0%, #27AE60 100%)',
-        logo: '../assets/images/rdstation_logo.svg',
+        logo: null,
         tagline: {
             en: 'Digital Marketing Excellence',
             pt: 'Excelência em Marketing Digital'

--- a/templates/companies/completebari.html
+++ b/templates/companies/completebari.html
@@ -1278,8 +1278,8 @@
         </header>
         
         <section class="section">
-            <h2 class="section-title" id="cv-profile-title"></h2>
-            <p class="profile-text" id="cv-profile-text"></p>
+            <h2 class="section-title" id="section-profile"></h2>
+            <p class="profile-text" id="cv-profile"></p>
         </section>
         
         <section class="section">

--- a/templates/companies/completebari_pt.html
+++ b/templates/companies/completebari_pt.html
@@ -850,8 +850,8 @@
 
         <main class="content">
             <section class="section">
-                <h2 class="section-title" id="cv-profile-title"></h2>
-                <p class="item-description" id="cv-profile-text"></p>
+                <h2 class="section-title" id="section-profile"></h2>
+                <p class="item-description" id="cv-profile"></p>
             </section>
 
             <section class="section">

--- a/templates/companies/meutudo.html
+++ b/templates/companies/meutudo.html
@@ -1145,7 +1145,7 @@
                 <i class="fas fa-user"></i>
                 <span id="cv-profile-title"></span>
             </h2>
-            <p id="cv-profile-content"></p>
+            <p id="cv-profile"></p>
         </section>
         
         <!-- Skills & Tools -->
@@ -1489,7 +1489,7 @@
             if (projectsTitleEl) projectsTitleEl.textContent = getText('sections.projects', 'en');
 
             // Profile content
-            const profileContentEl = document.getElementById('cv-profile-content');
+            const profileContentEl = document.getElementById('cv-profile');
             if (profileContentEl) profileContentEl.textContent = getText('professionalProfile', 'en');
 
             // Skills section (MeuTudo specific)

--- a/templates/companies/meutudo_pt.html
+++ b/templates/companies/meutudo_pt.html
@@ -1144,7 +1144,7 @@
                 <i class="fas fa-user"></i>
                 <span id="cv-profile-title"></span>
             </h2>
-            <p id="cv-profile-content"></p>
+            <p id="cv-profile"></p>
         </section>
         
         <!-- Skills & Tools -->
@@ -1488,7 +1488,7 @@
             if (projectsTitleEl) projectsTitleEl.textContent = getText('sections.projects', 'pt');
 
             // Profile content
-            const profileContentEl = document.getElementById('cv-profile-content');
+            const profileContentEl = document.getElementById('cv-profile');
             if (profileContentEl) profileContentEl.textContent = getText('professionalProfile', 'pt');
 
             // Skills section (MeuTudo specific)

--- a/templates/companies/rdstation.html
+++ b/templates/companies/rdstation.html
@@ -1543,7 +1543,7 @@
         
         <section class="section">
             <h2 class="section-title">PROFESSIONAL PROFILE</h2>
-            <p class="profile-text">
+            <p class="profile-text" id="cv-profile">
                 Professional in CRM Management and Data Intelligence focused on quantifiable results. At Grupo RBS, I led a Brand Equity research audit that supported strategic decisions. At DBC/Realize CFI, I developed a pipeline for competitor analysis generating insights on R$1B in transactions and automated critical reports. As CRM Coordinator at Lojas Renner, I optimized budget generating 10% annual savings, implemented 80% automated communications and strategies that resulted in consumption increase. My approach integrates data, technology and strategic vision for tangible results.
             </p>
         </section>

--- a/templates/companies/rdstation_pt.html
+++ b/templates/companies/rdstation_pt.html
@@ -1321,7 +1321,7 @@
         
         <section class="section">
             <h2 class="section-title">PERFIL PROFISSIONAL</h2>
-            <p class="profile-text">
+            <p class="profile-text" id="cv-profile">
                 Profissional em Gestão de CRM e Inteligência de Dados com foco em resultados quantificáveis. No Grupo RBS, liderei auditoria de pesquisa de Brand Equity que fundamentou decisões estratégicas. Na DBC/Realize CFI, desenvolvi pipeline para análise de concorrentes gerando insights sobre R$1B em transações e automatizei relatórios críticos. Como Coordenador de CRM nas Lojas Renner, otimizei orçamento gerando economia de 10% ao ano, implementei 80% de comunicações automatizadas e estratégias que resultaram em incremento no consumo. Minha abordagem integra dados, tecnologia e visão estratégica para resultados tangíveis.
             </p>
         </section>

--- a/validate-project.py
+++ b/validate-project.py
@@ -1,16 +1,19 @@
 #!/usr/bin/env python3
 """
 🔍 VALIDADOR DO PROJETO PEDRO MARCONATO CV
-Verifica se o projeto segue todas as regras estabelecidas
+Verifica se o projeto segue todas as regras estabelecidas (REGRAS_PROJETO.md)
 
 Uso: python validate-project.py
 """
 
-import os
 import re
-import glob
 from datetime import datetime
 from pathlib import Path
+
+# Funções de inicialização que EXISTEM no cv-texts.js
+VALID_INIT_MARKERS = ('initializeBasicContent', 'initializeCV', 'getText')
+STUB_SIZE_BYTES = 5000
+
 
 class ProjectValidator:
     def __init__(self):
@@ -18,294 +21,321 @@ class ProjectValidator:
         self.warnings = []
         self.info = []
         self.project_root = Path(__file__).parent
-        
+        self.templates_dir = self.project_root / 'templates/companies'
+        self.cv_styles_dir = self.project_root / 'cv_styles'
+
     def log_error(self, message):
         self.errors.append(f"❌ ERRO: {message}")
-        
+
     def log_warning(self, message):
         self.warnings.append(f"⚠️  AVISO: {message}")
-        
+
     def log_info(self, message):
         self.info.append(f"ℹ️  INFO: {message}")
 
+    # ------------------------------------------------------------------
     def validate_file_structure(self):
         """Valida estrutura de diretórios e arquivos"""
         print("🔍 Validando estrutura de arquivos...")
-        
-        # Verificar diretórios obrigatórios
+
         required_dirs = [
             'templates/companies',
-            'cv_styles', 
+            'cv_styles',
             'assets/js',
             'assets/images',
-            'assets/css'
+            'assets/css',
         ]
-        
         for dir_path in required_dirs:
-            full_path = self.project_root / dir_path
-            if not full_path.exists():
+            if not (self.project_root / dir_path).exists():
                 self.log_error(f"Diretório obrigatório não encontrado: {dir_path}")
             else:
                 self.log_info(f"Diretório OK: {dir_path}")
-        
-        # Verificar arquivos proibidos
+
+        # Arquivos proibidos
         forbidden_patterns = [
             '*_backup.html',
             'templates/companies/*.py',
             'templates/companies/*.sh',
             'templates/companies/*.txt',
             'test-*.html',
-            '*-transition.html'
+            '*-transition.html',
         ]
-        
         for pattern in forbidden_patterns:
-            matches = list(self.project_root.glob(pattern))
-            for match in matches:
+            for match in self.project_root.glob(pattern):
                 self.log_error(f"Arquivo proibido encontrado: {match.relative_to(self.project_root)}")
 
+        # Fonte única do cv-texts.js: só em assets/js/
+        strays = [p for p in self.project_root.rglob('cv-texts.js')
+                  if p.relative_to(self.project_root).as_posix() != 'assets/js/cv-texts.js'
+                  and '.git' not in p.parts]
+        for stray in strays:
+            self.log_error(f"Cópia proibida do cv-texts.js: {stray.relative_to(self.project_root)} "
+                           f"(fonte única é assets/js/cv-texts.js)")
+
+        # Nomenclatura legada de cv_styles (sem sufixo de idioma) é proibida
+        for f in self.cv_styles_dir.glob('cv_*_style.html'):
+            self.log_error(f"Estilo de impressão com nome legado (sem _EN/_PT): cv_styles/{f.name}")
+
+    # ------------------------------------------------------------------
     def validate_templates(self):
         """Valida templates HTML"""
         print("🔍 Validando templates...")
-        
-        template_files = list((self.project_root / 'templates/companies').glob('*.html'))
-        
-        for template_file in template_files:
-            self.validate_single_template(template_file)
-            
-        # Verificar consistência PT/EN
+
+        template_files = sorted(self.templates_dir.glob('*.html'))
         companies = set()
         for template_file in template_files:
+            self.validate_single_template(template_file)
             name = template_file.stem
-            if name.endswith('_pt'):
-                companies.add(name[:-3])  # Remove '_pt'
-            else:
-                companies.add(name)
-                
-        for company in companies:
-            en_file = self.project_root / 'templates/companies' / f'{company}.html'
-            pt_file = self.project_root / 'templates/companies' / f'{company}_pt.html'
-            
-            if not en_file.exists():
+            companies.add(name[:-3] if name.endswith('_pt') else name)
+
+        # Consistência PT/EN
+        for company in sorted(companies):
+            if not (self.templates_dir / f'{company}.html').exists():
                 self.log_error(f"Template EN não encontrado para: {company}")
-            if not pt_file.exists():
+            if not (self.templates_dir / f'{company}_pt.html').exists():
                 self.log_error(f"Template PT não encontrado para: {company}")
-                
+
+        self.companies = companies
         self.log_info(f"Total de empresas encontradas: {len(companies)}")
 
     def validate_single_template(self, template_file):
-        """Valida um template específico"""
         try:
-            with open(template_file, 'r', encoding='utf-8') as f:
-                content = f.read()
-                
-            template_name = template_file.stem
-            
-            # Verificar IDs obrigatórios
-            required_ids = [
-                'cv-name', 'cv-role', 'cv-email', 'cv-phone', 
-                'cv-location', 'cv-linkedin', 'cv-repository',
-                'section-skills', 'section-experience', 
-                'section-education', 'section-projects'
-            ]
-            
-            for required_id in required_ids:
-                if f'id="{required_id}"' not in content:
-                    self.log_error(f"ID obrigatório '{required_id}' não encontrado em {template_name}")
-                    
-            # Verificar scripts obrigatórios
-            required_scripts = [
-                'cv-texts.js',
-                'dynamic-favicon.js'
-            ]
-            
-            for script in required_scripts:
-                if script not in content:
-                    self.log_error(f"Script obrigatório '{script}' não encontrado em {template_name}")
-                    
-            # Verificar variáveis CSS incorretas
-            wrong_css_patterns = [
-                r'--sicredi-green.*:',
-                r'--sicredi-dark.*:',
-                r'--ifood-.*:.*#(?!EA1D2C|C41826)',  # Cores incorretas para iFood
-            ]
-            
-            for pattern in wrong_css_patterns:
-                matches = re.findall(pattern, content, re.IGNORECASE)
-                if matches:
-                    self.log_warning(f"Possível variável CSS incorreta em {template_name}: {matches}")
-                    
-            # Verificar DOCTYPE e estrutura básica
-            if '<!DOCTYPE html>' not in content:
-                self.log_error(f"DOCTYPE ausente em {template_name}")
-                
-            # Verificar idioma correto
-            if template_name.endswith('_pt'):
-                if 'lang="pt-BR"' not in content:
-                    self.log_warning(f"Idioma PT-BR não definido em {template_name}")
-            else:
-                if 'lang="en"' not in content:
-                    self.log_warning(f"Idioma EN não definido em {template_name}")
-                    
+            content = template_file.read_text(encoding='utf-8')
         except Exception as e:
-            self.log_error(f"Erro ao validar {template_file}: {str(e)}")
+            self.log_error(f"Erro ao ler {template_file.name}: {e}")
+            return
 
+        name = template_file.stem
+        company = name[:-3] if name.endswith('_pt') else name
+        lang_suffix = 'PT' if name.endswith('_pt') else 'EN'
+
+        # IDs obrigatórios
+        required_ids = [
+            'cv-name', 'cv-role', 'cv-email', 'cv-phone',
+            'cv-location', 'cv-linkedin', 'cv-repository',
+            'section-skills', 'section-experience',
+            'section-education', 'section-projects',
+        ]
+        for required_id in required_ids:
+            if f'id="{required_id}"' not in content:
+                self.log_error(f"ID obrigatório '{required_id}' não encontrado em {name}")
+        if 'id="cv-profile"' not in content:
+            self.log_warning(f"ID 'cv-profile' ausente em {name} (usa variação fora do padrão)")
+
+        # Scripts obrigatórios — caminho correto (assets/js)
+        if 'assets/js/cv-texts.js' not in content:
+            self.log_error(f"Script obrigatório 'assets/js/cv-texts.js' não referenciado em {name}")
+        if re.search(r'src="\.\./\.\./cv-texts\.js"', content):
+            self.log_error(f"{name} referencia cv-texts.js na raiz (deve ser assets/js/cv-texts.js)")
+        if 'dynamic-favicon.js' not in content:
+            self.log_error(f"Script obrigatório 'dynamic-favicon.js' não encontrado em {name}")
+
+        # Inicialização: initializeContent() NÃO existe no cv-texts.js
+        if re.search(r'\binitializeContent\s*\(', content):
+            self.log_error(f"{name} chama initializeContent(), função inexistente "
+                           f"(use initializeBasicContent/renderSkills/render*)")
+        if not any(marker in content for marker in VALID_INIT_MARKERS):
+            self.log_error(f"{name} não usa nenhuma função de inicialização do cv-texts.js "
+                           f"({', '.join(VALID_INIT_MARKERS)})")
+
+        # Botão de impressão: deve apontar para o cv_style do MESMO idioma e existir
+        style_refs = set(re.findall(r'cv_styles/(cv_[\w.-]+_style(?:_EN|_PT)?\.html)', content))
+        expected_style = f'cv_{company}_style_{lang_suffix}.html'
+        if not style_refs:
+            self.log_error(f"{name} não referencia nenhum estilo de impressão (cv_styles)")
+        else:
+            for ref in style_refs:
+                if not (self.cv_styles_dir / ref).exists():
+                    self.log_error(f"{name} referencia estilo inexistente: {ref}")
+                if ref != expected_style:
+                    self.log_error(f"{name} imprime {ref} (esperado {expected_style})")
+
+        # DOCTYPE e idioma
+        if '<!DOCTYPE html>' not in content:
+            self.log_error(f"DOCTYPE ausente em {name}")
+        if name.endswith('_pt'):
+            if 'lang="pt-BR"' not in content:
+                self.log_warning(f"Idioma PT-BR não definido em {name}")
+        elif 'lang="en"' not in content:
+            self.log_warning(f"Idioma EN não definido em {name}")
+
+        # Caminhos absolutos quebram no subpath do GitHub Pages
+        for match in re.findall(r'(?:src|href)="(/[^"]+)"', content):
+            self.log_error(f"{name} usa caminho absoluto '{match}' (quebra no GitHub Pages)")
+
+    # ------------------------------------------------------------------
     def validate_cv_styles(self):
         """Valida arquivos cv_styles"""
         print("🔍 Validando cv_styles...")
-        
-        cv_style_files = list((self.project_root / 'cv_styles').glob('*.html'))
-        template_files = list((self.project_root / 'templates/companies').glob('*.html'))
-        
-        # Para cada template, deve existir um cv_style correspondente
-        for template_file in template_files:
-            template_name = template_file.stem
-            
-            if template_name.endswith('_pt'):
-                expected_cv_style = f"cv_{template_name[:-3]}_style_PT.html"
+
+        cv_style_files = sorted(self.cv_styles_dir.glob('*.html'))
+
+        for template_file in self.templates_dir.glob('*.html'):
+            name = template_file.stem
+            if name.endswith('_pt'):
+                expected = f"cv_{name[:-3]}_style_PT.html"
             else:
-                expected_cv_style = f"cv_{template_name}_style_EN.html"
-                
-            cv_style_path = self.project_root / 'cv_styles' / expected_cv_style
-            
-            if not cv_style_path.exists():
-                self.log_warning(f"cv_style não encontrado para {template_name}: {expected_cv_style}")
-                
+                expected = f"cv_{name}_style_EN.html"
+            if not (self.cv_styles_dir / expected).exists():
+                self.log_error(f"cv_style não encontrado para {name}: {expected}")
+
+        # Stubs: arquivos suspeitosamente pequenos não são um CV imprimível
+        for f in cv_style_files:
+            if f.stat().st_size < STUB_SIZE_BYTES:
+                self.log_warning(f"cv_styles/{f.name} tem só {f.stat().st_size} bytes — possível stub")
+
         self.log_info(f"Total de cv_styles encontrados: {len(cv_style_files)}")
 
+    # ------------------------------------------------------------------
+    def validate_local_references(self):
+        """Todo src= local deve resolver para um arquivo existente"""
+        print("🔍 Validando referências locais (src=)...")
+
+        pages = (list(self.templates_dir.glob('*.html'))
+                 + list(self.cv_styles_dir.glob('*.html'))
+                 + [self.project_root / 'index.html'])
+        checked = 0
+        for page in pages:
+            if not page.exists():
+                continue
+            content = page.read_text(encoding='utf-8', errors='replace')
+            for src in re.findall(r'src="([^"]+)"', content):
+                if src.startswith(('http', 'data:', '//')) or len(src) > 200:
+                    continue
+                checked += 1
+                target = (page.parent / src).resolve()
+                if not target.exists():
+                    rel = page.relative_to(self.project_root)
+                    self.log_error(f"Referência quebrada em {rel}: {src}")
+        self.log_info(f"Referências locais src= verificadas: {checked}")
+
+    # ------------------------------------------------------------------
+    def validate_css_variables(self):
+        """Variáveis CSS de uma empresa não podem aparecer no template de outra"""
+        print("🔍 Validando variáveis CSS entre marcas...")
+
+        companies = getattr(self, 'companies', set())
+        for template_file in self.templates_dir.glob('*.html'):
+            name = template_file.stem
+            company = name[:-3] if name.endswith('_pt') else name
+            if company == 'general':
+                continue
+            content = template_file.read_text(encoding='utf-8', errors='replace')
+            declared = set(re.findall(r'--([a-z0-9_-]+?)-[a-z-]+\s*:', content))
+            for other in companies - {company, 'general'}:
+                if other in declared:
+                    self.log_warning(f"{name} define variáveis CSS da marca '{other}'")
+
+    # ------------------------------------------------------------------
     def validate_assets(self):
-        """Valida assets (JS, CSS, imagens)"""
+        """Valida assets (JS obrigatórios)"""
         print("🔍 Validando assets...")
-        
-        # Verificar arquivos JS obrigatórios
         required_js = [
             'assets/js/cv-texts.js',
             'assets/js/dynamic-favicon.js',
-            'assets/js/brands-config.js'
+            'assets/js/brands-config.js',
         ]
-        
         for js_file in required_js:
-            full_path = self.project_root / js_file
-            if not full_path.exists():
+            if not (self.project_root / js_file).exists():
                 self.log_error(f"Arquivo JS obrigatório não encontrado: {js_file}")
             else:
                 self.log_info(f"JS OK: {js_file}")
 
+    # ------------------------------------------------------------------
     def validate_brands_config(self):
-        """Valida brands-config.js"""
+        """Valida brands-config.js (logos consumidos a partir de templates/companies/)"""
         print("🔍 Validando brands-config.js...")
-        
+
         brands_config_path = self.project_root / 'assets/js/brands-config.js'
-        
         if not brands_config_path.exists():
             self.log_error("brands-config.js não encontrado")
             return
-            
-        try:
-            with open(brands_config_path, 'r', encoding='utf-8') as f:
-                content = f.read()
-                
-            # Verificar se há referências a logos inexistentes
-            logo_references = re.findall(r"logo: ['\"]([^'\"]+)['\"]", content)
-            
-            for logo_ref in logo_references:
-                if logo_ref and logo_ref != 'null':
-                    # Converter path relativo para absoluto
-                    logo_path = self.project_root / logo_ref.replace('../', '')
-                    if not logo_path.exists():
-                        self.log_warning(f"Logo referenciado mas não encontrado: {logo_ref}")
-                        
-        except Exception as e:
-            self.log_error(f"Erro ao validar brands-config.js: {str(e)}")
 
+        content = brands_config_path.read_text(encoding='utf-8')
+        for logo_ref in re.findall(r"logo: ['\"]([^'\"]+)['\"]", content):
+            if not logo_ref or logo_ref == 'null':
+                continue
+            # Consumidores vivem em templates/companies/ → prefixo correto é ../../
+            resolved = (self.templates_dir / logo_ref).resolve()
+            if not resolved.exists():
+                self.log_warning(f"Logo do brands-config.js não resolve a partir de "
+                                 f"templates/companies/: {logo_ref}")
+
+    # ------------------------------------------------------------------
     def check_documentation(self):
         """Verifica documentação"""
         print("🔍 Validando documentação...")
-        
-        required_docs = [
-            'README.md',
-            'REGRAS_PROJETO.md',
-            'DIAGRAMA_COMPONENTES.md'
-        ]
-        
+        required_docs = ['README.md', 'REGRAS_PROJETO.md', 'TEMPLATE_PADRAO.md', 'CLAUDE.md']
         for doc in required_docs:
-            doc_path = self.project_root / doc
-            if not doc_path.exists():
+            if not (self.project_root / doc).exists():
                 self.log_error(f"Documentação obrigatória não encontrada: {doc}")
             else:
                 self.log_info(f"Documentação OK: {doc}")
 
+    # ------------------------------------------------------------------
     def generate_report(self):
-        """Gera relatório final"""
-        print("\n" + "="*60)
+        print("\n" + "=" * 60)
         print("📊 RELATÓRIO DE VALIDAÇÃO")
-        print("="*60)
+        print("=" * 60)
         print(f"⏰ Data/Hora: {datetime.now().strftime('%d/%m/%Y %H:%M:%S')}")
         print(f"📁 Projeto: {self.project_root}")
         print()
-        
-        # Estatísticas
+
         total_issues = len(self.errors) + len(self.warnings)
-        print(f"📊 ESTATÍSTICAS:")
+        print("📊 ESTATÍSTICAS:")
         print(f"   ❌ Erros: {len(self.errors)}")
         print(f"   ⚠️  Avisos: {len(self.warnings)}")
         print(f"   ℹ️  Informações: {len(self.info)}")
         print(f"   📋 Total de problemas: {total_issues}")
         print()
-        
-        # Exibir problemas
+
         if self.errors:
             print("❌ ERROS CRÍTICOS:")
             for error in self.errors:
                 print(f"   {error}")
             print()
-            
         if self.warnings:
             print("⚠️  AVISOS:")
             for warning in self.warnings:
                 print(f"   {warning}")
             print()
-            
         if self.info:
             print("ℹ️  INFORMAÇÕES:")
             for info in self.info:
                 print(f"   {info}")
             print()
-        
-        # Status final
+
         if self.errors:
             print("🚨 STATUS: FALHA - Erros críticos encontrados!")
             print("   ➡️  Corrija os erros antes de fazer commit")
             return False
-        elif self.warnings:
+        if self.warnings:
             print("⚠️  STATUS: ATENÇÃO - Avisos encontrados")
             print("   ➡️  Revise os avisos, mas pode prosseguir")
             return True
-        else:
-            print("✅ STATUS: SUCESSO - Projeto conforme as regras!")
-            print("   ➡️  Pode fazer commit com segurança")
-            return True
+        print("✅ STATUS: SUCESSO - Projeto conforme as regras!")
+        print("   ➡️  Pode fazer commit com segurança")
+        return True
 
     def run_validation(self):
-        """Executa todas as validações"""
         print("🛡️  VALIDADOR DO PROJETO PEDRO MARCONATO CV")
-        print("="*50)
-        
+        print("=" * 50)
         self.validate_file_structure()
         self.validate_templates()
         self.validate_cv_styles()
+        self.validate_local_references()
+        self.validate_css_variables()
         self.validate_assets()
         self.validate_brands_config()
         self.check_documentation()
-        
         return self.generate_report()
 
+
 def main():
-    """Função principal"""
     validator = ProjectValidator()
     success = validator.run_validation()
-    
-    # Exit code para scripts automatizados
     exit(0 if success else 1)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Validador reescrito

O `validate-project.py` agora pega as classes de bug encontradas em toda esta revisão (nenhuma era detectada antes):

- **Alvo do botão de impressão** deve existir e ser do mesmo idioma da página (pegaria heineken EN imprimindo PT e sicredi_pt imprimindo EN)
- **`initializeContent()` é erro** — função inexistente que falha silenciosamente (pegaria o gerador quebrado)
- Todo template deve usar um entry point real do cv-texts.js e carregá-lo de `assets/js`
- **Toda referência local `src=` deve resolver** (pegaria os `../../assets/` dos cv_styles e o favicon 404 do meutudo)
- Caminhos absolutos `/assets/...` são erro (quebram no GitHub Pages)
- Nomenclatura legada `cv_X_style.html` e cópias soltas do cv-texts.js são erro
- cv_styles com menos de 5KB são flagados como prováveis stubs (pegaria os 15 stubs `_PT`)
- Checagem de variáveis CSS por empresa substitui os regex fixos que flagavam as variáveis do próprio Sicredi no template do Sicredi
- Docs obrigatórios atualizados (TEMPLATE_PADRAO.md e CLAUDE.md no lugar do DIAGRAMA_COMPONENTES.md que nunca existiu)

## Correções de conteúdo

- **brands-config.js**: os 10 campos `logo:` apontavam para arquivos inexistentes (`X_logo.svg`) ou com prefixo que resolve fora do repo; agora apontam para as imagens reais (rdstation não tem logo → `null`)
- **Perfil vazio do completebari (bug real)**: a seção de perfil renderizava **vazia** nos dois idiomas porque nada preenchia `cv-profile-text`. completebari, meutudo e rdstation agora usam o `id="cv-profile"` padrão, preenchido pelo `initializeBasicContent` a partir do cv-texts.js central

## Resultado

`python validate-project.py` → **0 erros, 0 avisos** ✅
Smoke test headless: perfil renderizando nos 6 arquivos alterados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)