### PR TITLE
Corrigir PDF/impressão das 4 marcas novas (conteúdo genérico → identidade da marca)

### DIFF
--- a/cv_styles/cv_grupo-rbs_style_EN.html
+++ b/cv_styles/cv_grupo-rbs_style_EN.html
@@ -5,93 +5,467 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pedro Henrique Marconato - CV</title>
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@400;500;600;700&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,600;0,8..60,700;1,8..60,400&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&display=swap');
 
         :root {
-            /* Grupo RBS Colors */
-            --primary-color: #003563;
-            --secondary-color: #0A5394;
-            --accent-color: #D64545;
-            --text-color: #2c3e50;
-            --border-color: rgba(0, 0, 0, 0.15);
+            /* Grupo RBS — institutional navy + derived editorial palette (brandbook) */
+            --rbs-navy: #003563;
+            --rbs-navy-deep: #00294D;
+            --rbs-blue: #0A5394;
+            --rbs-sky: #2E77B8;
+            --rbs-ice: #EAF2F9;
+            --rbs-red: #D64545;
+            --rbs-ink: #16283C;
+
+            --primary-color: var(--rbs-navy);
+            --secondary-color: var(--rbs-blue);
+            --accent-color: var(--rbs-red);
+            --text-color: var(--rbs-ink);
+            --border-color: rgba(0, 53, 99, 0.18);
+            --background-gradient: linear-gradient(150deg, var(--rbs-navy-deep) 0%, var(--rbs-navy) 55%, var(--rbs-blue) 100%);
+
+            --font-body: 'Source Sans 3', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            --font-serif: 'Source Serif 4', Georgia, 'Times New Roman', serif;
+            --font-mono: 'IBM Plex Mono', 'SF Mono', Menlo, monospace;
         }
 
         * { margin: 0; padding: 0; box-sizing: border-box; }
 
         body {
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            font-family: var(--font-body);
             color: var(--text-color);
             line-height: 1.5;
-            background: white;
+            background: #e7edf3;
             font-size: 12px;
+            -webkit-print-color-adjust: exact;
+            print-color-adjust: exact;
         }
 
-        .cv-container { max-width: 210mm; margin: 0 auto; padding: 14mm; background: white; }
+        .cv-container {
+            max-width: 210mm;
+            margin: 14px auto;
+            background: #ffffff;
+            box-shadow: 0 4px 24px rgba(0, 53, 99, 0.14);
+            border-radius: 4px;
+            overflow: hidden;
+        }
 
-        .header { border-bottom: 3px solid var(--primary-color); padding-bottom: 12px; margin-bottom: 16px; }
-        .header h1 { font-size: 22px; color: var(--primary-color); }
-        .header h2 { font-size: 13px; font-weight: 500; margin-bottom: 6px; }
-        .contact-info { font-size: 11px; }
-        .contact-info a { color: var(--text-color); text-decoration: none; }
+        /* ===== Header — navy masthead ===== */
+        .header {
+            background: var(--background-gradient);
+            color: #ffffff;
+            padding: 28px 40px 32px;
+            text-align: center;
+            position: relative;
+        }
 
-        .section { margin-bottom: 14px; }
-        .section-title {
-            font-size: 14px;
+        .brand-logo {
+            width: 150px;
+            margin: 0 auto 14px;
+        }
+
+        .brand-logo img {
+            width: 100%;
+            height: auto;
+            display: block;
+            margin: 0 auto;
+            filter: brightness(0) invert(1);
+        }
+
+        #cv-name {
+            font-family: var(--font-serif);
+            font-size: 25px;
             font-weight: 700;
-            color: var(--primary-color);
-            border-bottom: 1px solid var(--border-color);
-            padding-bottom: 3px;
-            margin-bottom: 8px;
-            text-transform: uppercase;
-        }
-
-        .skills-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 14px; }
-        .tool-item { margin-bottom: 6px; }
-        .tool-name { display: flex; justify-content: space-between; font-weight: 500; font-size: 11px; }
-        .tool-percentage { color: var(--accent-color); font-size: 10px; font-weight: 600; }
-        .dots-container { display: flex; gap: 2px; margin-top: 2px; }
-        .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--border-color); }
-        .dot.filled { background: var(--primary-color); }
-
-        .experience-item {
-            padding: 8px 0 8px 14px;
-            border-left: 2px solid var(--primary-color);
+            letter-spacing: -0.3px;
+            display: inline-block;
+            position: relative;
+            padding-bottom: 10px;
             margin-bottom: 10px;
-            page-break-inside: avoid;
         }
-        .job-title { font-size: 13px; font-weight: 700; color: var(--primary-color); }
-        .job-number { display: none; }
-        .experience-item .company { font-weight: 600; font-size: 12px; }
-        .experience-item .period { font-size: 11px; color: var(--accent-color); margin-bottom: 4px; }
-        .job-description { font-size: 11px; margin-bottom: 6px; }
-        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
-        .achievement-item { display: flex; gap: 6px; font-size: 10.5px; }
-        .achievement-icon { color: var(--primary-color); padding-top: 1px; }
-        .achievement-title { font-weight: 600; }
+
+        #cv-name::after {
+            content: '';
+            position: absolute;
+            bottom: 0;
+            left: 50%;
+            transform: translateX(-50%);
+            width: 64px;
+            height: 3px;
+            border-radius: 2px;
+            background: linear-gradient(90deg, var(--rbs-sky), var(--rbs-red));
+        }
+
+        #cv-role {
+            font-family: var(--font-serif);
+            font-style: italic;
+            font-weight: 400;
+            font-size: 13px;
+            color: rgba(255, 255, 255, 0.92);
+            margin-bottom: 16px;
+        }
+
+        .contact-info {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            gap: 8px;
+        }
+
+        .contact-pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 5px;
+            background: rgba(255, 255, 255, 0.14);
+            border: 1px solid rgba(255, 255, 255, 0.28);
+            border-radius: 20px;
+            padding: 4px 11px;
+            font-size: 10px;
+        }
+
+        .contact-pill i { font-size: 9.5px; color: #9CC4E8; }
+        .contact-pill a { color: #ffffff; text-decoration: none; }
+
+        /* ===== Sections ===== */
+        .section { padding: 14px 34px; }
+        .section:not(:last-of-type) { border-bottom: 1px solid var(--border-color); }
+
+        .section-title {
+            display: inline-block;
+            font-family: var(--font-serif);
+            font-size: 12.5px;
+            font-weight: 700;
+            letter-spacing: 0.4px;
+            text-transform: uppercase;
+            color: #ffffff;
+            background: var(--rbs-navy);
+            border-left: 4px solid var(--rbs-red);
+            border-radius: 3px 10px 10px 3px;
+            padding: 5px 14px 5px 12px;
+            margin-bottom: 10px;
+        }
+
+        #cv-profile {
+            font-size: 11px;
+            line-height: 1.65;
+            text-align: justify;
+        }
+
+        /* ===== Skills ===== */
+        .skills-grid {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 12px;
+        }
+
+        .skills-column {
+            background: linear-gradient(165deg, var(--rbs-ice), rgba(234, 242, 249, 0.35));
+            border: 1px solid var(--border-color);
+            border-top: 3px solid var(--rbs-navy);
+            border-radius: 6px;
+            padding: 10px 12px;
+        }
+
+        .skills-column:nth-child(2) { border-top-color: var(--rbs-blue); }
+        .skills-column:nth-child(3) { border-top-color: var(--rbs-sky); }
+
+        .skills-column h3 {
+            font-family: var(--font-serif) !important;
+            font-size: 11.5px !important;
+            font-weight: 700 !important;
+            color: var(--rbs-navy) !important;
+            text-transform: uppercase;
+            letter-spacing: 0.3px;
+            padding-bottom: 4px;
+            margin-bottom: 8px !important;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .tool-item { margin-bottom: 7px; }
+
+        .tool-name {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 6px;
+            font-weight: 600;
+            font-size: 10px;
+            margin-bottom: 3px;
+        }
+
+        .tool-percentage {
+            font-family: var(--font-mono);
+            font-size: 7.5px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.4px;
+            color: var(--rbs-blue);
+            background: rgba(10, 83, 148, 0.08);
+            border: 1px solid rgba(10, 83, 148, 0.22);
+            padding: 1px 6px;
+            border-radius: 3px;
+            white-space: nowrap;
+        }
+
+        .dots-container { display: flex; gap: 3px; }
+        .dot { width: 5px; height: 5px; border-radius: 50%; background: rgba(0, 53, 99, 0.16); }
+        .dot.filled { background: var(--rbs-navy); }
+
+        /* Tooltip does not work on paper */
         .tooltip { display: none; }
 
-        .education-item { margin-bottom: 8px; page-break-inside: avoid; }
-        .degree { font-weight: 700; color: var(--primary-color); font-size: 12px; }
-        .university { font-size: 11px; }
-        .thesis { font-size: 10.5px; }
-        .cta-button { display: none; }
-
-        .project-item { margin-bottom: 8px; page-break-inside: avoid; }
-        .project-title { font-weight: 700; color: var(--primary-color); font-size: 12px; }
-        .project-description { font-size: 11px; }
-        .tech-tag {
-            display: inline-block;
-            padding: 1px 7px;
-            margin: 2px 3px 0 0;
-            border: 1px solid var(--primary-color);
-            color: var(--primary-color);
-            border-radius: 8px;
-            font-size: 9.5px;
+        /* ===== Experience ===== */
+        .experience-item {
+            position: relative;
+            margin-bottom: 12px;
+            padding: 11px 14px 11px 16px;
+            background: linear-gradient(155deg, #ffffff, rgba(234, 242, 249, 0.5));
+            border: 1px solid var(--border-color);
+            border-left: 3px solid var(--rbs-navy);
+            border-radius: 5px;
+            page-break-inside: avoid;
         }
 
+        .job-title {
+            display: flex;
+            align-items: center;
+            gap: 7px;
+            font-family: var(--font-serif);
+            font-weight: 700;
+            font-size: 12.5px;
+            color: var(--rbs-navy);
+            margin-bottom: 4px;
+        }
+
+        .job-number {
+            display: inline-flex;
+            align-items: center;
+            background: var(--rbs-navy);
+            color: #ffffff;
+            font-family: var(--font-mono);
+            font-size: 8.5px;
+            font-weight: 600;
+            padding: 2px 6px;
+            border-radius: 3px;
+            flex-shrink: 0;
+        }
+
+        .job-number::before {
+            content: 'ED. ';
+            font-size: 7px;
+            opacity: 0.75;
+        }
+
+        .company {
+            font-weight: 600;
+            font-size: 10.5px;
+            color: var(--rbs-blue);
+            margin-bottom: 2px;
+        }
+
+        .period {
+            display: inline-block;
+            font-family: var(--font-mono);
+            font-size: 8.5px;
+            color: #51667E;
+            background: rgba(0, 53, 99, 0.06);
+            border: 1px solid rgba(0, 53, 99, 0.16);
+            padding: 2px 8px;
+            border-radius: 3px;
+            margin-bottom: 7px;
+        }
+
+        .job-description {
+            font-size: 10px;
+            line-height: 1.5;
+            margin-bottom: 7px;
+        }
+
+        .achievements-container {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 6px;
+        }
+
+        .achievement-item {
+            display: flex;
+            gap: 6px;
+            background: rgba(0, 53, 99, 0.045);
+            border: 1px solid rgba(0, 53, 99, 0.13);
+            border-radius: 5px;
+            padding: 6px 8px;
+        }
+
+        .achievement-icon {
+            color: var(--rbs-blue);
+            font-size: 10.5px;
+            padding-top: 1px;
+            flex-shrink: 0;
+        }
+
+        .achievement-content { flex: 1; }
+
+        .achievement-title {
+            font-weight: 600;
+            font-size: 9px;
+            color: var(--rbs-navy);
+            margin-bottom: 2px;
+        }
+
+        .achievement-description {
+            font-size: 8.5px;
+            line-height: 1.4;
+            color: var(--text-color);
+        }
+
+        /* ===== Education ===== */
+        #education-container {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 10px;
+        }
+
+        .education-item {
+            background: linear-gradient(165deg, rgba(234, 242, 249, 0.9), rgba(234, 242, 249, 0.35));
+            border: 1px solid var(--border-color);
+            border-left: 3px solid var(--rbs-blue);
+            border-radius: 5px;
+            padding: 10px 12px;
+            page-break-inside: avoid;
+        }
+
+        .degree {
+            font-family: var(--font-serif);
+            font-weight: 700;
+            font-size: 11px;
+            color: var(--rbs-navy);
+            margin-bottom: 3px;
+        }
+
+        .university { font-size: 9.5px; margin-bottom: 3px; }
+        .thesis { font-size: 9px; font-style: italic; color: #51667E; }
+
+        .cta-button {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            margin-top: 5px;
+            padding: 2px 7px;
+            background: var(--rbs-navy);
+            color: #ffffff;
+            border-radius: 3px;
+            text-decoration: none;
+            font-size: 8px;
+        }
+
+        /* ===== Projects ===== */
+        #projects-container {
+            display: grid;
+            grid-template-columns: 1fr 1fr 1fr;
+            gap: 10px;
+        }
+
+        .project-item {
+            position: relative;
+            background: #ffffff;
+            border: 1px solid var(--border-color);
+            border-radius: 5px;
+            padding: 10px 12px;
+            overflow: hidden;
+            page-break-inside: avoid;
+        }
+
+        .project-item::before {
+            content: '';
+            position: absolute;
+            top: 0; left: 0; right: 0;
+            height: 2.5px;
+            background: linear-gradient(90deg, var(--rbs-navy), var(--rbs-blue), var(--rbs-sky));
+        }
+
+        .project-title {
+            font-family: var(--font-serif);
+            font-weight: 700;
+            font-size: 10.5px;
+            color: var(--rbs-navy);
+            margin-top: 4px;
+            margin-bottom: 4px;
+        }
+
+        .project-description {
+            font-size: 9px;
+            line-height: 1.4;
+            margin-bottom: 6px;
+        }
+
+        .tech-tag {
+            display: inline-block;
+            font-family: var(--font-mono);
+            font-size: 7.5px;
+            padding: 2px 6px;
+            margin: 0 4px 4px 0;
+            background: rgba(0, 53, 99, 0.06);
+            color: var(--rbs-blue);
+            border: 1px solid rgba(0, 53, 99, 0.18);
+            border-radius: 3px;
+        }
+
+        /* ===== Print ===== */
         @media print {
-            body { margin: 0; padding: 0; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-            .cv-container { margin: 0; padding: 10mm; max-width: none; }
+            body {
+                margin: 0;
+                padding: 0;
+                background: #ffffff;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+            }
+
+            .cv-container { max-width: none; margin: 0; box-shadow: none; border-radius: 0; }
+
+            .header {
+                background: var(--background-gradient) !important;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+                padding: 16px 30px 20px !important;
+            }
+
+            #cv-name { font-size: 20px !important; padding-bottom: 8px !important; }
+            #cv-role { font-size: 11px !important; margin-bottom: 10px !important; }
+            .contact-pill { font-size: 8.5px !important; padding: 3px 9px !important; }
+
+            .section-title {
+                background: var(--rbs-navy) !important;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+                font-size: 10.5px !important;
+                padding: 4px 11px 4px 10px !important;
+                margin-bottom: 8px !important;
+            }
+
+            .section { padding: 9px 26px !important; }
+            #cv-profile { font-size: 9.5px !important; }
+
+            .skills-column { padding: 8px 10px !important; }
+            .skills-column h3 { font-size: 10px !important; margin-bottom: 6px !important; }
+            .tool-item { margin-bottom: 5px !important; }
+
+            .experience-item, .education-item, .project-item {
+                page-break-inside: avoid;
+                margin-bottom: 8px !important;
+            }
+
+            .job-title { font-size: 11px !important; }
+            .company { font-size: 9.5px !important; }
+            .job-description { font-size: 9px !important; }
+            .achievement-title { font-size: 8.5px !important; }
+            .achievement-description { font-size: 8px !important; }
+            .degree { font-size: 10px !important; }
+            .project-title { font-size: 10px !important; }
+
+            * { animation: none !important; transition: none !important; }
+
+            @page { size: A4; margin: 8mm; }
         }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
@@ -99,13 +473,17 @@
 <body>
     <div class="cv-container">
         <header class="header">
+            <div class="brand-logo">
+                <img src="../assets/images/grupo-rbs.png" alt="Grupo RBS">
+            </div>
             <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
             <h2 id="cv-role">CRM Management and Data Intelligence</h2>
             <div class="contact-info">
-                <span id="cv-email">pedrohmarconato@gmail.com</span> |
-                <span id="cv-phone">+55 (55) 981147758</span> |
-                <span id="cv-location"><span>Cachoeira do Sul, RS</span></span> |
-                <a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin">LinkedIn</a>
+                <span class="contact-pill"><i class="fas fa-envelope"></i><span id="cv-email">pedrohmarconato@gmail.com</span></span>
+                <span class="contact-pill"><i class="fas fa-phone"></i><span id="cv-phone">+55 (55) 981147758</span></span>
+                <span class="contact-pill"><i class="fas fa-map-marker-alt"></i><span id="cv-location"><span>Cachoeira do Sul, RS</span></span></span>
+                <span class="contact-pill"><i class="fab fa-linkedin"></i><a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin">LinkedIn</a></span>
+                <span class="contact-pill"><i class="fab fa-github"></i><a href="https://github.com/pedrohmarconato" id="cv-repository">Repository</a></span>
             </div>
         </header>
 
@@ -117,9 +495,9 @@
         <section class="section">
             <h2 class="section-title" id="section-skills">Skills & Tools</h2>
             <div class="skills-grid">
-                <div id="skills-strategic"></div>
-                <div id="skills-tools"></div>
-                <div id="skills-emerging"></div>
+                <div class="skills-column" id="skills-strategic"></div>
+                <div class="skills-column" id="skills-tools"></div>
+                <div class="skills-column" id="skills-emerging"></div>
             </div>
         </section>
 

--- a/cv_styles/cv_grupo-rbs_style_PT.html
+++ b/cv_styles/cv_grupo-rbs_style_PT.html
@@ -5,93 +5,467 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pedro Henrique Marconato - CV</title>
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@400;500;600;700&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,600;0,8..60,700;1,8..60,400&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&display=swap');
 
         :root {
-            /* Grupo RBS Colors */
-            --primary-color: #003563;
-            --secondary-color: #0A5394;
-            --accent-color: #D64545;
-            --text-color: #2c3e50;
-            --border-color: rgba(0, 0, 0, 0.15);
+            /* Grupo RBS — navy institucional + paleta editorial derivada (brandbook) */
+            --rbs-navy: #003563;
+            --rbs-navy-deep: #00294D;
+            --rbs-blue: #0A5394;
+            --rbs-sky: #2E77B8;
+            --rbs-ice: #EAF2F9;
+            --rbs-red: #D64545;
+            --rbs-ink: #16283C;
+
+            --primary-color: var(--rbs-navy);
+            --secondary-color: var(--rbs-blue);
+            --accent-color: var(--rbs-red);
+            --text-color: var(--rbs-ink);
+            --border-color: rgba(0, 53, 99, 0.18);
+            --background-gradient: linear-gradient(150deg, var(--rbs-navy-deep) 0%, var(--rbs-navy) 55%, var(--rbs-blue) 100%);
+
+            --font-body: 'Source Sans 3', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            --font-serif: 'Source Serif 4', Georgia, 'Times New Roman', serif;
+            --font-mono: 'IBM Plex Mono', 'SF Mono', Menlo, monospace;
         }
 
         * { margin: 0; padding: 0; box-sizing: border-box; }
 
         body {
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            font-family: var(--font-body);
             color: var(--text-color);
             line-height: 1.5;
-            background: white;
+            background: #e7edf3;
             font-size: 12px;
+            -webkit-print-color-adjust: exact;
+            print-color-adjust: exact;
         }
 
-        .cv-container { max-width: 210mm; margin: 0 auto; padding: 14mm; background: white; }
+        .cv-container {
+            max-width: 210mm;
+            margin: 14px auto;
+            background: #ffffff;
+            box-shadow: 0 4px 24px rgba(0, 53, 99, 0.14);
+            border-radius: 4px;
+            overflow: hidden;
+        }
 
-        .header { border-bottom: 3px solid var(--primary-color); padding-bottom: 12px; margin-bottom: 16px; }
-        .header h1 { font-size: 22px; color: var(--primary-color); }
-        .header h2 { font-size: 13px; font-weight: 500; margin-bottom: 6px; }
-        .contact-info { font-size: 11px; }
-        .contact-info a { color: var(--text-color); text-decoration: none; }
+        /* ===== Header — masthead navy ===== */
+        .header {
+            background: var(--background-gradient);
+            color: #ffffff;
+            padding: 28px 40px 32px;
+            text-align: center;
+            position: relative;
+        }
 
-        .section { margin-bottom: 14px; }
-        .section-title {
-            font-size: 14px;
+        .brand-logo {
+            width: 150px;
+            margin: 0 auto 14px;
+        }
+
+        .brand-logo img {
+            width: 100%;
+            height: auto;
+            display: block;
+            margin: 0 auto;
+            filter: brightness(0) invert(1);
+        }
+
+        #cv-name {
+            font-family: var(--font-serif);
+            font-size: 25px;
             font-weight: 700;
-            color: var(--primary-color);
-            border-bottom: 1px solid var(--border-color);
-            padding-bottom: 3px;
-            margin-bottom: 8px;
-            text-transform: uppercase;
-        }
-
-        .skills-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 14px; }
-        .tool-item { margin-bottom: 6px; }
-        .tool-name { display: flex; justify-content: space-between; font-weight: 500; font-size: 11px; }
-        .tool-percentage { color: var(--accent-color); font-size: 10px; font-weight: 600; }
-        .dots-container { display: flex; gap: 2px; margin-top: 2px; }
-        .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--border-color); }
-        .dot.filled { background: var(--primary-color); }
-
-        .experience-item {
-            padding: 8px 0 8px 14px;
-            border-left: 2px solid var(--primary-color);
+            letter-spacing: -0.3px;
+            display: inline-block;
+            position: relative;
+            padding-bottom: 10px;
             margin-bottom: 10px;
-            page-break-inside: avoid;
         }
-        .job-title { font-size: 13px; font-weight: 700; color: var(--primary-color); }
-        .job-number { display: none; }
-        .experience-item .company { font-weight: 600; font-size: 12px; }
-        .experience-item .period { font-size: 11px; color: var(--accent-color); margin-bottom: 4px; }
-        .job-description { font-size: 11px; margin-bottom: 6px; }
-        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
-        .achievement-item { display: flex; gap: 6px; font-size: 10.5px; }
-        .achievement-icon { color: var(--primary-color); padding-top: 1px; }
-        .achievement-title { font-weight: 600; }
+
+        #cv-name::after {
+            content: '';
+            position: absolute;
+            bottom: 0;
+            left: 50%;
+            transform: translateX(-50%);
+            width: 64px;
+            height: 3px;
+            border-radius: 2px;
+            background: linear-gradient(90deg, var(--rbs-sky), var(--rbs-red));
+        }
+
+        #cv-role {
+            font-family: var(--font-serif);
+            font-style: italic;
+            font-weight: 400;
+            font-size: 13px;
+            color: rgba(255, 255, 255, 0.92);
+            margin-bottom: 16px;
+        }
+
+        .contact-info {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            gap: 8px;
+        }
+
+        .contact-pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 5px;
+            background: rgba(255, 255, 255, 0.14);
+            border: 1px solid rgba(255, 255, 255, 0.28);
+            border-radius: 20px;
+            padding: 4px 11px;
+            font-size: 10px;
+        }
+
+        .contact-pill i { font-size: 9.5px; color: #9CC4E8; }
+        .contact-pill a { color: #ffffff; text-decoration: none; }
+
+        /* ===== Sections ===== */
+        .section { padding: 14px 34px; }
+        .section:not(:last-of-type) { border-bottom: 1px solid var(--border-color); }
+
+        .section-title {
+            display: inline-block;
+            font-family: var(--font-serif);
+            font-size: 12.5px;
+            font-weight: 700;
+            letter-spacing: 0.4px;
+            text-transform: uppercase;
+            color: #ffffff;
+            background: var(--rbs-navy);
+            border-left: 4px solid var(--rbs-red);
+            border-radius: 3px 10px 10px 3px;
+            padding: 5px 14px 5px 12px;
+            margin-bottom: 10px;
+        }
+
+        #cv-profile {
+            font-size: 11px;
+            line-height: 1.65;
+            text-align: justify;
+        }
+
+        /* ===== Skills ===== */
+        .skills-grid {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 12px;
+        }
+
+        .skills-column {
+            background: linear-gradient(165deg, var(--rbs-ice), rgba(234, 242, 249, 0.35));
+            border: 1px solid var(--border-color);
+            border-top: 3px solid var(--rbs-navy);
+            border-radius: 6px;
+            padding: 10px 12px;
+        }
+
+        .skills-column:nth-child(2) { border-top-color: var(--rbs-blue); }
+        .skills-column:nth-child(3) { border-top-color: var(--rbs-sky); }
+
+        .skills-column h3 {
+            font-family: var(--font-serif) !important;
+            font-size: 11.5px !important;
+            font-weight: 700 !important;
+            color: var(--rbs-navy) !important;
+            text-transform: uppercase;
+            letter-spacing: 0.3px;
+            padding-bottom: 4px;
+            margin-bottom: 8px !important;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .tool-item { margin-bottom: 7px; }
+
+        .tool-name {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 6px;
+            font-weight: 600;
+            font-size: 10px;
+            margin-bottom: 3px;
+        }
+
+        .tool-percentage {
+            font-family: var(--font-mono);
+            font-size: 7.5px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.4px;
+            color: var(--rbs-blue);
+            background: rgba(10, 83, 148, 0.08);
+            border: 1px solid rgba(10, 83, 148, 0.22);
+            padding: 1px 6px;
+            border-radius: 3px;
+            white-space: nowrap;
+        }
+
+        .dots-container { display: flex; gap: 3px; }
+        .dot { width: 5px; height: 5px; border-radius: 50%; background: rgba(0, 53, 99, 0.16); }
+        .dot.filled { background: var(--rbs-navy); }
+
+        /* Tooltip não funciona no papel */
         .tooltip { display: none; }
 
-        .education-item { margin-bottom: 8px; page-break-inside: avoid; }
-        .degree { font-weight: 700; color: var(--primary-color); font-size: 12px; }
-        .university { font-size: 11px; }
-        .thesis { font-size: 10.5px; }
-        .cta-button { display: none; }
-
-        .project-item { margin-bottom: 8px; page-break-inside: avoid; }
-        .project-title { font-weight: 700; color: var(--primary-color); font-size: 12px; }
-        .project-description { font-size: 11px; }
-        .tech-tag {
-            display: inline-block;
-            padding: 1px 7px;
-            margin: 2px 3px 0 0;
-            border: 1px solid var(--primary-color);
-            color: var(--primary-color);
-            border-radius: 8px;
-            font-size: 9.5px;
+        /* ===== Experiência ===== */
+        .experience-item {
+            position: relative;
+            margin-bottom: 12px;
+            padding: 11px 14px 11px 16px;
+            background: linear-gradient(155deg, #ffffff, rgba(234, 242, 249, 0.5));
+            border: 1px solid var(--border-color);
+            border-left: 3px solid var(--rbs-navy);
+            border-radius: 5px;
+            page-break-inside: avoid;
         }
 
+        .job-title {
+            display: flex;
+            align-items: center;
+            gap: 7px;
+            font-family: var(--font-serif);
+            font-weight: 700;
+            font-size: 12.5px;
+            color: var(--rbs-navy);
+            margin-bottom: 4px;
+        }
+
+        .job-number {
+            display: inline-flex;
+            align-items: center;
+            background: var(--rbs-navy);
+            color: #ffffff;
+            font-family: var(--font-mono);
+            font-size: 8.5px;
+            font-weight: 600;
+            padding: 2px 6px;
+            border-radius: 3px;
+            flex-shrink: 0;
+        }
+
+        .job-number::before {
+            content: 'ED. ';
+            font-size: 7px;
+            opacity: 0.75;
+        }
+
+        .company {
+            font-weight: 600;
+            font-size: 10.5px;
+            color: var(--rbs-blue);
+            margin-bottom: 2px;
+        }
+
+        .period {
+            display: inline-block;
+            font-family: var(--font-mono);
+            font-size: 8.5px;
+            color: #51667E;
+            background: rgba(0, 53, 99, 0.06);
+            border: 1px solid rgba(0, 53, 99, 0.16);
+            padding: 2px 8px;
+            border-radius: 3px;
+            margin-bottom: 7px;
+        }
+
+        .job-description {
+            font-size: 10px;
+            line-height: 1.5;
+            margin-bottom: 7px;
+        }
+
+        .achievements-container {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 6px;
+        }
+
+        .achievement-item {
+            display: flex;
+            gap: 6px;
+            background: rgba(0, 53, 99, 0.045);
+            border: 1px solid rgba(0, 53, 99, 0.13);
+            border-radius: 5px;
+            padding: 6px 8px;
+        }
+
+        .achievement-icon {
+            color: var(--rbs-blue);
+            font-size: 10.5px;
+            padding-top: 1px;
+            flex-shrink: 0;
+        }
+
+        .achievement-content { flex: 1; }
+
+        .achievement-title {
+            font-weight: 600;
+            font-size: 9px;
+            color: var(--rbs-navy);
+            margin-bottom: 2px;
+        }
+
+        .achievement-description {
+            font-size: 8.5px;
+            line-height: 1.4;
+            color: var(--text-color);
+        }
+
+        /* ===== Formação ===== */
+        #education-container {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 10px;
+        }
+
+        .education-item {
+            background: linear-gradient(165deg, rgba(234, 242, 249, 0.9), rgba(234, 242, 249, 0.35));
+            border: 1px solid var(--border-color);
+            border-left: 3px solid var(--rbs-blue);
+            border-radius: 5px;
+            padding: 10px 12px;
+            page-break-inside: avoid;
+        }
+
+        .degree {
+            font-family: var(--font-serif);
+            font-weight: 700;
+            font-size: 11px;
+            color: var(--rbs-navy);
+            margin-bottom: 3px;
+        }
+
+        .university { font-size: 9.5px; margin-bottom: 3px; }
+        .thesis { font-size: 9px; font-style: italic; color: #51667E; }
+
+        .cta-button {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            margin-top: 5px;
+            padding: 2px 7px;
+            background: var(--rbs-navy);
+            color: #ffffff;
+            border-radius: 3px;
+            text-decoration: none;
+            font-size: 8px;
+        }
+
+        /* ===== Projetos ===== */
+        #projects-container {
+            display: grid;
+            grid-template-columns: 1fr 1fr 1fr;
+            gap: 10px;
+        }
+
+        .project-item {
+            position: relative;
+            background: #ffffff;
+            border: 1px solid var(--border-color);
+            border-radius: 5px;
+            padding: 10px 12px;
+            overflow: hidden;
+            page-break-inside: avoid;
+        }
+
+        .project-item::before {
+            content: '';
+            position: absolute;
+            top: 0; left: 0; right: 0;
+            height: 2.5px;
+            background: linear-gradient(90deg, var(--rbs-navy), var(--rbs-blue), var(--rbs-sky));
+        }
+
+        .project-title {
+            font-family: var(--font-serif);
+            font-weight: 700;
+            font-size: 10.5px;
+            color: var(--rbs-navy);
+            margin-top: 4px;
+            margin-bottom: 4px;
+        }
+
+        .project-description {
+            font-size: 9px;
+            line-height: 1.4;
+            margin-bottom: 6px;
+        }
+
+        .tech-tag {
+            display: inline-block;
+            font-family: var(--font-mono);
+            font-size: 7.5px;
+            padding: 2px 6px;
+            margin: 0 4px 4px 0;
+            background: rgba(0, 53, 99, 0.06);
+            color: var(--rbs-blue);
+            border: 1px solid rgba(0, 53, 99, 0.18);
+            border-radius: 3px;
+        }
+
+        /* ===== Print ===== */
         @media print {
-            body { margin: 0; padding: 0; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-            .cv-container { margin: 0; padding: 10mm; max-width: none; }
+            body {
+                margin: 0;
+                padding: 0;
+                background: #ffffff;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+            }
+
+            .cv-container { max-width: none; margin: 0; box-shadow: none; border-radius: 0; }
+
+            .header {
+                background: var(--background-gradient) !important;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+                padding: 16px 30px 20px !important;
+            }
+
+            #cv-name { font-size: 20px !important; padding-bottom: 8px !important; }
+            #cv-role { font-size: 11px !important; margin-bottom: 10px !important; }
+            .contact-pill { font-size: 8.5px !important; padding: 3px 9px !important; }
+
+            .section-title {
+                background: var(--rbs-navy) !important;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+                font-size: 10.5px !important;
+                padding: 4px 11px 4px 10px !important;
+                margin-bottom: 8px !important;
+            }
+
+            .section { padding: 9px 26px !important; }
+            #cv-profile { font-size: 9.5px !important; }
+
+            .skills-column { padding: 8px 10px !important; }
+            .skills-column h3 { font-size: 10px !important; margin-bottom: 6px !important; }
+            .tool-item { margin-bottom: 5px !important; }
+
+            .experience-item, .education-item, .project-item {
+                page-break-inside: avoid;
+                margin-bottom: 8px !important;
+            }
+
+            .job-title { font-size: 11px !important; }
+            .company { font-size: 9.5px !important; }
+            .job-description { font-size: 9px !important; }
+            .achievement-title { font-size: 8.5px !important; }
+            .achievement-description { font-size: 8px !important; }
+            .degree { font-size: 10px !important; }
+            .project-title { font-size: 10px !important; }
+
+            * { animation: none !important; transition: none !important; }
+
+            @page { size: A4; margin: 8mm; }
         }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
@@ -99,13 +473,17 @@
 <body>
     <div class="cv-container">
         <header class="header">
+            <div class="brand-logo">
+                <img src="../assets/images/grupo-rbs.png" alt="Grupo RBS">
+            </div>
             <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
             <h2 id="cv-role">Gestão de CRM e Inteligência de Dados</h2>
             <div class="contact-info">
-                <span id="cv-email">pedrohmarconato@gmail.com</span> |
-                <span id="cv-phone">+55 (55) 981147758</span> |
-                <span id="cv-location"><span>Cachoeira do Sul, RS</span></span> |
-                <a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin">LinkedIn</a>
+                <span class="contact-pill"><i class="fas fa-envelope"></i><span id="cv-email">pedrohmarconato@gmail.com</span></span>
+                <span class="contact-pill"><i class="fas fa-phone"></i><span id="cv-phone">+55 (55) 981147758</span></span>
+                <span class="contact-pill"><i class="fas fa-map-marker-alt"></i><span id="cv-location"><span>Cachoeira do Sul, RS</span></span></span>
+                <span class="contact-pill"><i class="fab fa-linkedin"></i><a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin">LinkedIn</a></span>
+                <span class="contact-pill"><i class="fab fa-github"></i><a href="https://github.com/pedrohmarconato" id="cv-repository">Repositório</a></span>
             </div>
         </header>
 
@@ -117,9 +495,9 @@
         <section class="section">
             <h2 class="section-title" id="section-skills">Habilidades e Ferramentas</h2>
             <div class="skills-grid">
-                <div id="skills-strategic"></div>
-                <div id="skills-tools"></div>
-                <div id="skills-emerging"></div>
+                <div class="skills-column" id="skills-strategic"></div>
+                <div class="skills-column" id="skills-tools"></div>
+                <div class="skills-column" id="skills-emerging"></div>
             </div>
         </section>
 

--- a/cv_styles/cv_itau_style_EN.html
+++ b/cv_styles/cv_itau_style_EN.html
@@ -5,107 +5,435 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pedro Henrique Marconato - CV</title>
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,400&display=swap');
 
         :root {
-            /* Itau Colors */
-            --primary-color: #FF6200;
-            --secondary-color: #C24E00;
-            --accent-color: #FFB300;
-            --text-color: #2c3e50;
-            --border-color: rgba(0, 0, 0, 0.15);
+            /* Itaú — 2023 rebrand, "river stones" */
+            --itau-orange: #FF6200;
+            --itau-burnt: #C24E00;
+            --itau-terracotta: #8F3A00;
+            --itau-amber: #FFB300;
+            --itau-blue: #1E5BC6;
+            --itau-green: #00A868;
+            --itau-pink: #FF4D8D;
+            --itau-sand: #FFF4EC;
+            --itau-ink: #33261C;
+
+            --primary-color: var(--itau-orange);
+            --secondary-color: var(--itau-burnt);
+            --accent-color: var(--itau-amber);
+            --text-color: var(--itau-ink);
+            --border-color: rgba(194, 78, 0, 0.16);
+            --background-gradient: linear-gradient(135deg, var(--itau-orange) 0%, var(--itau-burnt) 100%);
+            --stone-radius: 58% 42% 44% 56% / 52% 58% 42% 48%;
         }
 
         * { margin: 0; padding: 0; box-sizing: border-box; }
 
         body {
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            font-family: 'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             color: var(--text-color);
             line-height: 1.5;
-            background: white;
+            background: var(--itau-sand);
             font-size: 12px;
         }
 
-        .cv-container { max-width: 210mm; margin: 0 auto; padding: 14mm; background: white; }
-
-        .header { border-bottom: 3px solid var(--primary-color); padding-bottom: 12px; margin-bottom: 16px; }
-        .header h1 { font-size: 22px; color: var(--primary-color); }
-        .header h2 { font-size: 13px; font-weight: 500; margin-bottom: 6px; }
-        .contact-info { font-size: 11px; }
-        .contact-info a { color: var(--text-color); text-decoration: none; }
-
-        .section { margin-bottom: 14px; }
-        .section-title {
-            font-size: 14px;
-            font-weight: 700;
-            color: var(--primary-color);
-            border-bottom: 1px solid var(--border-color);
-            padding-bottom: 3px;
-            margin-bottom: 8px;
-            text-transform: uppercase;
+        h1, .section-title, .job-title, .degree, .project-title {
+            font-weight: 800;
         }
 
-        .skills-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 14px; }
-        .tool-item { margin-bottom: 6px; }
-        .tool-name { display: flex; justify-content: space-between; font-weight: 500; font-size: 11px; }
-        .tool-percentage { color: var(--accent-color); font-size: 10px; font-weight: 600; }
-        .dots-container { display: flex; gap: 2px; margin-top: 2px; }
-        .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--border-color); }
-        .dot.filled { background: var(--primary-color); }
+        .cv-container {
+            max-width: 210mm;
+            margin: 0 auto;
+            background: #ffffff;
+            border-radius: 22px;
+            overflow: hidden;
+            box-shadow: 0 14px 40px rgba(194, 78, 0, 0.16);
+        }
+
+        /* ===== Header ===== */
+        .header {
+            background:
+                radial-gradient(circle at 14% 18%, rgba(255, 158, 74, 0.5) 0%, transparent 46%),
+                radial-gradient(circle at 90% 88%, rgba(194, 78, 0, 0.55) 0%, transparent 52%),
+                var(--background-gradient);
+            padding: 20px 28px 24px;
+            border-radius: 0 0 40px 64px;
+            position: relative;
+        }
+
+        .header-top {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+            margin-bottom: 12px;
+        }
+
+        .brand-logo {
+            flex-shrink: 0;
+            background: rgba(255, 255, 255, 0.96);
+            padding: 7px;
+            border-radius: 32% 68% 64% 36% / 48% 40% 60% 52%;
+            box-shadow: 0 6px 16px rgba(143, 58, 0, 0.32);
+            line-height: 0;
+        }
+
+        .brand-logo img { width: 42px; height: 42px; display: block; }
+
+        .header-text { flex: 1; min-width: 0; }
+
+        .tagline {
+            display: inline-flex;
+            align-items: center;
+            gap: 7px;
+            font-size: 8.5px;
+            font-weight: 600;
+            letter-spacing: 1.6px;
+            text-transform: lowercase;
+            color: rgba(255, 255, 255, 0.95);
+            background: rgba(143, 58, 0, 0.26);
+            border: 1px solid rgba(255, 255, 255, 0.3);
+            border-radius: 999px;
+            padding: 3px 11px;
+            margin-bottom: 7px;
+        }
+
+        .tagline-dot {
+            width: 5px;
+            height: 5px;
+            border-radius: 50%;
+            background: var(--itau-amber);
+            flex-shrink: 0;
+        }
+
+        .header h1 {
+            font-size: 20px;
+            color: white;
+            letter-spacing: -0.3px;
+            text-transform: uppercase;
+            line-height: 1.15;
+            margin-bottom: 3px;
+            text-shadow: 0 2px 10px rgba(143, 58, 0, 0.3);
+        }
+
+        .header h2 {
+            font-size: 11.5px;
+            font-weight: 500;
+            color: rgba(255, 255, 255, 0.95);
+        }
+
+        .contact-info {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 7px;
+        }
+
+        .contact-item {
+            display: inline-flex;
+            align-items: center;
+            gap: 5px;
+            background: rgba(255, 255, 255, 0.16);
+            border: 1px solid rgba(255, 255, 255, 0.24);
+            border-radius: 999px;
+            padding: 3px 11px;
+            color: white;
+            font-size: 9px;
+            font-weight: 500;
+        }
+
+        .contact-item i { font-size: 8.5px; }
+
+        .contact-item a { color: white; text-decoration: none; }
+
+        /* ===== Sections ===== */
+        .section { padding: 14px 28px; }
+
+        .section:not(:last-child) { border-bottom: 1px solid var(--border-color); }
+
+        .section-title {
+            display: inline-block;
+            background: var(--background-gradient);
+            color: white;
+            font-size: 11px;
+            font-weight: 700;
+            letter-spacing: 0.8px;
+            text-transform: lowercase;
+            padding: 6px 18px;
+            border-radius: 999px;
+            margin-bottom: 10px;
+            box-shadow: 0 4px 12px rgba(255, 98, 0, 0.28);
+        }
+
+        #cv-profile { font-size: 11px; line-height: 1.6; text-align: justify; }
+
+        /* ===== Skills ===== */
+        .skills-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr 1fr;
+            gap: 10px;
+        }
+
+        #skills-strategic, #skills-tools, #skills-emerging {
+            background: linear-gradient(160deg, rgba(255, 244, 236, 0.9), rgba(255, 244, 236, 0.35));
+            border: 1px solid rgba(255, 98, 0, 0.14);
+            border-top: 3px solid var(--itau-orange);
+            border-radius: 14px;
+            padding: 11px;
+        }
+
+        #skills-tools { border-top-color: var(--itau-amber); }
+        #skills-emerging { border-top-color: var(--itau-green); }
+
+        #skills-strategic h3, #skills-tools h3, #skills-emerging h3 {
+            font-size: 10px !important;
+            font-weight: 700 !important;
+            text-transform: uppercase;
+            letter-spacing: 0.3px;
+            color: var(--itau-terracotta) !important;
+            margin-bottom: 8px !important;
+        }
+
+        .tool-item { margin-bottom: 7px; }
+
+        .tool-name {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 6px;
+            font-weight: 500;
+            font-size: 9.5px;
+            margin-bottom: 3px;
+        }
+
+        .tool-percentage {
+            font-size: 7.5px;
+            font-weight: 700;
+            color: var(--itau-terracotta);
+            background: rgba(255, 179, 0, 0.22);
+            border: 1px solid rgba(255, 98, 0, 0.2);
+            border-radius: 999px;
+            padding: 1px 7px;
+            white-space: nowrap;
+            flex-shrink: 0;
+        }
+
+        .dots-container { display: flex; gap: 2px; flex-wrap: nowrap; }
+
+        .dot {
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background-color: rgba(194, 78, 0, 0.15);
+            flex-shrink: 0;
+        }
+
+        .dot.filled {
+            background: linear-gradient(135deg, var(--itau-orange) 0%, var(--itau-amber) 100%);
+        }
+
+        /* ===== Experience ===== */
+        #experience-container { position: relative; }
 
         .experience-item {
-            padding: 8px 0 8px 14px;
-            border-left: 2px solid var(--primary-color);
+            padding: 12px 14px;
             margin-bottom: 10px;
+            border-radius: 16px;
+            background: linear-gradient(150deg, #ffffff, rgba(255, 244, 236, 0.6));
+            border: 1px solid rgba(255, 98, 0, 0.16);
+            border-left: 4px solid var(--itau-orange);
             page-break-inside: avoid;
         }
-        .job-title { font-size: 13px; font-weight: 700; color: var(--primary-color); }
-        .job-number { display: none; }
-        .experience-item .company { font-weight: 600; font-size: 12px; }
-        .experience-item .period { font-size: 11px; color: var(--accent-color); margin-bottom: 4px; }
-        .job-description { font-size: 11px; margin-bottom: 6px; }
-        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
-        .achievement-item { display: flex; gap: 6px; font-size: 10.5px; }
-        .achievement-icon { color: var(--primary-color); padding-top: 1px; }
-        .achievement-title { font-weight: 600; }
-        .tooltip { display: none; }
 
-        .education-item { margin-bottom: 8px; page-break-inside: avoid; }
-        .degree { font-weight: 700; color: var(--primary-color); font-size: 12px; }
-        .university { font-size: 11px; }
-        .thesis { font-size: 10.5px; }
-        .cta-button { display: none; }
-
-        .project-item { margin-bottom: 8px; page-break-inside: avoid; }
-        .project-title { font-weight: 700; color: var(--primary-color); font-size: 12px; }
-        .project-description { font-size: 11px; }
-        .tech-tag {
-            display: inline-block;
-            padding: 1px 7px;
-            margin: 2px 3px 0 0;
-            border: 1px solid var(--primary-color);
-            color: var(--primary-color);
-            border-radius: 8px;
-            font-size: 9.5px;
+        .job-title {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 12.5px;
+            color: var(--itau-terracotta);
+            margin-bottom: 4px;
         }
 
+        .job-number {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 20px;
+            height: 18px;
+            background: linear-gradient(135deg, var(--itau-orange), var(--itau-amber));
+            color: white;
+            border-radius: var(--stone-radius);
+            font-size: 9.5px;
+            font-weight: 800;
+            flex-shrink: 0;
+        }
+
+        .experience-item .company {
+            font-weight: 600;
+            font-size: 11px;
+            color: var(--itau-orange);
+            margin-bottom: 2px;
+        }
+
+        .experience-item .period {
+            display: inline-block;
+            font-size: 9px;
+            font-weight: 600;
+            color: var(--itau-terracotta);
+            background: rgba(255, 98, 0, 0.08);
+            border: 1px solid rgba(255, 98, 0, 0.16);
+            border-radius: 999px;
+            padding: 1px 9px;
+            margin-bottom: 6px;
+        }
+
+        .job-description {
+            font-size: 10px;
+            line-height: 1.45;
+            margin-bottom: 6px;
+        }
+
+        .achievements-container {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 6px;
+        }
+
+        .achievement-item {
+            display: flex;
+            gap: 6px;
+            background: rgba(255, 98, 0, 0.05);
+            border: 1px solid rgba(255, 98, 0, 0.12);
+            border-radius: 10px;
+            padding: 6px 8px;
+        }
+
+        .achievement-icon {
+            color: var(--itau-orange);
+            font-size: 10px;
+            padding-top: 1px;
+            flex-shrink: 0;
+        }
+
+        .achievement-title {
+            font-weight: 700;
+            font-size: 9.5px;
+            color: var(--itau-terracotta);
+            margin-bottom: 1px;
+        }
+
+        .achievement-description { font-size: 8.8px; line-height: 1.35; }
+
+        .tooltip { display: none !important; }
+
+        /* ===== Education ===== */
+        #education-container {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 10px;
+        }
+
+        .education-item {
+            padding: 10px 12px;
+            border-radius: 12px;
+            background: linear-gradient(160deg, rgba(255, 244, 236, 0.9), rgba(255, 244, 236, 0.3));
+            border: 1px solid rgba(255, 98, 0, 0.14);
+            border-left: 4px solid var(--itau-amber);
+            page-break-inside: avoid;
+        }
+
+        .degree { font-size: 11.5px; color: var(--itau-terracotta); margin-bottom: 2px; }
+        .university { font-size: 10px; margin-bottom: 2px; }
+        .thesis { font-size: 9.5px; font-style: italic; color: #8a7263; }
+        .cta-button { display: none; }
+
+        /* ===== Projects ===== */
+        #projects-container {
+            display: grid;
+            grid-template-columns: 1fr 1fr 1fr;
+            gap: 10px;
+        }
+
+        .project-item {
+            padding: 10px 12px;
+            border-radius: 14px;
+            background: linear-gradient(150deg, #ffffff, rgba(255, 244, 236, 0.5));
+            border: 1px solid rgba(255, 98, 0, 0.14);
+            page-break-inside: avoid;
+        }
+
+        .project-title { font-size: 10.5px; color: var(--itau-terracotta); margin-bottom: 4px; }
+        .project-description { font-size: 9.5px; line-height: 1.4; margin-bottom: 6px; }
+
+        .tech-tag {
+            display: inline-block;
+            background: rgba(255, 98, 0, 0.08);
+            color: var(--itau-terracotta);
+            border: 1px solid rgba(255, 98, 0, 0.2);
+            border-radius: 999px;
+            padding: 2px 8px;
+            margin: 2px 3px 0 0;
+            font-size: 8px;
+            font-weight: 600;
+        }
+
+        /* ===== Print ===== */
         @media print {
-            body { margin: 0; padding: 0; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-            .cv-container { margin: 0; padding: 10mm; max-width: none; }
+            * {
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+            }
+
+            body { margin: 0; padding: 0; background: white; }
+
+            .cv-container {
+                margin: 0;
+                max-width: none;
+                border-radius: 0;
+                box-shadow: none;
+            }
+
+            .header { border-radius: 0 0 28px 46px; padding: 16px 24px 20px; }
+            .header h1 { font-size: 18px !important; }
+            .header h2 { font-size: 10.5px !important; }
+
+            .section { padding: 10px 24px !important; }
+            .section-title { font-size: 10px !important; padding: 5px 16px !important; margin-bottom: 8px !important; }
+
+            .experience-item, .education-item, .project-item {
+                page-break-inside: avoid;
+                margin-bottom: 8px !important;
+            }
+
+            .job-description, .achievement-description { font-size: 9px !important; }
+
+            @page {
+                size: A4;
+                margin: 8mm;
+            }
         }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <meta name="theme-color" content="#FF6200">
 </head>
 <body>
     <div class="cv-container">
         <header class="header">
-            <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
-            <h2 id="cv-role">CRM Management and Data Intelligence</h2>
+            <div class="header-top">
+                <div class="brand-logo">
+                    <img src="../assets/images/itau.png" alt="Itaú">
+                </div>
+                <div class="header-text">
+                    <div class="tagline"><span class="tagline-dot"></span>made of future</div>
+                    <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
+                    <h2 id="cv-role">CRM Management and Data Intelligence</h2>
+                </div>
+            </div>
             <div class="contact-info">
-                <span id="cv-email">pedrohmarconato@gmail.com</span> |
-                <span id="cv-phone">+55 (55) 981147758</span> |
-                <span id="cv-location"><span>Cachoeira do Sul, RS</span></span> |
-                <a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin">LinkedIn</a>
+                <span class="contact-item"><i class="fas fa-envelope"></i><span id="cv-email">pedrohmarconato@gmail.com</span></span>
+                <span class="contact-item"><i class="fas fa-phone"></i><span id="cv-phone">+55 (55) 981147758</span></span>
+                <span class="contact-item" id="cv-location"><i class="fas fa-map-marker-alt"></i><span>Cachoeira do Sul, RS</span></span>
+                <span class="contact-item"><i class="fab fa-linkedin"></i><a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin" target="_blank">LinkedIn</a></span>
+                <span class="contact-item"><i class="fab fa-github"></i><a href="https://github.com/pedrohmarconato/Pedro-Marconato-CV" id="cv-repository" target="_blank">Repository</a></span>
             </div>
         </header>
 

--- a/cv_styles/cv_itau_style_PT.html
+++ b/cv_styles/cv_itau_style_PT.html
@@ -5,107 +5,435 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pedro Henrique Marconato - CV</title>
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,400&display=swap');
 
         :root {
-            /* Itau Colors */
-            --primary-color: #FF6200;
-            --secondary-color: #C24E00;
-            --accent-color: #FFB300;
-            --text-color: #2c3e50;
-            --border-color: rgba(0, 0, 0, 0.15);
+            /* Itaú — rebrand 2023, "pedras de rio" */
+            --itau-orange: #FF6200;
+            --itau-burnt: #C24E00;
+            --itau-terracotta: #8F3A00;
+            --itau-amber: #FFB300;
+            --itau-blue: #1E5BC6;
+            --itau-green: #00A868;
+            --itau-pink: #FF4D8D;
+            --itau-sand: #FFF4EC;
+            --itau-ink: #33261C;
+
+            --primary-color: var(--itau-orange);
+            --secondary-color: var(--itau-burnt);
+            --accent-color: var(--itau-amber);
+            --text-color: var(--itau-ink);
+            --border-color: rgba(194, 78, 0, 0.16);
+            --background-gradient: linear-gradient(135deg, var(--itau-orange) 0%, var(--itau-burnt) 100%);
+            --stone-radius: 58% 42% 44% 56% / 52% 58% 42% 48%;
         }
 
         * { margin: 0; padding: 0; box-sizing: border-box; }
 
         body {
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            font-family: 'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             color: var(--text-color);
             line-height: 1.5;
-            background: white;
+            background: var(--itau-sand);
             font-size: 12px;
         }
 
-        .cv-container { max-width: 210mm; margin: 0 auto; padding: 14mm; background: white; }
-
-        .header { border-bottom: 3px solid var(--primary-color); padding-bottom: 12px; margin-bottom: 16px; }
-        .header h1 { font-size: 22px; color: var(--primary-color); }
-        .header h2 { font-size: 13px; font-weight: 500; margin-bottom: 6px; }
-        .contact-info { font-size: 11px; }
-        .contact-info a { color: var(--text-color); text-decoration: none; }
-
-        .section { margin-bottom: 14px; }
-        .section-title {
-            font-size: 14px;
-            font-weight: 700;
-            color: var(--primary-color);
-            border-bottom: 1px solid var(--border-color);
-            padding-bottom: 3px;
-            margin-bottom: 8px;
-            text-transform: uppercase;
+        h1, .section-title, .job-title, .degree, .project-title {
+            font-weight: 800;
         }
 
-        .skills-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 14px; }
-        .tool-item { margin-bottom: 6px; }
-        .tool-name { display: flex; justify-content: space-between; font-weight: 500; font-size: 11px; }
-        .tool-percentage { color: var(--accent-color); font-size: 10px; font-weight: 600; }
-        .dots-container { display: flex; gap: 2px; margin-top: 2px; }
-        .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--border-color); }
-        .dot.filled { background: var(--primary-color); }
+        .cv-container {
+            max-width: 210mm;
+            margin: 0 auto;
+            background: #ffffff;
+            border-radius: 22px;
+            overflow: hidden;
+            box-shadow: 0 14px 40px rgba(194, 78, 0, 0.16);
+        }
+
+        /* ===== Header ===== */
+        .header {
+            background:
+                radial-gradient(circle at 14% 18%, rgba(255, 158, 74, 0.5) 0%, transparent 46%),
+                radial-gradient(circle at 90% 88%, rgba(194, 78, 0, 0.55) 0%, transparent 52%),
+                var(--background-gradient);
+            padding: 20px 28px 24px;
+            border-radius: 0 0 40px 64px;
+            position: relative;
+        }
+
+        .header-top {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+            margin-bottom: 12px;
+        }
+
+        .brand-logo {
+            flex-shrink: 0;
+            background: rgba(255, 255, 255, 0.96);
+            padding: 7px;
+            border-radius: 32% 68% 64% 36% / 48% 40% 60% 52%;
+            box-shadow: 0 6px 16px rgba(143, 58, 0, 0.32);
+            line-height: 0;
+        }
+
+        .brand-logo img { width: 42px; height: 42px; display: block; }
+
+        .header-text { flex: 1; min-width: 0; }
+
+        .tagline {
+            display: inline-flex;
+            align-items: center;
+            gap: 7px;
+            font-size: 8.5px;
+            font-weight: 600;
+            letter-spacing: 1.6px;
+            text-transform: lowercase;
+            color: rgba(255, 255, 255, 0.95);
+            background: rgba(143, 58, 0, 0.26);
+            border: 1px solid rgba(255, 255, 255, 0.3);
+            border-radius: 999px;
+            padding: 3px 11px;
+            margin-bottom: 7px;
+        }
+
+        .tagline-dot {
+            width: 5px;
+            height: 5px;
+            border-radius: 50%;
+            background: var(--itau-amber);
+            flex-shrink: 0;
+        }
+
+        .header h1 {
+            font-size: 20px;
+            color: white;
+            letter-spacing: -0.3px;
+            text-transform: uppercase;
+            line-height: 1.15;
+            margin-bottom: 3px;
+            text-shadow: 0 2px 10px rgba(143, 58, 0, 0.3);
+        }
+
+        .header h2 {
+            font-size: 11.5px;
+            font-weight: 500;
+            color: rgba(255, 255, 255, 0.95);
+        }
+
+        .contact-info {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 7px;
+        }
+
+        .contact-item {
+            display: inline-flex;
+            align-items: center;
+            gap: 5px;
+            background: rgba(255, 255, 255, 0.16);
+            border: 1px solid rgba(255, 255, 255, 0.24);
+            border-radius: 999px;
+            padding: 3px 11px;
+            color: white;
+            font-size: 9px;
+            font-weight: 500;
+        }
+
+        .contact-item i { font-size: 8.5px; }
+
+        .contact-item a { color: white; text-decoration: none; }
+
+        /* ===== Sections ===== */
+        .section { padding: 14px 28px; }
+
+        .section:not(:last-child) { border-bottom: 1px solid var(--border-color); }
+
+        .section-title {
+            display: inline-block;
+            background: var(--background-gradient);
+            color: white;
+            font-size: 11px;
+            font-weight: 700;
+            letter-spacing: 0.8px;
+            text-transform: lowercase;
+            padding: 6px 18px;
+            border-radius: 999px;
+            margin-bottom: 10px;
+            box-shadow: 0 4px 12px rgba(255, 98, 0, 0.28);
+        }
+
+        #cv-profile { font-size: 11px; line-height: 1.6; text-align: justify; }
+
+        /* ===== Skills ===== */
+        .skills-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr 1fr;
+            gap: 10px;
+        }
+
+        #skills-strategic, #skills-tools, #skills-emerging {
+            background: linear-gradient(160deg, rgba(255, 244, 236, 0.9), rgba(255, 244, 236, 0.35));
+            border: 1px solid rgba(255, 98, 0, 0.14);
+            border-top: 3px solid var(--itau-orange);
+            border-radius: 14px;
+            padding: 11px;
+        }
+
+        #skills-tools { border-top-color: var(--itau-amber); }
+        #skills-emerging { border-top-color: var(--itau-green); }
+
+        #skills-strategic h3, #skills-tools h3, #skills-emerging h3 {
+            font-size: 10px !important;
+            font-weight: 700 !important;
+            text-transform: uppercase;
+            letter-spacing: 0.3px;
+            color: var(--itau-terracotta) !important;
+            margin-bottom: 8px !important;
+        }
+
+        .tool-item { margin-bottom: 7px; }
+
+        .tool-name {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 6px;
+            font-weight: 500;
+            font-size: 9.5px;
+            margin-bottom: 3px;
+        }
+
+        .tool-percentage {
+            font-size: 7.5px;
+            font-weight: 700;
+            color: var(--itau-terracotta);
+            background: rgba(255, 179, 0, 0.22);
+            border: 1px solid rgba(255, 98, 0, 0.2);
+            border-radius: 999px;
+            padding: 1px 7px;
+            white-space: nowrap;
+            flex-shrink: 0;
+        }
+
+        .dots-container { display: flex; gap: 2px; flex-wrap: nowrap; }
+
+        .dot {
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background-color: rgba(194, 78, 0, 0.15);
+            flex-shrink: 0;
+        }
+
+        .dot.filled {
+            background: linear-gradient(135deg, var(--itau-orange) 0%, var(--itau-amber) 100%);
+        }
+
+        /* ===== Experience ===== */
+        #experience-container { position: relative; }
 
         .experience-item {
-            padding: 8px 0 8px 14px;
-            border-left: 2px solid var(--primary-color);
+            padding: 12px 14px;
             margin-bottom: 10px;
+            border-radius: 16px;
+            background: linear-gradient(150deg, #ffffff, rgba(255, 244, 236, 0.6));
+            border: 1px solid rgba(255, 98, 0, 0.16);
+            border-left: 4px solid var(--itau-orange);
             page-break-inside: avoid;
         }
-        .job-title { font-size: 13px; font-weight: 700; color: var(--primary-color); }
-        .job-number { display: none; }
-        .experience-item .company { font-weight: 600; font-size: 12px; }
-        .experience-item .period { font-size: 11px; color: var(--accent-color); margin-bottom: 4px; }
-        .job-description { font-size: 11px; margin-bottom: 6px; }
-        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
-        .achievement-item { display: flex; gap: 6px; font-size: 10.5px; }
-        .achievement-icon { color: var(--primary-color); padding-top: 1px; }
-        .achievement-title { font-weight: 600; }
-        .tooltip { display: none; }
 
-        .education-item { margin-bottom: 8px; page-break-inside: avoid; }
-        .degree { font-weight: 700; color: var(--primary-color); font-size: 12px; }
-        .university { font-size: 11px; }
-        .thesis { font-size: 10.5px; }
-        .cta-button { display: none; }
-
-        .project-item { margin-bottom: 8px; page-break-inside: avoid; }
-        .project-title { font-weight: 700; color: var(--primary-color); font-size: 12px; }
-        .project-description { font-size: 11px; }
-        .tech-tag {
-            display: inline-block;
-            padding: 1px 7px;
-            margin: 2px 3px 0 0;
-            border: 1px solid var(--primary-color);
-            color: var(--primary-color);
-            border-radius: 8px;
-            font-size: 9.5px;
+        .job-title {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 12.5px;
+            color: var(--itau-terracotta);
+            margin-bottom: 4px;
         }
 
+        .job-number {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 20px;
+            height: 18px;
+            background: linear-gradient(135deg, var(--itau-orange), var(--itau-amber));
+            color: white;
+            border-radius: var(--stone-radius);
+            font-size: 9.5px;
+            font-weight: 800;
+            flex-shrink: 0;
+        }
+
+        .experience-item .company {
+            font-weight: 600;
+            font-size: 11px;
+            color: var(--itau-orange);
+            margin-bottom: 2px;
+        }
+
+        .experience-item .period {
+            display: inline-block;
+            font-size: 9px;
+            font-weight: 600;
+            color: var(--itau-terracotta);
+            background: rgba(255, 98, 0, 0.08);
+            border: 1px solid rgba(255, 98, 0, 0.16);
+            border-radius: 999px;
+            padding: 1px 9px;
+            margin-bottom: 6px;
+        }
+
+        .job-description {
+            font-size: 10px;
+            line-height: 1.45;
+            margin-bottom: 6px;
+        }
+
+        .achievements-container {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 6px;
+        }
+
+        .achievement-item {
+            display: flex;
+            gap: 6px;
+            background: rgba(255, 98, 0, 0.05);
+            border: 1px solid rgba(255, 98, 0, 0.12);
+            border-radius: 10px;
+            padding: 6px 8px;
+        }
+
+        .achievement-icon {
+            color: var(--itau-orange);
+            font-size: 10px;
+            padding-top: 1px;
+            flex-shrink: 0;
+        }
+
+        .achievement-title {
+            font-weight: 700;
+            font-size: 9.5px;
+            color: var(--itau-terracotta);
+            margin-bottom: 1px;
+        }
+
+        .achievement-description { font-size: 8.8px; line-height: 1.35; }
+
+        .tooltip { display: none !important; }
+
+        /* ===== Education ===== */
+        #education-container {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 10px;
+        }
+
+        .education-item {
+            padding: 10px 12px;
+            border-radius: 12px;
+            background: linear-gradient(160deg, rgba(255, 244, 236, 0.9), rgba(255, 244, 236, 0.3));
+            border: 1px solid rgba(255, 98, 0, 0.14);
+            border-left: 4px solid var(--itau-amber);
+            page-break-inside: avoid;
+        }
+
+        .degree { font-size: 11.5px; color: var(--itau-terracotta); margin-bottom: 2px; }
+        .university { font-size: 10px; margin-bottom: 2px; }
+        .thesis { font-size: 9.5px; font-style: italic; color: #8a7263; }
+        .cta-button { display: none; }
+
+        /* ===== Projects ===== */
+        #projects-container {
+            display: grid;
+            grid-template-columns: 1fr 1fr 1fr;
+            gap: 10px;
+        }
+
+        .project-item {
+            padding: 10px 12px;
+            border-radius: 14px;
+            background: linear-gradient(150deg, #ffffff, rgba(255, 244, 236, 0.5));
+            border: 1px solid rgba(255, 98, 0, 0.14);
+            page-break-inside: avoid;
+        }
+
+        .project-title { font-size: 10.5px; color: var(--itau-terracotta); margin-bottom: 4px; }
+        .project-description { font-size: 9.5px; line-height: 1.4; margin-bottom: 6px; }
+
+        .tech-tag {
+            display: inline-block;
+            background: rgba(255, 98, 0, 0.08);
+            color: var(--itau-terracotta);
+            border: 1px solid rgba(255, 98, 0, 0.2);
+            border-radius: 999px;
+            padding: 2px 8px;
+            margin: 2px 3px 0 0;
+            font-size: 8px;
+            font-weight: 600;
+        }
+
+        /* ===== Print ===== */
         @media print {
-            body { margin: 0; padding: 0; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-            .cv-container { margin: 0; padding: 10mm; max-width: none; }
+            * {
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+            }
+
+            body { margin: 0; padding: 0; background: white; }
+
+            .cv-container {
+                margin: 0;
+                max-width: none;
+                border-radius: 0;
+                box-shadow: none;
+            }
+
+            .header { border-radius: 0 0 28px 46px; padding: 16px 24px 20px; }
+            .header h1 { font-size: 18px !important; }
+            .header h2 { font-size: 10.5px !important; }
+
+            .section { padding: 10px 24px !important; }
+            .section-title { font-size: 10px !important; padding: 5px 16px !important; margin-bottom: 8px !important; }
+
+            .experience-item, .education-item, .project-item {
+                page-break-inside: avoid;
+                margin-bottom: 8px !important;
+            }
+
+            .job-description, .achievement-description { font-size: 9px !important; }
+
+            @page {
+                size: A4;
+                margin: 8mm;
+            }
         }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <meta name="theme-color" content="#FF6200">
 </head>
 <body>
     <div class="cv-container">
         <header class="header">
-            <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
-            <h2 id="cv-role">Gestão de CRM e Inteligência de Dados</h2>
+            <div class="header-top">
+                <div class="brand-logo">
+                    <img src="../assets/images/itau.png" alt="Itaú">
+                </div>
+                <div class="header-text">
+                    <div class="tagline"><span class="tagline-dot"></span>feito de futuro</div>
+                    <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
+                    <h2 id="cv-role">Gestão de CRM e Inteligência de Dados</h2>
+                </div>
+            </div>
             <div class="contact-info">
-                <span id="cv-email">pedrohmarconato@gmail.com</span> |
-                <span id="cv-phone">+55 (55) 981147758</span> |
-                <span id="cv-location"><span>Cachoeira do Sul, RS</span></span> |
-                <a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin">LinkedIn</a>
+                <span class="contact-item"><i class="fas fa-envelope"></i><span id="cv-email">pedrohmarconato@gmail.com</span></span>
+                <span class="contact-item"><i class="fas fa-phone"></i><span id="cv-phone">+55 (55) 981147758</span></span>
+                <span class="contact-item" id="cv-location"><i class="fas fa-map-marker-alt"></i><span>Cachoeira do Sul, RS</span></span>
+                <span class="contact-item"><i class="fab fa-linkedin"></i><a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin" target="_blank">LinkedIn</a></span>
+                <span class="contact-item"><i class="fab fa-github"></i><a href="https://github.com/pedrohmarconato/Pedro-Marconato-CV" id="cv-repository" target="_blank">Repositório</a></span>
             </div>
         </header>
 

--- a/cv_styles/cv_magalu_style_EN.html
+++ b/cv_styles/cv_magalu_style_EN.html
@@ -5,93 +5,404 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pedro Henrique Marconato - CV</title>
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap');
 
         :root {
-            /* Magalu Colors */
+            /* Magalu Colors (docs/magalu_brandbook.md) */
             --primary-color: #0086FF;
             --secondary-color: #236FBE;
             --accent-color: #FF3BA8;
+            --light-bg: #E5F2FF;
             --text-color: #2c3e50;
-            --border-color: rgba(0, 0, 0, 0.15);
+            --muted-color: #5a6b7a;
+            --border-color: rgba(0, 134, 255, 0.18);
+            --background-gradient: linear-gradient(135deg, #0086FF 0%, #236FBE 100%);
+            --font-title: 'Baloo 2', 'Trebuchet MS', sans-serif;
+            --font-body: 'Nunito', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
         }
 
         * { margin: 0; padding: 0; box-sizing: border-box; }
 
         body {
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            font-family: var(--font-body);
             color: var(--text-color);
-            line-height: 1.5;
-            background: white;
-            font-size: 12px;
+            line-height: 1.55;
+            background: linear-gradient(180deg, #eaf4ff 0%, #f8fbff 100%);
+            font-size: 12.5px;
         }
 
-        .cv-container { max-width: 210mm; margin: 0 auto; padding: 14mm; background: white; }
+        .cv-container {
+            max-width: 210mm;
+            margin: 20px auto;
+            padding: 0 0 14mm;
+            background: #ffffff;
+            border-radius: 20px;
+            overflow: hidden;
+            box-shadow: 0 10px 40px rgba(0, 134, 255, 0.14);
+        }
 
-        .header { border-bottom: 3px solid var(--primary-color); padding-bottom: 12px; margin-bottom: 16px; }
-        .header h1 { font-size: 22px; color: var(--primary-color); }
-        .header h2 { font-size: 13px; font-weight: 500; margin-bottom: 6px; }
-        .contact-info { font-size: 11px; }
-        .contact-info a { color: var(--text-color); text-decoration: none; }
+        /* Header */
+        .header {
+            background: var(--background-gradient);
+            padding: 32px 40px 34px;
+            position: relative;
+            overflow: hidden;
+        }
 
-        .section { margin-bottom: 14px; }
+        .header::before {
+            content: '';
+            position: absolute;
+            width: 190px;
+            height: 190px;
+            border-radius: 50%;
+            background: rgba(255, 255, 255, 0.08);
+            top: -80px;
+            right: -50px;
+        }
+
+        .header::after {
+            content: '';
+            position: absolute;
+            width: 130px;
+            height: 130px;
+            border-radius: 50%;
+            background: rgba(255, 59, 168, 0.12);
+            bottom: -60px;
+            left: -35px;
+        }
+
+        .header-content { position: relative; z-index: 1; }
+
+        .brand-logo {
+            width: 150px;
+            height: 42px;
+            margin: 0 auto 14px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .brand-logo img {
+            width: 100%;
+            height: 100%;
+            object-fit: contain;
+            filter: brightness(0) invert(1);
+        }
+
+        .header h1 {
+            font-family: var(--font-title);
+            font-size: 24px;
+            font-weight: 800;
+            color: #ffffff;
+            text-align: center;
+            letter-spacing: 0.3px;
+        }
+
+        .header h2 {
+            font-family: var(--font-body);
+            font-size: 13.5px;
+            font-weight: 700;
+            color: rgba(255, 255, 255, 0.95);
+            text-align: center;
+            margin-top: 4px;
+            margin-bottom: 16px;
+        }
+
+        .contact-info {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            justify-content: center;
+        }
+
+        .contact-pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            background: rgba(255, 255, 255, 0.18);
+            border: 1px solid rgba(255, 255, 255, 0.3);
+            border-radius: 999px;
+            padding: 7px 14px;
+            color: #ffffff;
+            font-size: 11.5px;
+            font-weight: 600;
+            text-decoration: none;
+        }
+
+        .contact-pill i { font-size: 11px; color: #ffffff; }
+        .contact-pill span, .contact-pill a { color: #ffffff; text-decoration: none; }
+
+        /* Sections */
+        .section { padding: 22px 40px; position: relative; }
+
+        .section:not(:last-child)::after {
+            content: '';
+            position: absolute;
+            bottom: 0;
+            left: 40px;
+            right: 40px;
+            height: 1px;
+            background: linear-gradient(to right, transparent, var(--border-color), transparent);
+        }
+
         .section-title {
+            font-family: var(--font-title);
+            background: var(--background-gradient);
+            color: #ffffff;
             font-size: 14px;
             font-weight: 700;
-            color: var(--primary-color);
-            border-bottom: 1px solid var(--border-color);
-            padding-bottom: 3px;
-            margin-bottom: 8px;
-            text-transform: uppercase;
+            padding: 8px 18px;
+            border-radius: 999px;
+            margin-bottom: 16px;
+            display: inline-block;
+            letter-spacing: 0.2px;
+            box-shadow: 0 4px 12px rgba(0, 134, 255, 0.22);
         }
 
-        .skills-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 14px; }
-        .tool-item { margin-bottom: 6px; }
-        .tool-name { display: flex; justify-content: space-between; font-weight: 500; font-size: 11px; }
-        .tool-percentage { color: var(--accent-color); font-size: 10px; font-weight: 600; }
-        .dots-container { display: flex; gap: 2px; margin-top: 2px; }
-        .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--border-color); }
+        #cv-profile { font-size: 12.5px; line-height: 1.65; color: var(--text-color); }
+
+        /* Skills */
+        .skills-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 16px; }
+
+        .skills-card {
+            background: linear-gradient(135deg, var(--light-bg), #ffffff);
+            border: 1px solid var(--border-color);
+            border-radius: 16px;
+            padding: 14px 16px;
+        }
+
+        .skills-card h3 { font-family: var(--font-title); }
+
+        .tool-item { margin-bottom: 9px; }
+        .tool-item:last-child { margin-bottom: 0; }
+
+        .tool-name {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-weight: 700;
+            font-size: 11.5px;
+            color: var(--text-color);
+            margin-bottom: 4px;
+        }
+
+        .tool-percentage {
+            color: var(--accent-color);
+            font-size: 9.5px;
+            font-weight: 800;
+            background: rgba(255, 59, 168, 0.1);
+            padding: 2px 8px;
+            border-radius: 999px;
+        }
+
+        .dots-container { display: flex; gap: 3px; }
+        .dot { width: 7px; height: 7px; border-radius: 50%; background: rgba(0, 134, 255, 0.15); }
         .dot.filled { background: var(--primary-color); }
 
+        /* Experience */
         .experience-item {
-            padding: 8px 0 8px 14px;
-            border-left: 2px solid var(--primary-color);
-            margin-bottom: 10px;
+            position: relative;
+            margin-bottom: 16px;
+            padding: 16px 18px 16px 22px;
+            border-radius: 16px;
+            border: 1px solid var(--border-color);
+            border-left: 5px solid var(--primary-color);
+            background: linear-gradient(135deg, #ffffff 0%, rgba(229, 242, 255, 0.5) 100%);
+            box-shadow: 0 3px 14px rgba(0, 134, 255, 0.07);
             page-break-inside: avoid;
         }
-        .job-title { font-size: 13px; font-weight: 700; color: var(--primary-color); }
-        .job-number { display: none; }
-        .experience-item .company { font-weight: 600; font-size: 12px; }
-        .experience-item .period { font-size: 11px; color: var(--accent-color); margin-bottom: 4px; }
-        .job-description { font-size: 11px; margin-bottom: 6px; }
-        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
-        .achievement-item { display: flex; gap: 6px; font-size: 10.5px; }
-        .achievement-icon { color: var(--primary-color); padding-top: 1px; }
-        .achievement-title { font-weight: 600; }
-        .tooltip { display: none; }
 
-        .education-item { margin-bottom: 8px; page-break-inside: avoid; }
-        .degree { font-weight: 700; color: var(--primary-color); font-size: 12px; }
-        .university { font-size: 11px; }
-        .thesis { font-size: 10.5px; }
-        .cta-button { display: none; }
+        .job-title {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-family: var(--font-title);
+            font-weight: 700;
+            font-size: 14px;
+            color: var(--secondary-color);
+            margin-bottom: 4px;
+        }
 
-        .project-item { margin-bottom: 8px; page-break-inside: avoid; }
-        .project-title { font-weight: 700; color: var(--primary-color); font-size: 12px; }
-        .project-description { font-size: 11px; }
-        .tech-tag {
-            display: inline-block;
-            padding: 1px 7px;
-            margin: 2px 3px 0 0;
-            border: 1px solid var(--primary-color);
+        .job-number {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 20px;
+            height: 20px;
+            flex-shrink: 0;
+            border-radius: 50%;
+            background: var(--background-gradient);
+            color: #ffffff;
+            font-family: var(--font-body);
+            font-size: 10px;
+            font-weight: 800;
+        }
+
+        .experience-item .company { font-weight: 700; font-size: 12px; color: var(--primary-color); }
+        .experience-item .period { font-size: 11px; color: var(--accent-color); font-weight: 700; margin-bottom: 6px; }
+        .job-description { font-size: 11.5px; line-height: 1.55; margin-bottom: 8px; color: var(--text-color); }
+
+        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+
+        .achievement-item {
+            display: flex;
+            gap: 8px;
+            align-items: flex-start;
+            background: rgba(255, 255, 255, 0.65);
+            border-radius: 10px;
+            padding: 6px 8px;
+        }
+
+        .achievement-icon {
+            width: 20px;
+            height: 20px;
+            flex-shrink: 0;
+            border-radius: 50%;
+            background: rgba(0, 134, 255, 0.12);
             color: var(--primary-color);
-            border-radius: 8px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
             font-size: 9.5px;
         }
 
+        .achievement-title { font-weight: 700; font-size: 10.5px; color: var(--text-color); }
+        .achievement-description { font-size: 10px; color: var(--muted-color); line-height: 1.4; }
+
+        .tooltip { display: none; } /* hover doesn't work on paper */
+
+        /* Education */
+        .education-item {
+            margin-bottom: 10px;
+            padding: 14px 16px;
+            border-radius: 14px;
+            background: linear-gradient(135deg, var(--light-bg), #ffffff);
+            border: 1px solid var(--border-color);
+            page-break-inside: avoid;
+        }
+
+        .degree { font-family: var(--font-title); font-weight: 700; color: var(--primary-color); font-size: 12.5px; }
+        .university { font-size: 11px; margin-top: 2px; }
+        .thesis { font-size: 10.5px; color: var(--muted-color); font-style: italic; margin-top: 2px; }
+        .cta-button { display: none; }
+
+        /* Projects */
+        .project-item {
+            margin-bottom: 10px;
+            padding: 14px 16px;
+            border-radius: 14px;
+            background: linear-gradient(135deg, #ffffff, rgba(229, 242, 255, 0.5));
+            border: 1px solid var(--border-color);
+            page-break-inside: avoid;
+        }
+
+        .project-title { font-family: var(--font-title); font-weight: 700; color: var(--primary-color); font-size: 12.5px; }
+        .project-description { font-size: 11px; margin-top: 3px; margin-bottom: 6px; }
+
+        .tech-tag {
+            display: inline-block;
+            padding: 3px 10px;
+            margin: 2px 4px 0 0;
+            background: var(--light-bg);
+            border: 1px solid rgba(0, 134, 255, 0.35);
+            color: var(--primary-color);
+            border-radius: 999px;
+            font-size: 9.5px;
+            font-weight: 700;
+        }
+
         @media print {
-            body { margin: 0; padding: 0; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-            .cv-container { margin: 0; padding: 10mm; max-width: none; }
+            * { animation: none !important; }
+
+            body {
+                background: #ffffff;
+                margin: 0;
+                padding: 0;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+            }
+
+            .cv-container { margin: 0; max-width: 100%; border-radius: 0; box-shadow: none; padding-bottom: 6mm; }
+
+            .header {
+                background: var(--background-gradient) !important;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+                padding: 18px 26px 22px !important;
+                page-break-after: avoid;
+            }
+
+            .header h1 { font-size: 19px !important; }
+            .header h2 { font-size: 11px !important; margin-bottom: 10px !important; }
+            .brand-logo { width: 110px !important; height: 32px !important; margin-bottom: 8px !important; }
+
+            .contact-pill {
+                font-size: 8.5px !important;
+                padding: 4px 9px !important;
+                background: rgba(255, 255, 255, 0.22) !important;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+            }
+
+            .section { padding: 10px 26px !important; page-break-inside: avoid; }
+            .section:not(:last-child)::after { left: 26px; right: 26px; }
+
+            .section-title {
+                background: var(--background-gradient) !important;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+                font-size: 11.5px !important;
+                padding: 5px 14px !important;
+                margin-bottom: 9px !important;
+                box-shadow: none !important;
+            }
+
+            #cv-profile { font-size: 10.5px !important; line-height: 1.5 !important; }
+
+            .skills-grid { gap: 10px !important; }
+            .skills-card { padding: 9px 11px !important; border-radius: 12px !important; }
+            .skills-card h3 { font-size: 12px !important; margin-bottom: 8px !important; }
+            .tool-item { margin-bottom: 6px !important; }
+            .tool-name { font-size: 9.5px !important; }
+            .tool-percentage { font-size: 7.5px !important; padding: 1px 6px !important; }
+            .dot { width: 5.5px !important; height: 5.5px !important; }
+
+            .experience-item {
+                padding: 10px 12px 10px 15px !important;
+                margin-bottom: 8px !important;
+                border-radius: 10px !important;
+                box-shadow: none !important;
+                page-break-inside: avoid !important;
+            }
+
+            .job-title { font-size: 11.5px !important; }
+            .job-number { width: 15px !important; height: 15px !important; font-size: 8px !important; }
+            .experience-item .company { font-size: 10px !important; }
+            .experience-item .period { font-size: 9px !important; margin-bottom: 4px !important; }
+            .job-description { font-size: 9.5px !important; margin-bottom: 5px !important; }
+            .achievements-container { gap: 5px !important; }
+            .achievement-item { padding: 4px 6px !important; gap: 5px !important; }
+            .achievement-icon { width: 15px !important; height: 15px !important; font-size: 7.5px !important; }
+            .achievement-title { font-size: 9px !important; }
+            .achievement-description { font-size: 8.5px !important; }
+
+            .education-item, .project-item {
+                padding: 9px 11px !important;
+                margin-bottom: 6px !important;
+                border-radius: 10px !important;
+                page-break-inside: avoid !important;
+            }
+
+            .degree, .project-title { font-size: 10.5px !important; }
+            .university { font-size: 9.5px !important; }
+            .thesis { font-size: 9px !important; }
+            .project-description { font-size: 9.5px !important; }
+            .tech-tag { font-size: 8px !important; padding: 2px 8px !important; }
+
+            .tooltip { display: none !important; }
+
+            @page { size: A4; margin: 8mm; }
         }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
@@ -99,13 +410,19 @@
 <body>
     <div class="cv-container">
         <header class="header">
-            <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
-            <h2 id="cv-role">CRM Management and Data Intelligence</h2>
-            <div class="contact-info">
-                <span id="cv-email">pedrohmarconato@gmail.com</span> |
-                <span id="cv-phone">+55 (55) 981147758</span> |
-                <span id="cv-location"><span>Cachoeira do Sul, RS</span></span> |
-                <a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin">LinkedIn</a>
+            <div class="header-content">
+                <div class="brand-logo">
+                    <img src="../assets/images/magalu.svg" alt="Magalu">
+                </div>
+                <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
+                <h2 id="cv-role">CRM Management and Data Intelligence</h2>
+                <div class="contact-info">
+                    <span class="contact-pill"><i class="fas fa-envelope"></i><span id="cv-email">pedrohmarconato@gmail.com</span></span>
+                    <span class="contact-pill"><i class="fas fa-phone"></i><span id="cv-phone">+55 (55) 981147758</span></span>
+                    <span class="contact-pill" id="cv-location"><i class="fas fa-map-marker-alt"></i><span>Cachoeira do Sul, RS</span></span>
+                    <a class="contact-pill" href="https://linkedin.com/in/pedrohmarconato" target="_blank"><i class="fab fa-linkedin"></i><span id="cv-linkedin">LinkedIn</span></a>
+                    <a class="contact-pill" href="https://github.com/pedrohmarconato" target="_blank"><i class="fab fa-github"></i><span id="cv-repository">Repository</span></a>
+                </div>
             </div>
         </header>
 
@@ -117,9 +434,9 @@
         <section class="section">
             <h2 class="section-title" id="section-skills">Skills & Tools</h2>
             <div class="skills-grid">
-                <div id="skills-strategic"></div>
-                <div id="skills-tools"></div>
-                <div id="skills-emerging"></div>
+                <div id="skills-strategic" class="skills-card"></div>
+                <div id="skills-tools" class="skills-card"></div>
+                <div id="skills-emerging" class="skills-card"></div>
             </div>
         </section>
 

--- a/cv_styles/cv_magalu_style_PT.html
+++ b/cv_styles/cv_magalu_style_PT.html
@@ -5,93 +5,404 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pedro Henrique Marconato - CV</title>
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap');
 
         :root {
-            /* Magalu Colors */
+            /* Magalu Colors (docs/magalu_brandbook.md) */
             --primary-color: #0086FF;
             --secondary-color: #236FBE;
             --accent-color: #FF3BA8;
+            --light-bg: #E5F2FF;
             --text-color: #2c3e50;
-            --border-color: rgba(0, 0, 0, 0.15);
+            --muted-color: #5a6b7a;
+            --border-color: rgba(0, 134, 255, 0.18);
+            --background-gradient: linear-gradient(135deg, #0086FF 0%, #236FBE 100%);
+            --font-title: 'Baloo 2', 'Trebuchet MS', sans-serif;
+            --font-body: 'Nunito', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
         }
 
         * { margin: 0; padding: 0; box-sizing: border-box; }
 
         body {
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            font-family: var(--font-body);
             color: var(--text-color);
-            line-height: 1.5;
-            background: white;
-            font-size: 12px;
+            line-height: 1.55;
+            background: linear-gradient(180deg, #eaf4ff 0%, #f8fbff 100%);
+            font-size: 12.5px;
         }
 
-        .cv-container { max-width: 210mm; margin: 0 auto; padding: 14mm; background: white; }
+        .cv-container {
+            max-width: 210mm;
+            margin: 20px auto;
+            padding: 0 0 14mm;
+            background: #ffffff;
+            border-radius: 20px;
+            overflow: hidden;
+            box-shadow: 0 10px 40px rgba(0, 134, 255, 0.14);
+        }
 
-        .header { border-bottom: 3px solid var(--primary-color); padding-bottom: 12px; margin-bottom: 16px; }
-        .header h1 { font-size: 22px; color: var(--primary-color); }
-        .header h2 { font-size: 13px; font-weight: 500; margin-bottom: 6px; }
-        .contact-info { font-size: 11px; }
-        .contact-info a { color: var(--text-color); text-decoration: none; }
+        /* Header */
+        .header {
+            background: var(--background-gradient);
+            padding: 32px 40px 34px;
+            position: relative;
+            overflow: hidden;
+        }
 
-        .section { margin-bottom: 14px; }
+        .header::before {
+            content: '';
+            position: absolute;
+            width: 190px;
+            height: 190px;
+            border-radius: 50%;
+            background: rgba(255, 255, 255, 0.08);
+            top: -80px;
+            right: -50px;
+        }
+
+        .header::after {
+            content: '';
+            position: absolute;
+            width: 130px;
+            height: 130px;
+            border-radius: 50%;
+            background: rgba(255, 59, 168, 0.12);
+            bottom: -60px;
+            left: -35px;
+        }
+
+        .header-content { position: relative; z-index: 1; }
+
+        .brand-logo {
+            width: 150px;
+            height: 42px;
+            margin: 0 auto 14px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .brand-logo img {
+            width: 100%;
+            height: 100%;
+            object-fit: contain;
+            filter: brightness(0) invert(1);
+        }
+
+        .header h1 {
+            font-family: var(--font-title);
+            font-size: 24px;
+            font-weight: 800;
+            color: #ffffff;
+            text-align: center;
+            letter-spacing: 0.3px;
+        }
+
+        .header h2 {
+            font-family: var(--font-body);
+            font-size: 13.5px;
+            font-weight: 700;
+            color: rgba(255, 255, 255, 0.95);
+            text-align: center;
+            margin-top: 4px;
+            margin-bottom: 16px;
+        }
+
+        .contact-info {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            justify-content: center;
+        }
+
+        .contact-pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            background: rgba(255, 255, 255, 0.18);
+            border: 1px solid rgba(255, 255, 255, 0.3);
+            border-radius: 999px;
+            padding: 7px 14px;
+            color: #ffffff;
+            font-size: 11.5px;
+            font-weight: 600;
+            text-decoration: none;
+        }
+
+        .contact-pill i { font-size: 11px; color: #ffffff; }
+        .contact-pill span, .contact-pill a { color: #ffffff; text-decoration: none; }
+
+        /* Sections */
+        .section { padding: 22px 40px; position: relative; }
+
+        .section:not(:last-child)::after {
+            content: '';
+            position: absolute;
+            bottom: 0;
+            left: 40px;
+            right: 40px;
+            height: 1px;
+            background: linear-gradient(to right, transparent, var(--border-color), transparent);
+        }
+
         .section-title {
+            font-family: var(--font-title);
+            background: var(--background-gradient);
+            color: #ffffff;
             font-size: 14px;
             font-weight: 700;
-            color: var(--primary-color);
-            border-bottom: 1px solid var(--border-color);
-            padding-bottom: 3px;
-            margin-bottom: 8px;
-            text-transform: uppercase;
+            padding: 8px 18px;
+            border-radius: 999px;
+            margin-bottom: 16px;
+            display: inline-block;
+            letter-spacing: 0.2px;
+            box-shadow: 0 4px 12px rgba(0, 134, 255, 0.22);
         }
 
-        .skills-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 14px; }
-        .tool-item { margin-bottom: 6px; }
-        .tool-name { display: flex; justify-content: space-between; font-weight: 500; font-size: 11px; }
-        .tool-percentage { color: var(--accent-color); font-size: 10px; font-weight: 600; }
-        .dots-container { display: flex; gap: 2px; margin-top: 2px; }
-        .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--border-color); }
+        #cv-profile { font-size: 12.5px; line-height: 1.65; color: var(--text-color); }
+
+        /* Skills */
+        .skills-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 16px; }
+
+        .skills-card {
+            background: linear-gradient(135deg, var(--light-bg), #ffffff);
+            border: 1px solid var(--border-color);
+            border-radius: 16px;
+            padding: 14px 16px;
+        }
+
+        .skills-card h3 { font-family: var(--font-title); }
+
+        .tool-item { margin-bottom: 9px; }
+        .tool-item:last-child { margin-bottom: 0; }
+
+        .tool-name {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-weight: 700;
+            font-size: 11.5px;
+            color: var(--text-color);
+            margin-bottom: 4px;
+        }
+
+        .tool-percentage {
+            color: var(--accent-color);
+            font-size: 9.5px;
+            font-weight: 800;
+            background: rgba(255, 59, 168, 0.1);
+            padding: 2px 8px;
+            border-radius: 999px;
+        }
+
+        .dots-container { display: flex; gap: 3px; }
+        .dot { width: 7px; height: 7px; border-radius: 50%; background: rgba(0, 134, 255, 0.15); }
         .dot.filled { background: var(--primary-color); }
 
+        /* Experience */
         .experience-item {
-            padding: 8px 0 8px 14px;
-            border-left: 2px solid var(--primary-color);
-            margin-bottom: 10px;
+            position: relative;
+            margin-bottom: 16px;
+            padding: 16px 18px 16px 22px;
+            border-radius: 16px;
+            border: 1px solid var(--border-color);
+            border-left: 5px solid var(--primary-color);
+            background: linear-gradient(135deg, #ffffff 0%, rgba(229, 242, 255, 0.5) 100%);
+            box-shadow: 0 3px 14px rgba(0, 134, 255, 0.07);
             page-break-inside: avoid;
         }
-        .job-title { font-size: 13px; font-weight: 700; color: var(--primary-color); }
-        .job-number { display: none; }
-        .experience-item .company { font-weight: 600; font-size: 12px; }
-        .experience-item .period { font-size: 11px; color: var(--accent-color); margin-bottom: 4px; }
-        .job-description { font-size: 11px; margin-bottom: 6px; }
-        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
-        .achievement-item { display: flex; gap: 6px; font-size: 10.5px; }
-        .achievement-icon { color: var(--primary-color); padding-top: 1px; }
-        .achievement-title { font-weight: 600; }
-        .tooltip { display: none; }
 
-        .education-item { margin-bottom: 8px; page-break-inside: avoid; }
-        .degree { font-weight: 700; color: var(--primary-color); font-size: 12px; }
-        .university { font-size: 11px; }
-        .thesis { font-size: 10.5px; }
-        .cta-button { display: none; }
+        .job-title {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-family: var(--font-title);
+            font-weight: 700;
+            font-size: 14px;
+            color: var(--secondary-color);
+            margin-bottom: 4px;
+        }
 
-        .project-item { margin-bottom: 8px; page-break-inside: avoid; }
-        .project-title { font-weight: 700; color: var(--primary-color); font-size: 12px; }
-        .project-description { font-size: 11px; }
-        .tech-tag {
-            display: inline-block;
-            padding: 1px 7px;
-            margin: 2px 3px 0 0;
-            border: 1px solid var(--primary-color);
+        .job-number {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 20px;
+            height: 20px;
+            flex-shrink: 0;
+            border-radius: 50%;
+            background: var(--background-gradient);
+            color: #ffffff;
+            font-family: var(--font-body);
+            font-size: 10px;
+            font-weight: 800;
+        }
+
+        .experience-item .company { font-weight: 700; font-size: 12px; color: var(--primary-color); }
+        .experience-item .period { font-size: 11px; color: var(--accent-color); font-weight: 700; margin-bottom: 6px; }
+        .job-description { font-size: 11.5px; line-height: 1.55; margin-bottom: 8px; color: var(--text-color); }
+
+        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+
+        .achievement-item {
+            display: flex;
+            gap: 8px;
+            align-items: flex-start;
+            background: rgba(255, 255, 255, 0.65);
+            border-radius: 10px;
+            padding: 6px 8px;
+        }
+
+        .achievement-icon {
+            width: 20px;
+            height: 20px;
+            flex-shrink: 0;
+            border-radius: 50%;
+            background: rgba(0, 134, 255, 0.12);
             color: var(--primary-color);
-            border-radius: 8px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
             font-size: 9.5px;
         }
 
+        .achievement-title { font-weight: 700; font-size: 10.5px; color: var(--text-color); }
+        .achievement-description { font-size: 10px; color: var(--muted-color); line-height: 1.4; }
+
+        .tooltip { display: none; } /* hover não funciona no papel */
+
+        /* Education */
+        .education-item {
+            margin-bottom: 10px;
+            padding: 14px 16px;
+            border-radius: 14px;
+            background: linear-gradient(135deg, var(--light-bg), #ffffff);
+            border: 1px solid var(--border-color);
+            page-break-inside: avoid;
+        }
+
+        .degree { font-family: var(--font-title); font-weight: 700; color: var(--primary-color); font-size: 12.5px; }
+        .university { font-size: 11px; margin-top: 2px; }
+        .thesis { font-size: 10.5px; color: var(--muted-color); font-style: italic; margin-top: 2px; }
+        .cta-button { display: none; }
+
+        /* Projects */
+        .project-item {
+            margin-bottom: 10px;
+            padding: 14px 16px;
+            border-radius: 14px;
+            background: linear-gradient(135deg, #ffffff, rgba(229, 242, 255, 0.5));
+            border: 1px solid var(--border-color);
+            page-break-inside: avoid;
+        }
+
+        .project-title { font-family: var(--font-title); font-weight: 700; color: var(--primary-color); font-size: 12.5px; }
+        .project-description { font-size: 11px; margin-top: 3px; margin-bottom: 6px; }
+
+        .tech-tag {
+            display: inline-block;
+            padding: 3px 10px;
+            margin: 2px 4px 0 0;
+            background: var(--light-bg);
+            border: 1px solid rgba(0, 134, 255, 0.35);
+            color: var(--primary-color);
+            border-radius: 999px;
+            font-size: 9.5px;
+            font-weight: 700;
+        }
+
         @media print {
-            body { margin: 0; padding: 0; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-            .cv-container { margin: 0; padding: 10mm; max-width: none; }
+            * { animation: none !important; }
+
+            body {
+                background: #ffffff;
+                margin: 0;
+                padding: 0;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+            }
+
+            .cv-container { margin: 0; max-width: 100%; border-radius: 0; box-shadow: none; padding-bottom: 6mm; }
+
+            .header {
+                background: var(--background-gradient) !important;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+                padding: 18px 26px 22px !important;
+                page-break-after: avoid;
+            }
+
+            .header h1 { font-size: 19px !important; }
+            .header h2 { font-size: 11px !important; margin-bottom: 10px !important; }
+            .brand-logo { width: 110px !important; height: 32px !important; margin-bottom: 8px !important; }
+
+            .contact-pill {
+                font-size: 8.5px !important;
+                padding: 4px 9px !important;
+                background: rgba(255, 255, 255, 0.22) !important;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+            }
+
+            .section { padding: 10px 26px !important; page-break-inside: avoid; }
+            .section:not(:last-child)::after { left: 26px; right: 26px; }
+
+            .section-title {
+                background: var(--background-gradient) !important;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+                font-size: 11.5px !important;
+                padding: 5px 14px !important;
+                margin-bottom: 9px !important;
+                box-shadow: none !important;
+            }
+
+            #cv-profile { font-size: 10.5px !important; line-height: 1.5 !important; }
+
+            .skills-grid { gap: 10px !important; }
+            .skills-card { padding: 9px 11px !important; border-radius: 12px !important; }
+            .skills-card h3 { font-size: 12px !important; margin-bottom: 8px !important; }
+            .tool-item { margin-bottom: 6px !important; }
+            .tool-name { font-size: 9.5px !important; }
+            .tool-percentage { font-size: 7.5px !important; padding: 1px 6px !important; }
+            .dot { width: 5.5px !important; height: 5.5px !important; }
+
+            .experience-item {
+                padding: 10px 12px 10px 15px !important;
+                margin-bottom: 8px !important;
+                border-radius: 10px !important;
+                box-shadow: none !important;
+                page-break-inside: avoid !important;
+            }
+
+            .job-title { font-size: 11.5px !important; }
+            .job-number { width: 15px !important; height: 15px !important; font-size: 8px !important; }
+            .experience-item .company { font-size: 10px !important; }
+            .experience-item .period { font-size: 9px !important; margin-bottom: 4px !important; }
+            .job-description { font-size: 9.5px !important; margin-bottom: 5px !important; }
+            .achievements-container { gap: 5px !important; }
+            .achievement-item { padding: 4px 6px !important; gap: 5px !important; }
+            .achievement-icon { width: 15px !important; height: 15px !important; font-size: 7.5px !important; }
+            .achievement-title { font-size: 9px !important; }
+            .achievement-description { font-size: 8.5px !important; }
+
+            .education-item, .project-item {
+                padding: 9px 11px !important;
+                margin-bottom: 6px !important;
+                border-radius: 10px !important;
+                page-break-inside: avoid !important;
+            }
+
+            .degree, .project-title { font-size: 10.5px !important; }
+            .university { font-size: 9.5px !important; }
+            .thesis { font-size: 9px !important; }
+            .project-description { font-size: 9.5px !important; }
+            .tech-tag { font-size: 8px !important; padding: 2px 8px !important; }
+
+            .tooltip { display: none !important; }
+
+            @page { size: A4; margin: 8mm; }
         }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
@@ -99,13 +410,19 @@
 <body>
     <div class="cv-container">
         <header class="header">
-            <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
-            <h2 id="cv-role">Gestão de CRM e Inteligência de Dados</h2>
-            <div class="contact-info">
-                <span id="cv-email">pedrohmarconato@gmail.com</span> |
-                <span id="cv-phone">+55 (55) 981147758</span> |
-                <span id="cv-location"><span>Cachoeira do Sul, RS</span></span> |
-                <a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin">LinkedIn</a>
+            <div class="header-content">
+                <div class="brand-logo">
+                    <img src="../assets/images/magalu.svg" alt="Magalu">
+                </div>
+                <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
+                <h2 id="cv-role">Gestão de CRM e Inteligência de Dados</h2>
+                <div class="contact-info">
+                    <span class="contact-pill"><i class="fas fa-envelope"></i><span id="cv-email">pedrohmarconato@gmail.com</span></span>
+                    <span class="contact-pill"><i class="fas fa-phone"></i><span id="cv-phone">+55 (55) 981147758</span></span>
+                    <span class="contact-pill" id="cv-location"><i class="fas fa-map-marker-alt"></i><span>Cachoeira do Sul, RS</span></span>
+                    <a class="contact-pill" href="https://linkedin.com/in/pedrohmarconato" target="_blank"><i class="fab fa-linkedin"></i><span id="cv-linkedin">LinkedIn</span></a>
+                    <a class="contact-pill" href="https://github.com/pedrohmarconato" target="_blank"><i class="fab fa-github"></i><span id="cv-repository">Repositório</span></a>
+                </div>
             </div>
         </header>
 
@@ -117,9 +434,9 @@
         <section class="section">
             <h2 class="section-title" id="section-skills">Habilidades e Ferramentas</h2>
             <div class="skills-grid">
-                <div id="skills-strategic"></div>
-                <div id="skills-tools"></div>
-                <div id="skills-emerging"></div>
+                <div id="skills-strategic" class="skills-card"></div>
+                <div id="skills-tools" class="skills-card"></div>
+                <div id="skills-emerging" class="skills-card"></div>
             </div>
         </section>
 

--- a/cv_styles/cv_nubank_style_EN.html
+++ b/cv_styles/cv_nubank_style_EN.html
@@ -4,94 +4,251 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pedro Henrique Marconato - CV</title>
+    <meta name="theme-color" content="#820AD1">
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Sora:wght@400;600;700;800&display=swap');
 
         :root {
-            /* Nubank Colors */
-            --primary-color: #820AD1;
-            --secondary-color: #5C08A0;
-            --accent-color: #A64CE8;
-            --text-color: #2c3e50;
-            --border-color: rgba(0, 0, 0, 0.15);
+            /* Nubank Colors — brandbook (docs/nubank_brandbook.md) */
+            --primary-color: #820AD1;   /* Roxo Nu — masterbrand */
+            --secondary-color: #5C08A0; /* Roxo Profundo */
+            --accent-color: #A64CE8;    /* Lilás */
+            --lavender-color: #C89AF2;  /* Lavanda — empty dots */
+            --mist-color: #F3E9FC;      /* Névoa — alternating section background */
+            --text-color: #1A1A1A;
+            --border-color: rgba(130, 10, 209, 0.15);
+            --gradient: linear-gradient(135deg, #820AD1 0%, #5C08A0 100%);
+            --font-display: 'Sora', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
         }
 
         * { margin: 0; padding: 0; box-sizing: border-box; }
 
         body {
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            font-family: var(--font-body);
             color: var(--text-color);
-            line-height: 1.5;
-            background: white;
+            line-height: 1.55;
+            background: #ffffff;
             font-size: 12px;
         }
 
-        .cv-container { max-width: 210mm; margin: 0 auto; padding: 14mm; background: white; }
+        .cv-container { max-width: 210mm; margin: 0 auto; background: #ffffff; }
 
-        .header { border-bottom: 3px solid var(--primary-color); padding-bottom: 12px; margin-bottom: 16px; }
-        .header h1 { font-size: 22px; color: var(--primary-color); }
-        .header h2 { font-size: 13px; font-weight: 500; margin-bottom: 6px; }
-        .contact-info { font-size: 11px; }
-        .contact-info a { color: var(--text-color); text-decoration: none; }
-
-        .section { margin-bottom: 14px; }
-        .section-title {
-            font-size: 14px;
-            font-weight: 700;
-            color: var(--primary-color);
-            border-bottom: 1px solid var(--border-color);
-            padding-bottom: 3px;
-            margin-bottom: 8px;
-            text-transform: uppercase;
+        /* Header — minimalist purple hero */
+        .header {
+            background: var(--gradient);
+            padding: 34px 40px 38px;
+            text-align: center;
         }
 
-        .skills-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 14px; }
-        .tool-item { margin-bottom: 6px; }
-        .tool-name { display: flex; justify-content: space-between; font-weight: 500; font-size: 11px; }
-        .tool-percentage { color: var(--accent-color); font-size: 10px; font-weight: 600; }
-        .dots-container { display: flex; gap: 2px; margin-top: 2px; }
-        .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--border-color); }
+        .brand-logo { width: 100px; height: 55px; margin: 0 auto 14px; }
+        .brand-logo img { width: 100%; height: 100%; object-fit: contain; filter: brightness(0) invert(1); }
+
+        .header h1 {
+            font-family: var(--font-display);
+            font-size: 23px;
+            font-weight: 700;
+            color: #ffffff;
+            letter-spacing: 0.2px;
+            margin-bottom: 6px;
+        }
+
+        .header h2 {
+            font-size: 12.5px;
+            font-weight: 400;
+            color: rgba(255, 255, 255, 0.92);
+            margin-bottom: 16px;
+        }
+
+        .contact-info {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            gap: 8px;
+        }
+
+        .contact-info > span,
+        .contact-info > a {
+            display: inline-block;
+            background: rgba(255, 255, 255, 0.14);
+            border: 1px solid rgba(255, 255, 255, 0.24);
+            color: #ffffff;
+            text-decoration: none;
+            font-size: 10.5px;
+            font-weight: 500;
+            padding: 5px 12px;
+            border-radius: 20px;
+        }
+
+        /* Sections — generous whitespace, alternating mist */
+        .section { padding: 24px 40px; }
+        .section:nth-of-type(even) { background: var(--mist-color); }
+
+        .section-title {
+            display: inline-block;
+            font-family: var(--font-display);
+            background: var(--primary-color);
+            color: #ffffff;
+            font-size: 12px;
+            font-weight: 700;
+            letter-spacing: 0.4px;
+            text-transform: uppercase;
+            padding: 6px 14px;
+            border-radius: 8px;
+            margin-bottom: 14px;
+        }
+
+        #cv-profile { font-size: 11.5px; line-height: 1.65; }
+
+        /* Skills — purple dot scale */
+        .skills-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; }
+
+        #skills-strategic h3,
+        #skills-tools h3,
+        #skills-emerging h3 {
+            font-family: var(--font-display) !important;
+            font-size: 11.5px !important;
+            font-weight: 700 !important;
+            color: var(--secondary-color) !important;
+            text-transform: uppercase;
+            letter-spacing: 0.3px;
+            padding-bottom: 6px;
+            margin-bottom: 10px !important;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .tool-item { margin-bottom: 8px; }
+        .tool-name { display: flex; justify-content: space-between; align-items: baseline; font-size: 10.8px; font-weight: 500; }
+        .tool-percentage { color: var(--accent-color); font-size: 9px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.2px; }
+        .dots-container { display: flex; gap: 3px; margin-top: 3px; }
+        .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--lavender-color); }
         .dot.filled { background: var(--primary-color); }
 
+        /* Experience — clean cards, soft shadow */
         .experience-item {
-            padding: 8px 0 8px 14px;
-            border-left: 2px solid var(--primary-color);
-            margin-bottom: 10px;
-            page-break-inside: avoid;
+            background: #ffffff;
+            border-left: 3px solid var(--primary-color);
+            border-radius: 0 10px 10px 0;
+            padding: 14px 18px;
+            margin-bottom: 14px;
+            box-shadow: 0 2px 10px rgba(130, 10, 209, 0.07);
         }
-        .job-title { font-size: 13px; font-weight: 700; color: var(--primary-color); }
-        .job-number { display: none; }
-        .experience-item .company { font-weight: 600; font-size: 12px; }
-        .experience-item .period { font-size: 11px; color: var(--accent-color); margin-bottom: 4px; }
-        .job-description { font-size: 11px; margin-bottom: 6px; }
-        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
-        .achievement-item { display: flex; gap: 6px; font-size: 10.5px; }
-        .achievement-icon { color: var(--primary-color); padding-top: 1px; }
-        .achievement-title { font-weight: 600; }
+
+        .job-title {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-family: var(--font-display);
+            font-size: 13.5px;
+            font-weight: 700;
+            color: var(--secondary-color);
+            margin-bottom: 4px;
+        }
+
+        .job-number {
+            flex-shrink: 0;
+            width: 20px;
+            height: 20px;
+            border-radius: 50%;
+            background: var(--primary-color);
+            color: #ffffff;
+            font-family: var(--font-body);
+            font-size: 10.5px;
+            font-weight: 700;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .company { font-weight: 600; font-size: 11.5px; color: var(--text-color); }
+        .period { font-size: 10.5px; color: var(--accent-color); font-weight: 600; margin-bottom: 6px; }
+        .job-description { font-size: 11px; line-height: 1.55; margin-bottom: 8px; color: var(--text-color); }
+
+        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 8px 16px; }
+        .achievement-item { display: flex; gap: 7px; align-items: flex-start; font-size: 10.3px; }
+        .achievement-icon { flex-shrink: 0; width: 15px; text-align: center; color: var(--primary-color); padding-top: 1px; }
+        .achievement-title { font-weight: 600; color: var(--text-color); }
+        .achievement-description { color: #4a4a4a; line-height: 1.4; }
         .tooltip { display: none; }
 
-        .education-item { margin-bottom: 8px; page-break-inside: avoid; }
-        .degree { font-weight: 700; color: var(--primary-color); font-size: 12px; }
-        .university { font-size: 11px; }
-        .thesis { font-size: 10.5px; }
+        /* Education */
+        .education-item {
+            background: #ffffff;
+            border-left: 3px solid var(--secondary-color);
+            border-radius: 0 10px 10px 0;
+            padding: 10px 16px;
+            margin-bottom: 10px;
+        }
+        .degree { font-family: var(--font-display); font-weight: 700; font-size: 12px; color: var(--secondary-color); margin-bottom: 2px; }
+        .university { font-size: 11px; margin-bottom: 2px; }
+        .thesis { font-size: 10px; color: #555555; font-style: italic; }
         .cta-button { display: none; }
 
-        .project-item { margin-bottom: 8px; page-break-inside: avoid; }
-        .project-title { font-weight: 700; color: var(--primary-color); font-size: 12px; }
-        .project-description { font-size: 11px; }
+        /* Projects */
+        .project-item {
+            background: #ffffff;
+            border-left: 3px solid var(--primary-color);
+            border-radius: 0 10px 10px 0;
+            padding: 12px 16px;
+            margin-bottom: 10px;
+        }
+        .project-title { font-family: var(--font-display); font-weight: 700; font-size: 12px; color: var(--secondary-color); margin-bottom: 4px; }
+        .project-description { font-size: 11px; line-height: 1.5; margin-bottom: 6px; }
         .tech-tag {
             display: inline-block;
-            padding: 1px 7px;
-            margin: 2px 3px 0 0;
-            border: 1px solid var(--primary-color);
-            color: var(--primary-color);
-            border-radius: 8px;
-            font-size: 9.5px;
+            padding: 2px 9px;
+            margin: 3px 4px 0 0;
+            border: 1px solid var(--accent-color);
+            color: var(--secondary-color);
+            border-radius: 10px;
+            font-size: 9px;
+            font-weight: 500;
         }
 
         @media print {
-            body { margin: 0; padding: 0; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-            .cv-container { margin: 0; padding: 10mm; max-width: none; }
+            body { margin: 0; padding: 0; -webkit-print-color-adjust: exact !important; print-color-adjust: exact !important; }
+            .cv-container { max-width: 100%; margin: 0; }
+
+            .header {
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+                padding: 22px 30px 26px !important;
+                page-break-after: avoid;
+            }
+
+            .section-title {
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+            }
+
+            .section:nth-of-type(even) {
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+            }
+
+            .section { padding: 14px 30px !important; page-break-inside: avoid; }
+            .experience-item, .education-item, .project-item { page-break-inside: avoid; }
+
+            .header h1 { font-size: 19px !important; }
+            .header h2 { font-size: 11px !important; }
+            .brand-logo { width: 80px !important; height: 44px !important; margin-bottom: 10px !important; }
+            .contact-info > span, .contact-info > a { font-size: 8.5px !important; padding: 3px 8px !important; }
+            .section-title { font-size: 10.5px !important; padding: 4px 11px !important; margin-bottom: 10px !important; }
+
+            .job-title { font-size: 11.5px !important; }
+            .job-number { width: 16px !important; height: 16px !important; font-size: 9px !important; }
+            .job-description, .achievement-item { font-size: 9px !important; }
+            .company, .period { font-size: 9.5px !important; }
+            .experience-item { padding: 10px 14px !important; margin-bottom: 10px !important; }
+            .education-item, .project-item { padding: 8px 14px !important; margin-bottom: 8px !important; }
+            .degree, .project-title { font-size: 10.5px !important; }
+            .university, .project-description { font-size: 9.5px !important; }
+            .thesis { font-size: 8.5px !important; }
+            .tool-name { font-size: 9.5px !important; }
+            .tool-percentage { font-size: 8px !important; }
+            #skills-strategic h3, #skills-tools h3, #skills-emerging h3 { font-size: 10px !important; }
+
+            @page { size: A4; margin: 8mm; }
         }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
@@ -99,12 +256,15 @@
 <body>
     <div class="cv-container">
         <header class="header">
+            <div class="brand-logo">
+                <img src="../assets/images/nubank.png" alt="Nubank">
+            </div>
             <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
             <h2 id="cv-role">CRM Management and Data Intelligence</h2>
             <div class="contact-info">
-                <span id="cv-email">pedrohmarconato@gmail.com</span> |
-                <span id="cv-phone">+55 (55) 981147758</span> |
-                <span id="cv-location"><span>Cachoeira do Sul, RS</span></span> |
+                <span id="cv-email">pedrohmarconato@gmail.com</span>
+                <span id="cv-phone">+55 (55) 981147758</span>
+                <span id="cv-location"><span>Cachoeira do Sul, RS</span></span>
                 <a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin">LinkedIn</a>
             </div>
         </header>

--- a/cv_styles/cv_nubank_style_PT.html
+++ b/cv_styles/cv_nubank_style_PT.html
@@ -4,94 +4,251 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pedro Henrique Marconato - CV</title>
+    <meta name="theme-color" content="#820AD1">
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Sora:wght@400;600;700;800&display=swap');
 
         :root {
-            /* Nubank Colors */
-            --primary-color: #820AD1;
-            --secondary-color: #5C08A0;
-            --accent-color: #A64CE8;
-            --text-color: #2c3e50;
-            --border-color: rgba(0, 0, 0, 0.15);
+            /* Nubank Colors — brandbook (docs/nubank_brandbook.md) */
+            --primary-color: #820AD1;   /* Roxo Nu — masterbrand */
+            --secondary-color: #5C08A0; /* Roxo Profundo */
+            --accent-color: #A64CE8;    /* Lilás */
+            --lavender-color: #C89AF2;  /* Lavanda — dots vazios */
+            --mist-color: #F3E9FC;      /* Névoa — fundo alternado de seção */
+            --text-color: #1A1A1A;
+            --border-color: rgba(130, 10, 209, 0.15);
+            --gradient: linear-gradient(135deg, #820AD1 0%, #5C08A0 100%);
+            --font-display: 'Sora', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
         }
 
         * { margin: 0; padding: 0; box-sizing: border-box; }
 
         body {
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            font-family: var(--font-body);
             color: var(--text-color);
-            line-height: 1.5;
-            background: white;
+            line-height: 1.55;
+            background: #ffffff;
             font-size: 12px;
         }
 
-        .cv-container { max-width: 210mm; margin: 0 auto; padding: 14mm; background: white; }
+        .cv-container { max-width: 210mm; margin: 0 auto; background: #ffffff; }
 
-        .header { border-bottom: 3px solid var(--primary-color); padding-bottom: 12px; margin-bottom: 16px; }
-        .header h1 { font-size: 22px; color: var(--primary-color); }
-        .header h2 { font-size: 13px; font-weight: 500; margin-bottom: 6px; }
-        .contact-info { font-size: 11px; }
-        .contact-info a { color: var(--text-color); text-decoration: none; }
-
-        .section { margin-bottom: 14px; }
-        .section-title {
-            font-size: 14px;
-            font-weight: 700;
-            color: var(--primary-color);
-            border-bottom: 1px solid var(--border-color);
-            padding-bottom: 3px;
-            margin-bottom: 8px;
-            text-transform: uppercase;
+        /* Header — hero roxo minimalista */
+        .header {
+            background: var(--gradient);
+            padding: 34px 40px 38px;
+            text-align: center;
         }
 
-        .skills-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 14px; }
-        .tool-item { margin-bottom: 6px; }
-        .tool-name { display: flex; justify-content: space-between; font-weight: 500; font-size: 11px; }
-        .tool-percentage { color: var(--accent-color); font-size: 10px; font-weight: 600; }
-        .dots-container { display: flex; gap: 2px; margin-top: 2px; }
-        .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--border-color); }
+        .brand-logo { width: 100px; height: 55px; margin: 0 auto 14px; }
+        .brand-logo img { width: 100%; height: 100%; object-fit: contain; filter: brightness(0) invert(1); }
+
+        .header h1 {
+            font-family: var(--font-display);
+            font-size: 23px;
+            font-weight: 700;
+            color: #ffffff;
+            letter-spacing: 0.2px;
+            margin-bottom: 6px;
+        }
+
+        .header h2 {
+            font-size: 12.5px;
+            font-weight: 400;
+            color: rgba(255, 255, 255, 0.92);
+            margin-bottom: 16px;
+        }
+
+        .contact-info {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            gap: 8px;
+        }
+
+        .contact-info > span,
+        .contact-info > a {
+            display: inline-block;
+            background: rgba(255, 255, 255, 0.14);
+            border: 1px solid rgba(255, 255, 255, 0.24);
+            color: #ffffff;
+            text-decoration: none;
+            font-size: 10.5px;
+            font-weight: 500;
+            padding: 5px 12px;
+            border-radius: 20px;
+        }
+
+        /* Seções — muito espaço em branco, névoa alternada */
+        .section { padding: 24px 40px; }
+        .section:nth-of-type(even) { background: var(--mist-color); }
+
+        .section-title {
+            display: inline-block;
+            font-family: var(--font-display);
+            background: var(--primary-color);
+            color: #ffffff;
+            font-size: 12px;
+            font-weight: 700;
+            letter-spacing: 0.4px;
+            text-transform: uppercase;
+            padding: 6px 14px;
+            border-radius: 8px;
+            margin-bottom: 14px;
+        }
+
+        #cv-profile { font-size: 11.5px; line-height: 1.65; }
+
+        /* Skills — dots em escala de roxo */
+        .skills-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; }
+
+        #skills-strategic h3,
+        #skills-tools h3,
+        #skills-emerging h3 {
+            font-family: var(--font-display) !important;
+            font-size: 11.5px !important;
+            font-weight: 700 !important;
+            color: var(--secondary-color) !important;
+            text-transform: uppercase;
+            letter-spacing: 0.3px;
+            padding-bottom: 6px;
+            margin-bottom: 10px !important;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .tool-item { margin-bottom: 8px; }
+        .tool-name { display: flex; justify-content: space-between; align-items: baseline; font-size: 10.8px; font-weight: 500; }
+        .tool-percentage { color: var(--accent-color); font-size: 9px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.2px; }
+        .dots-container { display: flex; gap: 3px; margin-top: 3px; }
+        .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--lavender-color); }
         .dot.filled { background: var(--primary-color); }
 
+        /* Experiência — cards limpos, sombra suave */
         .experience-item {
-            padding: 8px 0 8px 14px;
-            border-left: 2px solid var(--primary-color);
-            margin-bottom: 10px;
-            page-break-inside: avoid;
+            background: #ffffff;
+            border-left: 3px solid var(--primary-color);
+            border-radius: 0 10px 10px 0;
+            padding: 14px 18px;
+            margin-bottom: 14px;
+            box-shadow: 0 2px 10px rgba(130, 10, 209, 0.07);
         }
-        .job-title { font-size: 13px; font-weight: 700; color: var(--primary-color); }
-        .job-number { display: none; }
-        .experience-item .company { font-weight: 600; font-size: 12px; }
-        .experience-item .period { font-size: 11px; color: var(--accent-color); margin-bottom: 4px; }
-        .job-description { font-size: 11px; margin-bottom: 6px; }
-        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
-        .achievement-item { display: flex; gap: 6px; font-size: 10.5px; }
-        .achievement-icon { color: var(--primary-color); padding-top: 1px; }
-        .achievement-title { font-weight: 600; }
+
+        .job-title {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-family: var(--font-display);
+            font-size: 13.5px;
+            font-weight: 700;
+            color: var(--secondary-color);
+            margin-bottom: 4px;
+        }
+
+        .job-number {
+            flex-shrink: 0;
+            width: 20px;
+            height: 20px;
+            border-radius: 50%;
+            background: var(--primary-color);
+            color: #ffffff;
+            font-family: var(--font-body);
+            font-size: 10.5px;
+            font-weight: 700;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .company { font-weight: 600; font-size: 11.5px; color: var(--text-color); }
+        .period { font-size: 10.5px; color: var(--accent-color); font-weight: 600; margin-bottom: 6px; }
+        .job-description { font-size: 11px; line-height: 1.55; margin-bottom: 8px; color: var(--text-color); }
+
+        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 8px 16px; }
+        .achievement-item { display: flex; gap: 7px; align-items: flex-start; font-size: 10.3px; }
+        .achievement-icon { flex-shrink: 0; width: 15px; text-align: center; color: var(--primary-color); padding-top: 1px; }
+        .achievement-title { font-weight: 600; color: var(--text-color); }
+        .achievement-description { color: #4a4a4a; line-height: 1.4; }
         .tooltip { display: none; }
 
-        .education-item { margin-bottom: 8px; page-break-inside: avoid; }
-        .degree { font-weight: 700; color: var(--primary-color); font-size: 12px; }
-        .university { font-size: 11px; }
-        .thesis { font-size: 10.5px; }
+        /* Educação */
+        .education-item {
+            background: #ffffff;
+            border-left: 3px solid var(--secondary-color);
+            border-radius: 0 10px 10px 0;
+            padding: 10px 16px;
+            margin-bottom: 10px;
+        }
+        .degree { font-family: var(--font-display); font-weight: 700; font-size: 12px; color: var(--secondary-color); margin-bottom: 2px; }
+        .university { font-size: 11px; margin-bottom: 2px; }
+        .thesis { font-size: 10px; color: #555555; font-style: italic; }
         .cta-button { display: none; }
 
-        .project-item { margin-bottom: 8px; page-break-inside: avoid; }
-        .project-title { font-weight: 700; color: var(--primary-color); font-size: 12px; }
-        .project-description { font-size: 11px; }
+        /* Projetos */
+        .project-item {
+            background: #ffffff;
+            border-left: 3px solid var(--primary-color);
+            border-radius: 0 10px 10px 0;
+            padding: 12px 16px;
+            margin-bottom: 10px;
+        }
+        .project-title { font-family: var(--font-display); font-weight: 700; font-size: 12px; color: var(--secondary-color); margin-bottom: 4px; }
+        .project-description { font-size: 11px; line-height: 1.5; margin-bottom: 6px; }
         .tech-tag {
             display: inline-block;
-            padding: 1px 7px;
-            margin: 2px 3px 0 0;
-            border: 1px solid var(--primary-color);
-            color: var(--primary-color);
-            border-radius: 8px;
-            font-size: 9.5px;
+            padding: 2px 9px;
+            margin: 3px 4px 0 0;
+            border: 1px solid var(--accent-color);
+            color: var(--secondary-color);
+            border-radius: 10px;
+            font-size: 9px;
+            font-weight: 500;
         }
 
         @media print {
-            body { margin: 0; padding: 0; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-            .cv-container { margin: 0; padding: 10mm; max-width: none; }
+            body { margin: 0; padding: 0; -webkit-print-color-adjust: exact !important; print-color-adjust: exact !important; }
+            .cv-container { max-width: 100%; margin: 0; }
+
+            .header {
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+                padding: 22px 30px 26px !important;
+                page-break-after: avoid;
+            }
+
+            .section-title {
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+            }
+
+            .section:nth-of-type(even) {
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+            }
+
+            .section { padding: 14px 30px !important; page-break-inside: avoid; }
+            .experience-item, .education-item, .project-item { page-break-inside: avoid; }
+
+            .header h1 { font-size: 19px !important; }
+            .header h2 { font-size: 11px !important; }
+            .brand-logo { width: 80px !important; height: 44px !important; margin-bottom: 10px !important; }
+            .contact-info > span, .contact-info > a { font-size: 8.5px !important; padding: 3px 8px !important; }
+            .section-title { font-size: 10.5px !important; padding: 4px 11px !important; margin-bottom: 10px !important; }
+
+            .job-title { font-size: 11.5px !important; }
+            .job-number { width: 16px !important; height: 16px !important; font-size: 9px !important; }
+            .job-description, .achievement-item { font-size: 9px !important; }
+            .company, .period { font-size: 9.5px !important; }
+            .experience-item { padding: 10px 14px !important; margin-bottom: 10px !important; }
+            .education-item, .project-item { padding: 8px 14px !important; margin-bottom: 8px !important; }
+            .degree, .project-title { font-size: 10.5px !important; }
+            .university, .project-description { font-size: 9.5px !important; }
+            .thesis { font-size: 8.5px !important; }
+            .tool-name { font-size: 9.5px !important; }
+            .tool-percentage { font-size: 8px !important; }
+            #skills-strategic h3, #skills-tools h3, #skills-emerging h3 { font-size: 10px !important; }
+
+            @page { size: A4; margin: 8mm; }
         }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
@@ -99,12 +256,15 @@
 <body>
     <div class="cv-container">
         <header class="header">
+            <div class="brand-logo">
+                <img src="../assets/images/nubank.png" alt="Nubank">
+            </div>
             <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
             <h2 id="cv-role">Gestão de CRM e Inteligência de Dados</h2>
             <div class="contact-info">
-                <span id="cv-email">pedrohmarconato@gmail.com</span> |
-                <span id="cv-phone">+55 (55) 981147758</span> |
-                <span id="cv-location"><span>Cachoeira do Sul, RS</span></span> |
+                <span id="cv-email">pedrohmarconato@gmail.com</span>
+                <span id="cv-phone">+55 (55) 981147758</span>
+                <span id="cv-location"><span>Cachoeira do Sul, RS</span></span>
                 <a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin">LinkedIn</a>
             </div>
         </header>

--- a/index.html
+++ b/index.html
@@ -847,7 +847,7 @@
   "templates/companies/magalu_pt.html": ["magalu_pt", "magalu_pt.html"],
   "templates/companies/nubank.html": ["nubank", "nu bank", "nu", "nubank.html"],
   "templates/companies/nubank_pt.html": ["nubank_pt", "nubank_pt.html"],
-  "templates/companies/itau.html": ["itau", "itaú", "itau unibanco", "itau.html"],
+  "templates/companies/itau.html": ["itau", "itaú", "ita", "itau unibanco", "itau.html"],
   "templates/companies/itau_pt.html": ["itau_pt", "itaú_pt", "itau_pt.html"],
   "templates/companies/grupo-rbs.html": ["grupo rbs", "grupo-rbs", "rbs", "grupo-rbs.html"],
   "templates/companies/grupo-rbs_pt.html": ["grupo-rbs_pt", "grupo-rbs_pt.html"],


### PR DESCRIPTION
## Bug

Ao clicar em imprimir/gerar PDF em Grupo RBS, Itaú, Nubank ou Magalu, o resultado era o esqueleto genérico de 156 linhas que `create-new-template.py` cria por padrão — sem cor, logo ou fonte da marca — enquanto a página normal já tinha o redesign completo. Parecia "outra página".

## Causa

Ao gerar as 4 marcas, as páginas (`templates/companies/`) foram redesenhadas por completo, mas os estilos de impressão (`cv_styles/`) nunca foram tocados — só o link do botão de imprimir estava correto, o CSS/estrutura visual continuava genérico.

## Correção

Reescrevi os 8 arquivos de impressão (PT+EN × 4 marcas) para levar a identidade visual de cada marca — header com gradiente e logo, tipografia, section-titles, cards de experiência/formação/projetos, skills com dots — **mantendo o conteúdo 100% dinâmico** (nada foi hardcoded; tudo continua vindo de `assets/js/cv-texts.js` pelos mesmos containers/IDs e chamadas de inicialização).

Inclui também a correção do alias de busca "ita" para o Itaú (o campo de busca da home apaga acentos enquanto a pessoa digita — quem digita "Itaú" com o acento real acaba com "ita" no campo, não "itau").

## Verificação

- `validate-project.py`: 0 erros/0 avisos
- As 8 páginas de impressão renderizam 4 experiências / 2 formações / 3 projetos / 16 skills via cv-texts.js (Chrome headless)
- PDF real gerado via `--print-to-pdf` (não só screenshot de tela) e revisado visualmente por marca — cores, logo e tipografia batendo com a página

🤖 Generated with [Claude Code](https://claude.com/claude-code)