### PR TITLE
fix: PDF de impressão vira currículo estático branded (≠ página)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,10 @@ em EN e PT.
 
 - `index.html` — home com busca por empresa (objeto `companyMappings` no próprio arquivo)
 - `templates/companies/[empresa].html` + `[empresa]_pt.html` — páginas por empresa
-- `cv_styles/cv_[empresa]_style_EN.html` + `_PT.html` — versões de impressão
-  (somente sufixos `_EN`/`_PT`; o padrão legado sem sufixo foi extinto)
+- `cv_styles/cv_[empresa]_style_EN.html` + `_PT.html` — versões de impressão (PDF):
+  currículo clássico **estático** e branded, **propositalmente diferente da página**
+  (somente sufixos `_EN`/`_PT`; padrão legado sem sufixo foi extinto). O conteúdo
+  canônico do currículo mora nas bases `cv_boticario_style_{EN,PT}.html`.
 - `assets/js/cv-texts.js` — **fonte única de todo o conteúdo do CV**
   (textos, experiências, skills, projetos, nos dois idiomas). Nunca duplicar.
 - `assets/js/dynamic-favicon.js`, `brands-config.js`, `fallback-script.js`
@@ -21,9 +23,14 @@ em EN e PT.
 1. Leia `REGRAS_PROJETO.md` antes de modificar qualquer coisa.
 2. Novo template: **sempre** via `python create-new-template.py` — nunca copiar
    HTML de outra empresa.
-3. Conteúdo do CV (novo emprego, idade, skills): editar **apenas**
-   `assets/js/cv-texts.js`. Estilos de impressão antigos com conteúdo estático
-   precisam de atualização manual; os gerados atualmente são dinâmicos.
+3. **Página ≠ PDF — dois conteúdos distintos, de propósito.** A *página*
+   (`templates/companies/`) é dinâmica: conteúdo 100% via `assets/js/cv-texts.js`
+   (fonte única da página) — mudou emprego/idade/skill, edite só o cv-texts.js.
+   O *PDF* (`cv_styles/`, botão de impressão) é o **currículo clássico estático**,
+   branded por empresa, com conteúdo vindo da base canônica Boticário — **não** da
+   página. NUNCA gere o PDF espelhando a página (foi o bug corrigido em 2026-07-05).
+   Para mudar o currículo do PDF: editar `cv_boticario_style_{EN,PT}.html` e
+   re-rebrandar as demais empresas.
 4. API de inicialização real: `initializeBasicContent(lang)`,
    `renderSkills(containerId, categoria, lang)`, `renderExperienceTimeline(lang)`,
    `renderEducation(lang)`, `renderProjects(lang)`, `initializeModalTexts(lang)`.

--- a/REGRAS_PROJETO.md
+++ b/REGRAS_PROJETO.md
@@ -36,8 +36,8 @@
 ```
 templates/companies/[empresa].html        (página EN)
 templates/companies/[empresa]_pt.html     (página PT)
-cv_styles/cv_[empresa]_style_EN.html      (impressão EN — dinâmica)
-cv_styles/cv_[empresa]_style_PT.html      (impressão PT — dinâmica)
+cv_styles/cv_[empresa]_style_EN.html      (impressão EN — currículo estático branded)
+cv_styles/cv_[empresa]_style_PT.html      (impressão PT — currículo estático branded)
 ```
 O script também atualiza `assets/js/brands-config.js` e o
 `companyMappings` do `index.html` (sem isso a empresa não aparece na busca da home).
@@ -131,11 +131,12 @@ win.onload = function() { win.print(); }
 
 1. Fonte única: `assets/js/cv-texts.js` (nunca duplicar)
 2. Referência nos templates: `../../assets/js/cv-texts.js`
-3. Referência nos cv_styles dinâmicos: `../assets/js/cv-texts.js`
-4. Todos os IDs básicos e de seção presentes
-5. Ao atualizar o CV (novo emprego, idade etc.), editar **somente** o cv-texts.js;
-   estilos de impressão estáticos antigos precisam ser atualizados manualmente —
-   prefira os dinâmicos gerados pelo script atual
+3. cv-texts.js alimenta **apenas as páginas** (`templates/companies/`); os
+   `cv_styles/` (impressão/PDF) são **estáticos** e NÃO carregam cv-texts.js
+4. Todos os IDs básicos e de seção presentes (nas páginas)
+5. Ao atualizar o CV da **página**, editar **somente** o cv-texts.js. O currículo
+   do **PDF** é conteúdo separado (base canônica `cv_boticario_style_{EN,PT}.html`)
+   — página ≠ PDF, de propósito; nunca faça o PDF espelhar a página
 
 ---
 

--- a/TEMPLATE_PADRAO.md
+++ b/TEMPLATE_PADRAO.md
@@ -26,8 +26,8 @@ O script cria/atualiza automaticamente:
 ```
 templates/companies/[empresa].html        # página EN
 templates/companies/[empresa]_pt.html     # página PT
-cv_styles/cv_[empresa]_style_EN.html      # impressão EN (dinâmica)
-cv_styles/cv_[empresa]_style_PT.html      # impressão PT (dinâmica)
+cv_styles/cv_[empresa]_style_EN.html      # impressão EN (currículo estático branded)
+cv_styles/cv_[empresa]_style_PT.html      # impressão PT (currículo estático branded)
 assets/js/brands-config.js                # cores/gradiente da marca
 index.html                                # companyMappings (busca da home)
 ```
@@ -117,11 +117,15 @@ document.addEventListener('DOMContentLoaded', function() {
 
 ## 🖨️ ESTILO DE IMPRESSÃO (cv_styles)
 
-Os arquivos de impressão gerados são **dinâmicos**: carregam
-`../assets/js/cv-texts.js` e renderizam o conteúdo com as mesmas funções da
-página. Assim, quando o CV muda (novo cargo, nova skill), a impressão de todas
-as empresas atualiza junto — sem retrabalho manual e sem risco de imprimir
-conteúdo desatualizado.
+Os arquivos de impressão são o **currículo clássico ESTÁTICO** (RESUMO DE
+QUALIFICAÇÕES → FORMAÇÃO → EXPERIÊNCIA), branded por empresa — **um documento
+propositalmente diferente da página** (a página é a versão web rica/dinâmica via
+cv-texts.js; o PDF é o currículo tradicional de 1 página). O conteúdo canônico do
+currículo mora em `cv_boticario_style_{EN,PT}.html`; o gerador **rebranda** essa
+base para cada nova empresa (header escuro + cores da marca; logo, fontes e
+tratamentos especiais de header entram na elevação da marca). Para atualizar o
+currículo do PDF, edite a base canônica e re-rebrande — **nunca** faça o PDF
+espelhar a página (foi o bug corrigido em 2026-07-05).
 
 ---
 

--- a/create-new-template.py
+++ b/create-new-template.py
@@ -9,8 +9,8 @@ Uso não-interativo:  python create-new-template.py <Empresa> <#primaria> <#secu
 Arquivos gerados/atualizados para cada empresa:
   templates/companies/<empresa>.html      (página EN)
   templates/companies/<empresa>_pt.html   (página PT)
-  cv_styles/cv_<empresa>_style_EN.html    (impressão EN, dinâmica via cv-texts.js)
-  cv_styles/cv_<empresa>_style_PT.html    (impressão PT, dinâmica via cv-texts.js)
+  cv_styles/cv_<empresa>_style_EN.html    (impressão EN — currículo clássico ESTÁTICO, branded)
+  cv_styles/cv_<empresa>_style_PT.html    (impressão PT — currículo clássico ESTÁTICO, branded)
   assets/js/brands-config.js              (cores/gradiente da marca)
   index.html                              (companyMappings — busca da home)
 """
@@ -428,165 +428,86 @@ PAGE_TEMPLATE = Template('''<!DOCTYPE html>
 </html>
 ''')
 
-# Estilo de impressão DINÂMICO: renderiza o conteúdo a partir do cv-texts.js,
-# então nunca fica desatualizado quando o CV muda.
-PRINT_TEMPLATE = Template('''<!DOCTYPE html>
-<html lang="$lang">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pedro Henrique Marconato - CV</title>
-    <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+# Impressão ESTÁTICA (currículo clássico != página): rebranda o currículo
+# canônico (cv_boticario_style_{EN,PT}.html) aplicando a camada de marca.
+# O conteúdo do currículo mora só na base canônica; a página (dinâmica) e o
+# PDF (estático) são propositalmente dois conteúdos distintos.
 
-        :root {
-            /* $empresa_display Colors */
-            --primary-color: $primary_color;
-            --secondary-color: $secondary_color;
-            --accent-color: $accent_color;
-            --text-color: #2c3e50;
-            --border-color: rgba(0, 0, 0, 0.15);
-        }
+# Âncoras exatas da base canônica (Boticário) usadas na rebrandização.
+_A_TITLE = "<title>Pedro Henrique Marconato - CV</title>"
+_A_IMPORT = ("@import url('https://fonts.googleapis.com/css2?"
+             "family=IBM+Plex+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;"
+             "1,300;1,400;1,500;1,600;1,700&display=swap');")
+_A_BODYFONT = ("font-family: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, "
+               "'Segoe UI', Roboto, sans-serif;")
+_A_SKILLTAG_BG = "            background: rgba(123, 194, 36, 0.15);"
+_A_SKILLTAG_BORDER = "            border: 1px solid rgba(123, 194, 36, 0.3);"
+_A_THEME1 = '<meta name="theme-color" content="#011E38">'
+_A_THEME2 = '<meta name="msapplication-TileColor" content="#011E38">'
+_A_LOGO_CSS = """        .boticario-logo {
+            position: absolute;
+            bottom: 20px;
+            right: 40px;
+            width: 160px;
+            height: auto;
+            opacity: 0.9;
+        }"""
+_A_LOGO_IMG = ('<img src="../assets/images/boticario.svg" alt="O Boticário" '
+               'class="boticario-logo">')
 
-        * { margin: 0; padding: 0; box-sizing: border-box; }
 
-        body {
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            color: var(--text-color);
-            line-height: 1.5;
-            background: white;
-            font-size: 12px;
-        }
+def render_print_scaffold(base, data):
+    """Currículo estático da nova empresa a partir da base canônica.
 
-        .cv-container { max-width: 210mm; margin: 0 auto; padding: 14mm; background: white; }
+    Scaffold: header escuro (gradiente da marca), fonte Inter, SEM logo. A
+    elevação da marca (espelhando uma marca existente) adiciona logo, fontes
+    e tratamentos especiais de header (ex.: hero claro/amarelo)."""
+    primary = data['primary_color']
+    secondary = data['secondary_color']
+    accent = data['accent_color']
+    display = data['empresa_display']
 
-        .header { border-bottom: 3px solid var(--primary-color); padding-bottom: 12px; margin-bottom: 16px; }
-        .header h1 { font-size: 22px; color: var(--primary-color); }
-        .header h2 { font-size: 13px; font-weight: 500; margin-bottom: 6px; }
-        .contact-info { font-size: 11px; }
-        .contact-info a { color: var(--text-color); text-decoration: none; }
+    def repl(t, old, new, tag):
+        if old not in t:
+            raise ValueError(f"base canônica sem âncora '{tag}' — impressão não gerada")
+        return t.replace(old, new, 1)
 
-        .section { margin-bottom: 14px; }
-        .section-title {
-            font-size: 14px;
-            font-weight: 700;
-            color: var(--primary-color);
-            border-bottom: 1px solid var(--border-color);
-            padding-bottom: 3px;
-            margin-bottom: 8px;
-            text-transform: uppercase;
-        }
+    t = base
+    t = repl(t, _A_TITLE,
+             f"<title>Pedro Henrique Marconato - CV ({display})</title>", "title")
+    t = repl(t, _A_IMPORT,
+             "@import url('https://fonts.googleapis.com/css2?"
+             "family=Inter:wght@300;400;500;600;700&display=swap');", "import")
+    root = (
+        "        :root {\n"
+        f"            /* {display} Colors */\n"
+        f"            --primary-color: {primary};\n"
+        f"            --secondary-color: {secondary};\n"
+        f"            --accent-color: {accent};\n"
+        "            --light-accent: #F4F6F9;\n"
+        "            --text-color: #2c3e50;\n"
+        "            --border-color: rgba(0, 0, 0, 0.12);\n"
+        f"            --background-gradient: linear-gradient(135deg, {primary} 0%, {secondary} 100%);\n"
+        "        }"
+    )
+    t2, n = re.subn(r"        :root \{.*?--background-gradient:.*?\n        \}",
+                    lambda m: root, t, count=1, flags=re.S)
+    if n != 1:
+        raise ValueError("base canônica sem âncora ':root' — impressão não gerada")
+    t = t2
+    t = repl(t, _A_BODYFONT,
+             "font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;",
+             "bodyfont")
+    t = repl(t, _A_SKILLTAG_BG, f"            background: {accent}26;", "tagbg")
+    t = repl(t, _A_SKILLTAG_BORDER, f"            border: 1px solid {accent}4D;", "tagborder")
+    t = repl(t, _A_THEME1, f'<meta name="theme-color" content="{primary}">', "theme1")
+    t = repl(t, _A_THEME2, f'<meta name="msapplication-TileColor" content="{primary}">', "theme2")
+    # scaffold sem logo — a elevação da marca insere .brand-logo + <img>
+    t = repl(t, _A_LOGO_CSS,
+             "        /* logo da marca: adicionar .brand-logo na elevação */", "logo_css")
+    t = repl(t, _A_LOGO_IMG, "", "logo_img")
+    return t
 
-        .skills-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 14px; }
-        .tool-item { margin-bottom: 6px; }
-        .tool-name { display: flex; justify-content: space-between; font-weight: 500; font-size: 11px; }
-        .tool-percentage { color: var(--accent-color); font-size: 10px; font-weight: 600; }
-        .dots-container { display: flex; gap: 2px; margin-top: 2px; }
-        .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--border-color); }
-        .dot.filled { background: var(--primary-color); }
-
-        .experience-item {
-            padding: 8px 0 8px 14px;
-            border-left: 2px solid var(--primary-color);
-            margin-bottom: 10px;
-            page-break-inside: avoid;
-        }
-        .job-title { font-size: 13px; font-weight: 700; color: var(--primary-color); }
-        .job-number { display: none; }
-        .experience-item .company { font-weight: 600; font-size: 12px; }
-        .experience-item .period { font-size: 11px; color: var(--accent-color); margin-bottom: 4px; }
-        .job-description { font-size: 11px; margin-bottom: 6px; }
-        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
-        .achievement-item { display: flex; gap: 6px; font-size: 10.5px; }
-        .achievement-icon { color: var(--primary-color); padding-top: 1px; }
-        .achievement-title { font-weight: 600; }
-        .tooltip { display: none; }
-
-        .education-item { margin-bottom: 8px; page-break-inside: avoid; }
-        .degree { font-weight: 700; color: var(--primary-color); font-size: 12px; }
-        .university { font-size: 11px; }
-        .thesis { font-size: 10.5px; }
-        .cta-button { display: none; }
-
-        .project-item { margin-bottom: 8px; page-break-inside: avoid; }
-        .project-title { font-weight: 700; color: var(--primary-color); font-size: 12px; }
-        .project-description { font-size: 11px; }
-        .tech-tag {
-            display: inline-block;
-            padding: 1px 7px;
-            margin: 2px 3px 0 0;
-            border: 1px solid var(--primary-color);
-            color: var(--primary-color);
-            border-radius: 8px;
-            font-size: 9.5px;
-        }
-
-        @media print {
-            body { margin: 0; padding: 0; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-            .cv-container { margin: 0; padding: 10mm; max-width: none; }
-        }
-    </style>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-</head>
-<body>
-    <div class="cv-container">
-        <header class="header">
-            <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
-            <h2 id="cv-role">$role_text</h2>
-            <div class="contact-info">
-                <span id="cv-email">pedrohmarconato@gmail.com</span> |
-                <span id="cv-phone">+55 (55) 981147758</span> |
-                <span id="cv-location"><span>Cachoeira do Sul, RS</span></span> |
-                <a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin">LinkedIn</a>
-            </div>
-        </header>
-
-        <section class="section">
-            <h2 class="section-title" id="section-profile">$profile_title</h2>
-            <p id="cv-profile"></p>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-skills">$skills_title</h2>
-            <div class="skills-grid">
-                <div id="skills-strategic"></div>
-                <div id="skills-tools"></div>
-                <div id="skills-emerging"></div>
-            </div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-experience">$experience_title</h2>
-            <div id="experience-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-education">$education_title</h2>
-            <div id="education-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-projects">$projects_title</h2>
-            <div id="projects-container"></div>
-        </section>
-    </div>
-
-    <script src="../assets/js/cv-texts.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            var lang = '$lang_code';
-            initializeBasicContent(lang);
-            renderSkills('skills-strategic', 'strategic', lang);
-            renderSkills('skills-tools', 'tools', lang);
-            renderSkills('skills-emerging', 'emerging', lang);
-            renderExperienceTimeline(lang);
-            renderEducation(lang);
-            renderProjects(lang);
-        });
-    </script>
-</body>
-</html>
-''')
 
 LANG_CONFIG = {
     'en': {
@@ -685,8 +606,14 @@ class TemplateCreator:
         return file_path
 
     def create_cv_style(self, data, lang):
-        content = PRINT_TEMPLATE.substitute({**data, **LANG_CONFIG[lang]})
-        filename = f"cv_{data['empresa_lower']}_style_{LANG_CONFIG[lang]['lang_upper']}.html"
+        lang_upper = LANG_CONFIG[lang]['lang_upper']
+        base_path = self.cv_styles_dir / f"cv_boticario_style_{lang_upper}.html"
+        if not base_path.exists():
+            raise FileNotFoundError(
+                f"base canônica ausente: {base_path.name} (necessária p/ impressão estática)")
+        base = base_path.read_text(encoding='utf-8')
+        content = render_print_scaffold(base, data)
+        filename = f"cv_{data['empresa_lower']}_style_{lang_upper}.html"
         file_path = self.cv_styles_dir / filename
         file_path.write_text(content, encoding='utf-8')
         return file_path

--- a/cv_styles/cv_accenture_style_EN.html
+++ b/cv_styles/cv_accenture_style_EN.html
@@ -4,340 +4,668 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pedro Henrique Marconato - CV (Accenture)</title>
-    <meta name="theme-color" content="#A100FF">
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
-
+        @import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@300;400;500;600;700&display=swap');
+        
         :root {
-            /* Accenture Colors — brandbook (docs/accenture_brandbook.md) */
-            --primary-color: #A100FF;   /* Accenture Purple — masterbrand */
-            --secondary-color: #460073; /* Deep Violet */
-            --accent-color: #BD00FF;    /* Magenta glow */
-            --lavender-color: #D89CFF;  /* Light violet — empty dots */
-            --mist-color: #F5EEFF;      /* Mist — alternating section background */
+            /* Accenture — brand tokens */
+            --primary-color: #A100FF;
+            --secondary-color: #460073;
+            --accent-color: #BD00FF;
+            --light-accent: #F4ECFF;
             --text-color: #1E1533;
             --border-color: rgba(161, 0, 255, 0.15);
-            --gradient: linear-gradient(135deg, #A100FF 0%, #460073 100%);
-            --font-display: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            --background-gradient: linear-gradient(135deg, #A100FF 0%, #460073 100%);
+
             --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            --font-display: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+
+            --header-text: #ffffff;
+            --header-text-soft: rgba(255, 255, 255, 0.95);
+            --header-chip-bg: rgba(255, 255, 255, 0.15);
+            --header-chip-border: rgba(255, 255, 255, 0.28);
+
+            --tag-bg: rgba(189, 0, 255, 0.14);
+            --tag-border: rgba(189, 0, 255, 0.30);
         }
-
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-
+        
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
         body {
             font-family: var(--font-body);
             color: var(--text-color);
-            line-height: 1.55;
-            background: #ffffff;
-            font-size: 12px;
+            line-height: 1.6;
+            background: var(--light-accent);
+            min-height: 100vh;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
         }
 
-        .cv-container { max-width: 210mm; margin: 0 auto; background: #ffffff; }
-
-        /* Header — minimalist purple hero with a subtle chevron cut */
+        /* Main container */
+        .cv-container {
+            max-width: 210mm;
+            margin: 0 auto;
+            background: rgba(255, 255, 255, 1);
+            overflow: hidden;
+            position: relative;
+        }
+        
+        /* Header Section */
         .header {
-            background: var(--gradient);
-            padding: 34px 40px 38px;
-            text-align: center;
+            background: var(--background-gradient);
+            padding: 50px 50px 55px 50px;
             position: relative;
             overflow: hidden;
         }
-
-        /* O ">" da Accenture — chevron sutil recortado no canto */
-        .header::after {
-            content: ">";
-            position: absolute;
-            right: 18px;
-            bottom: -18px;
-            font-family: var(--font-display);
-            font-size: 120px;
-            font-weight: 700;
-            line-height: 1;
-            color: rgba(255, 255, 255, 0.10);
-            pointer-events: none;
+        
+        .header-content {
+            position: relative;
+            z-index: 1;
         }
 
-        .brand-logo { width: 132px; height: 46px; margin: 0 auto 14px; position: relative; z-index: 2; }
-        .brand-logo img { width: 100%; height: 100%; object-fit: contain; filter: brightness(0) invert(1); }
-
+.brand-logo {
+            position: absolute;
+            bottom: 20px;
+            right: 40px;
+            width: 150px;
+            height: auto;
+            opacity: 0.95;
+            filter: brightness(0) invert(1);
+        }
+        
         .header h1 {
             font-family: var(--font-display);
-            font-size: 23px;
+            font-size: 32px;
             font-weight: 700;
-            color: #ffffff;
-            letter-spacing: 0.2px;
-            margin-bottom: 6px;
-            position: relative;
-            z-index: 2;
+            color: var(--header-text);
+            margin-bottom: 8px;
+            letter-spacing: -0.5px;
+            text-transform: uppercase;
         }
 
-        .header h2 {
-            font-size: 12.5px;
+        .header-tagline {
+            font-size: 17px;
             font-weight: 400;
-            color: rgba(255, 255, 255, 0.92);
-            margin-bottom: 16px;
-            position: relative;
-            z-index: 2;
+            color: var(--header-text-soft);
+            margin-top: 22px;
+            margin-bottom: 28px;
+            font-style: italic;
+            letter-spacing: 0.5px;
         }
-
+        
         .contact-info {
             display: flex;
             flex-wrap: wrap;
-            justify-content: center;
-            gap: 8px;
-            position: relative;
-            z-index: 2;
+            gap: 10px;
+            align-items: center;
+            margin-top: 12px;
         }
-
-        .contact-info > span,
-        .contact-info > a {
-            display: inline-block;
-            background: rgba(255, 255, 255, 0.14);
-            border: 1px solid rgba(255, 255, 255, 0.24);
-            color: #ffffff;
-            text-decoration: none;
-            font-size: 10.5px;
+        
+        .contact-item {
+            display: inline-flex;
+            align-items: center;
+            background: var(--header-chip-bg);
+            border-radius: 10px;
+            padding: 8px 14px;
+            color: var(--header-text);
+            font-size: 12.5px;
             font-weight: 500;
-            padding: 5px 12px;
-            border-radius: 20px;
+            border: 1px solid var(--header-chip-border);
         }
-
-        /* Sections — generous whitespace, alternating mist */
-        .section { padding: 24px 40px; }
-        .section:nth-of-type(even) { background: var(--mist-color); }
-
-        .section-title {
-            display: inline-block;
-            font-family: var(--font-display);
-            background: var(--primary-color);
-            color: #ffffff;
+        
+        .contact-item i {
+            margin-right: 6px;
             font-size: 12px;
-            font-weight: 700;
-            letter-spacing: 0.4px;
-            text-transform: uppercase;
-            padding: 6px 14px;
-            border-radius: 8px;
-            margin-bottom: 14px;
         }
-
-        #cv-profile { font-size: 11.5px; line-height: 1.65; }
-
-        /* Skills — purple dot scale */
-        .skills-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; }
-
-        #skills-strategic h3,
-        #skills-tools h3,
-        #skills-emerging h3 {
-            font-family: var(--font-display) !important;
-            font-size: 11.5px !important;
-            font-weight: 700 !important;
-            color: var(--secondary-color) !important;
-            text-transform: uppercase;
-            letter-spacing: 0.3px;
-            padding-bottom: 6px;
-            margin-bottom: 10px !important;
+        
+        /* Section Styles */
+        .section {
+            padding: 25px 50px;
             border-bottom: 1px solid var(--border-color);
         }
 
-        .tool-item { margin-bottom: 8px; }
-        .tool-name { display: flex; justify-content: space-between; align-items: baseline; font-size: 10.8px; font-weight: 500; }
-        .tool-percentage { color: var(--accent-color); font-size: 9px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.2px; }
-        .dots-container { display: flex; gap: 3px; margin-top: 3px; }
-        .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--lavender-color); }
-        .dot.filled { background: var(--primary-color); }
+        .section:last-child {
+            border-bottom: none;
+        }
 
-        /* Experience — clean cards, soft shadow */
-        .experience-item {
-            background: #ffffff;
-            border-left: 3px solid var(--primary-color);
-            border-radius: 0 10px 10px 0;
-            padding: 14px 18px;
+        .section-title {
+            font-family: var(--font-display);
+            background: var(--primary-color);
+            color: white;
+            font-size: 15px;
+            font-weight: 600;
+            margin-bottom: 18px;
+            padding: 8px 16px;
+            border-radius: 12px;
+            letter-spacing: 0.3px;
+            display: inline-block;
+            text-transform: uppercase;
+        }
+
+        /* Resumo de Qualificações */
+        .qualifications-list {
+            list-style: none;
+            padding: 0;
+        }
+
+        .qualifications-list li {
+            position: relative;
+            padding-left: 28px;
             margin-bottom: 14px;
-            box-shadow: 0 2px 10px rgba(70, 0, 115, 0.07);
+            font-size: 13.5px;
+            line-height: 1.7;
+            color: var(--text-color);
+        }
+
+        .qualifications-list li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+            font-size: 20px;
+            top: -2px;
+        }
+        
+        /* Skills & Tools Grid */
+        .skills-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 20px;
+        }
+
+        .skills-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 16px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
+        }
+
+        .skills-section h3 {
+            font-size: 12px;
+            color: var(--primary-color);
+            margin-bottom: 10px;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .skill-items {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
+
+        .skill-tag {
+            background: var(--tag-bg);
+            color: var(--primary-color);
+            padding: 4px 10px;
+            border-radius: 12px;
+            font-size: 10.5px;
+            font-weight: 500;
+            border: 1px solid var(--tag-border);
+        }
+
+        /* Cursos Complementares */
+        .courses-section {
+            margin-top: 10px;
+        }
+
+        .course-item {
+            padding: 8px 0;
+            border-bottom: 1px solid var(--border-color);
+            font-size: 11px;
+        }
+
+        .course-item:last-child {
+            border-bottom: none;
+        }
+
+        .course-name {
+            color: var(--text-color);
+            font-weight: 500;
+            display: block;
+            margin-bottom: 2px;
+        }
+
+        .course-info {
+            color: var(--secondary-color);
+            font-size: 10px;
+            font-style: italic;
+        }
+        
+        /* Experience Timeline */
+        .experience-timeline {
+            position: relative;
+            margin-left: 20px;
+            padding-left: 30px;
+        }
+        
+        .experience-timeline::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            top: 0;
+            bottom: 0;
+            width: 3px;
+            background: var(--primary-color);
+            border-radius: 3px;
+        }
+
+        .experience-item {
+            margin-bottom: 25px;
+            position: relative;
+            padding: 18px;
+            border-radius: 14px;
+            background: #fff;
+            border: 1px solid var(--border-color);
+        }
+        
+        .experience-item::before {
+            content: "";
+            position: absolute;
+            left: -36px;
+            top: 25px;
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background: var(--accent-color);
+            border: 3px solid white;
+        }
+        
+        .job-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-bottom: 10px;
         }
 
         .job-title {
-            display: flex;
-            align-items: center;
-            gap: 8px;
             font-family: var(--font-display);
-            font-size: 13.5px;
-            font-weight: 700;
-            color: var(--secondary-color);
+            font-weight: 600;
+            font-size: 16px;
+            color: var(--primary-color);
             margin-bottom: 4px;
         }
-
-        .job-number {
-            flex-shrink: 0;
-            width: 20px;
-            height: 20px;
-            border-radius: 50%;
-            background: var(--primary-color);
-            color: #ffffff;
-            font-family: var(--font-body);
-            font-size: 10.5px;
-            font-weight: 700;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .company { font-weight: 600; font-size: 11.5px; color: var(--text-color); }
-        .period { font-size: 10.5px; color: var(--accent-color); font-weight: 600; margin-bottom: 6px; }
-        .job-description { font-size: 11px; line-height: 1.55; margin-bottom: 8px; color: var(--text-color); }
-
-        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 8px 16px; }
-        .achievement-item { display: flex; gap: 7px; align-items: flex-start; font-size: 10.3px; }
-        .achievement-icon { flex-shrink: 0; width: 15px; text-align: center; color: var(--primary-color); padding-top: 1px; }
-        .achievement-title { font-weight: 600; color: var(--text-color); }
-        .achievement-description { color: #4a4a4a; line-height: 1.4; }
-        .tooltip { display: none; }
-
-        /* Education */
-        .education-item {
-            background: #ffffff;
-            border-left: 3px solid var(--secondary-color);
-            border-radius: 0 10px 10px 0;
-            padding: 10px 16px;
-            margin-bottom: 10px;
-        }
-        .degree { font-family: var(--font-display); font-weight: 700; font-size: 12px; color: var(--secondary-color); margin-bottom: 2px; }
-        .university { font-size: 11px; margin-bottom: 2px; }
-        .thesis { font-size: 10px; color: #555555; font-style: italic; }
-        .cta-button { display: none; }
-
-        /* Projects */
-        .project-item {
-            background: #ffffff;
-            border-left: 3px solid var(--primary-color);
-            border-radius: 0 10px 10px 0;
-            padding: 12px 16px;
-            margin-bottom: 10px;
-        }
-        .project-title { font-family: var(--font-display); font-weight: 700; font-size: 12px; color: var(--secondary-color); margin-bottom: 4px; }
-        .project-description { font-size: 11px; line-height: 1.5; margin-bottom: 6px; }
-        .tech-tag {
-            display: inline-block;
-            padding: 2px 9px;
-            margin: 3px 4px 0 0;
-            border: 1px solid var(--accent-color);
-            color: var(--secondary-color);
-            border-radius: 10px;
-            font-size: 9px;
+        
+        .company {
             font-weight: 500;
+            font-size: 13px;
+            color: var(--secondary-color);
+        }
+        
+        .period {
+            font-size: 12px;
+            color: var(--secondary-color);
+            font-weight: 600;
+            text-align: right;
+        }
+        
+        .job-description {
+            font-size: 12px;
+            line-height: 1.6;
+            color: var(--text-color);
+            margin-bottom: 12px;
         }
 
-        @media print {
-            body { margin: 0; padding: 0; -webkit-print-color-adjust: exact !important; print-color-adjust: exact !important; }
-            .cv-container { max-width: 100%; margin: 0; }
+        .job-bullets {
+            list-style: none;
+            padding: 0;
+        }
 
-            .header {
+        .job-bullets li {
+            position: relative;
+            padding-left: 20px;
+            margin-bottom: 8px;
+            font-size: 12px;
+            line-height: 1.5;
+            color: var(--text-color);
+        }
+
+        .job-bullets li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+        }
+        
+        /* Education */
+        .education-tech-container {
+            display: grid;
+            grid-template-columns: 1fr 2fr;
+            gap: 25px;
+        }
+        
+        .education-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 20px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
+        }
+
+        .education-item {
+            margin-bottom: 12px;
+            padding-bottom: 12px;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .education-item:last-child {
+            margin-bottom: 0;
+            padding-bottom: 0;
+            border-bottom: none;
+        }
+        
+        .degree {
+            font-family: var(--font-display);
+            font-weight: 600;
+            font-size: 13px;
+            color: var(--primary-color);
+            margin-bottom: 3px;
+        }
+        
+        .university {
+            font-size: 11px;
+            color: var(--text-color);
+            margin-bottom: 2px;
+        }
+        
+        .edu-period {
+            font-size: 10px;
+            color: var(--secondary-color);
+            font-style: italic;
+        }
+
+        .tech-skills-container {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 15px;
+        }
+
+        /* Languages */
+        .language-container {
+            display: flex;
+            justify-content: center;
+            gap: 30px;
+        }
+
+        .language-item {
+            text-align: center;
+        }
+
+        .language-name {
+            font-weight: 600;
+            color: var(--primary-color);
+            font-size: 13px;
+            margin-bottom: 2px;
+        }
+
+        .language-level {
+            font-size: 11px;
+            color: var(--text-color);
+        }
+
+        /* Print Styles */
+        @media print {
+            body {
+                background: white;
+                margin: 0;
+                padding: 0;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
-                padding: 22px 30px 26px !important;
+            }
+
+            .cv-container {
+                max-width: 100%;
+                margin: 0;
+                box-shadow: none;
+            }
+
+            .header {
+                background: var(--background-gradient) !important;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+                padding: 25px 35px !important;
                 page-break-after: avoid;
             }
 
-            .header::after {
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
-            }
-
             .section-title {
+                background: var(--primary-color) !important;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
+                color: white !important;
+                page-break-after: avoid;
             }
 
-            .section:nth-of-type(even) {
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
+            .section {
+                padding: 15px 35px;
+                page-break-inside: avoid;
             }
 
-            .section { padding: 14px 30px !important; page-break-inside: avoid; }
-            .experience-item, .education-item, .project-item { page-break-inside: avoid; }
+            .experience-item {
+                page-break-inside: avoid;
+            }
 
-            .header h1 { font-size: 19px !important; }
-            .header h2 { font-size: 11px !important; }
-            .brand-logo { width: 108px !important; height: 38px !important; margin-bottom: 10px !important; }
-            .contact-info > span, .contact-info > a { font-size: 8.5px !important; padding: 3px 8px !important; }
-            .section-title { font-size: 10.5px !important; padding: 4px 11px !important; margin-bottom: 10px !important; }
+            /* Hide animations */
+            * {
+                animation: none !important;
+            }
 
-            .job-title { font-size: 11.5px !important; }
-            .job-number { width: 16px !important; height: 16px !important; font-size: 9px !important; }
-            .job-description, .achievement-item { font-size: 9px !important; }
-            .company, .period { font-size: 9.5px !important; }
-            .experience-item { padding: 10px 14px !important; margin-bottom: 10px !important; }
-            .education-item, .project-item { padding: 8px 14px !important; margin-bottom: 8px !important; }
-            .degree, .project-title { font-size: 10.5px !important; }
-            .university, .project-description { font-size: 9.5px !important; }
-            .thesis { font-size: 8.5px !important; }
-            .tool-name { font-size: 9.5px !important; }
-            .tool-percentage { font-size: 8px !important; }
-            #skills-strategic h3, #skills-tools h3, #skills-emerging h3 { font-size: 10px !important; }
-
-            @page { size: A4; margin: 8mm; }
+            @page {
+                size: A4;
+                margin: 8mm;
+            }
         }
+        .contact-info { max-width: calc(100% - 180px); }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <!-- Favicon Meta Tags -->
+    <meta name="theme-color" content="#A100FF">
+    <meta name="msapplication-TileColor" content="#A100FF">
+    <meta name="msapplication-config" content="../assets/favicons/browserconfig.xml">
 </head>
 <body>
     <div class="cv-container">
         <header class="header">
-            <div class="brand-logo">
-                <img src="../assets/images/accenture.svg" alt="Accenture">
-            </div>
-            <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
-            <h2 id="cv-role">CRM Management and Data Intelligence</h2>
-            <div class="contact-info">
-                <span id="cv-email">pedrohmarconato@gmail.com</span>
-                <span id="cv-phone">+55 (55) 981147758</span>
-                <span id="cv-location"><span>Cachoeira do Sul, RS</span></span>
-                <a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin">LinkedIn</a>
+            <div class="header-content">
+                <img src="../assets/images/accenture.svg" alt="Accenture" class="brand-logo">
+                <h1>PEDRO HENRIQUE MARCONATO</h1>
+                
+                <div class="header-tagline">CRM | ANALYTICS | BUSINESS INTELLIGENCE | LTV | SQL</div>
+                
+                <div class="contact-info">
+                    <div class="contact-item">
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-phone"></i> +55 (55) 98114-7758
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-envelope"></i> pedrohmarconato@gmail.com
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fab fa-linkedin"></i> linkedin.com/in/pedrohmarconato
+                    </div>
+                </div>
             </div>
         </header>
-
-        <section class="section">
-            <h2 class="section-title" id="section-profile">Professional Profile</h2>
-            <p id="cv-profile"></p>
+        
+        <section class="section" style="padding-top: 35px;">
+            <h2 class="section-title">PROFESSIONAL SUMMARY</h2>
+            <ul class="qualifications-list">
+                <li>Master's degree in Business Administration, with an Analytics track, combining data intelligence, CRM, analytical visualization, and automation to generate business value</li>
+                <li>Experience in large and highly complex companies, such as Grupo RBS, Realize CFI (Lojas Renner S.A. Group), and Rede Globo, leading strategic projects in CRM, business intelligence, and marketing performance</li>
+                <li>Experience with data applied to marketing, channels, credit, control, and operations, connecting areas and translating technical needs into high-impact analytical solutions</li>
+                <li>Highlights in visualization, segmentation, and consumer behavior projects, with mastery of tools such as Databricks, SQL, Responsys, Power BI, Python, Salesforce, Mailchimp, Tableau, SAS, Mix Agents, and Kanbanize</li>
+                <li>Knowledge in agile methodologies (Scrum, Kanban), working on backlog prioritization, squad structuring, and accelerating delivery with a focus on the customer</li>
+                <li>Experience with data integration from multiple sources, building pipelines, predictive analytics, and behavior mapping to support strategic decisions</li>
+                <li>Differentiator in combining analytical capacity, strategic thinking, and technical knowledge, with recognized performance as leadership even in consultative structures</li>
+                <li>People management, leading multidisciplinary teams with a focus on development, autonomy, and generating consistent results</li>
+            </ul>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-skills">Skills & Tools</h2>
-            <div class="skills-grid">
-                <div id="skills-strategic"></div>
-                <div id="skills-tools"></div>
-                <div id="skills-emerging"></div>
+            <h2 class="section-title">EDUCATION & TECHNOLOGY</h2>
+            <div class="education-tech-container">
+                <div class="education-section">
+                    <h3 style="font-size: 12px; color: var(--primary-color); margin-bottom: 12px; font-weight: 600;">EDUCATION</h3>
+                    <div class="education-item">
+                        <div class="degree">Master's in Business Administration</div>
+                        <div class="university">Federal University of Santa Maria - UFSM</div>
+                        <div class="edu-period">Completed: 2019</div>
+                    </div>
+                    
+                    <div class="education-item">
+                        <div class="degree">Bachelor's in Business Administration</div>
+                        <div class="university">Federal University of Santa Maria - UFSM</div>
+                        <div class="edu-period">Completed: 2015</div>
+                    </div>
+                </div>
+                
+                <div class="tech-skills-container">
+                    <div class="skills-section">
+                        <h3>TOOLS & PLATFORMS</h3>
+                        <div class="skill-items">
+                            <span class="skill-tag">Databricks</span>
+                            <span class="skill-tag">SQL</span>
+                            <span class="skill-tag">Power BI</span>
+                            <span class="skill-tag">Python</span>
+                            <span class="skill-tag">Oracle Responsys</span>
+                            <span class="skill-tag">Kanbanize</span>
+                            <span class="skill-tag">Mailchimp</span>
+                            <span class="skill-tag">Mix Agents</span>
+                            <span class="skill-tag">SAS</span>
+                            <span class="skill-tag">Tableau</span>
+                            <span class="skill-tag">Salesforce CRM</span>
+                        </div>
+                    </div>
+                    
+                    <div class="skills-section">
+                        <h3>CERTIFICATIONS & COURSES</h3>
+                        <div class="courses-section">
+                            <div class="course-item">
+                                <span class="course-name">Statement of Accomplishment - Intermediate R Course</span>
+                                <span class="course-info">Marketing Analytics In Practice - Coursera</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Marketing Analytics in R</span>
+                                <span class="course-info">PPGA - Graduate Program in Business Administration</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Fundamentals of Problem Solving</span>
+                                <span class="course-info">Marketing in a Digital World - Illinois University</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-experience">Professional Experience</h2>
-            <div id="experience-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-education">Education</h2>
-            <div id="education-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-projects">Projects & Innovation</h2>
-            <div id="projects-container"></div>
+            <h2 class="section-title">PROFESSIONAL EXPERIENCE</h2>
+            
+            <div class="experience-timeline">
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">CADASTRA (Digital Marketing and Performance Agency)</div>
+                        </div>
+                        <div class="period">2025-Present</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">Data Analytics Coordinator</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">Sep/2025-Present</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Leading Data Analytics and AI operations for enterprise clients in technology, retail and education sectors, managing multidisciplinary team (DataViz, Data Engineering, Web Analytics)</li>
+                        <li>Simultaneous management of strategic accounts with direct interface to C-level stakeholders and business areas (Performance, E-commerce, Commercial)</li>
+                        <li>Data architecture and governance definition for Business Intelligence, Real-Time Analytics and AI applications projects</li>
+                        <li>Technical diagnosis and restructuring of legacy data environments, including infrastructure migration (AWS→GCP) with projected 40% reduction in processing costs</li>
+                        <li>Data operations restructuring with team expansion (+67%) and scope extension to multiple LATAM business units</li>
+                        <li>Stabilization of critical data environments, achieving 20% savings in operational processing costs (Airflow/DAGs)</li>
+                        <li>Development of automations with n8n and AI Agents (LLMs), including automated Status Report with AI-generated executive summaries</li>
+                        <li>Leadership of first generative AI initiatives in client operations, positioning the area as innovation reference</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">LOJAS RENNER | REALIZE CFI (National Financial Services Company)</div>
+                        </div>
+                        <div class="period">2020-2025</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">CRM Manager</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2021-2025</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for leading the strategic CRM front, focusing on area evolution, customer base growth, and business value generation</li>
+                        <li>Definition and monitoring of area OKRs, connecting business goals to relationship indicators</li>
+                        <li>Planning, execution, and optimization of multichannel relationship campaigns (email, SMS, push, among others), applying intelligent segmentations and automations to increase usage frequency and sales</li>
+                        <li>Building personalized journeys based on customer behavior and profile, promoting lifecycle evolution and loyalty in financial products (cards, loans, insurance, and consumption in the Renner ecosystem)</li>
+                        <li>Management of agile management rhythm (daily, planning, reviews, and retrospectives), using frameworks such as Scrum and Kanban to maintain delivery pace, priority visibility, and impact focus</li>
+                        <li>Area backlog management, with mapping, prioritization, and organization of demands according to incremental value and alignment with the commercial team</li>
+                        <li>Strategic management of suppliers and technology partners, including CRM platforms, automation, and data enrichment, ensuring delivery quality and alignment with area guidelines</li>
+                        <li>Continuous interface with key areas (IT, Products, Analytics, Marketing, Stores, and Commercial), promoting alignment between CRM initiatives and corporate objectives</li>
+                        <li>Technical and operational management of tools such as Oracle Responsys, Databricks, and Power BI, enabling automated segmentations, data processing, and performance dashboards</li>
+                        <li>Monitoring and analysis of KPIs and campaign indicators, using data to guide decisions, validate hypotheses, and promote continuous improvement</li>
+                        <li>Leadership of strategic projects and initiatives to expand the active customer base and activate new communication channels</li>
+                    </ul>
+                    
+                    <div class="job-title" style="margin-top: 15px; margin-bottom: 8px;">Analytics Specialist</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2020-2021</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for creating dashboards and strategic indicators for areas such as Marketing, CRM, Credit, and Channels, delivering an integrated real-time view to support business decisions</li>
+                        <li>Development of segmented databases and automated reports focused on the CRM team, with a focus on efficiency gains, agility in analyses, and revenue generation through more precise actions</li>
+                        <li>Organization and integration of operational, behavioral, and transactional data, consolidating multiple sources into a reliable base for comprehensive customer lifecycle analyses</li>
+                        <li>Practical use of tools such as SQL, BigQuery, Python, and Power BI for exploratory analyses, routine automations, and development of predictive models applied to the business</li>
+                        <li>Close collaboration with Marketing, Products, Risk, and Operations areas, translating strategic needs into applicable analyses, focusing on action direction and decision-making</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Analytics Specialist</div>
+                            <div class="company">DBC COMPANY (National IT Consulting Company)</div>
+                        </div>
+                        <div class="period">2020-2021</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for supporting the strategic restructuring of the CRM area at client Realize, implementing agile methodologies (Kanban) and defining processes that reduced campaign time-to-market and increased operational efficiency</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Business Intelligence Analyst</div>
+                            <div class="company">GRUPO RBS (National Media Company)</div>
+                        </div>
+                        <div class="period">2019 - 2020</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for structuring and analyzing commercial performance, audience, and market behavior data, supporting leadership in strategic decision-making for client Rede Globo</li>
+                        <li>Development of segmentation studies and consumption potential mapping, using data to guide decisions, validate hypotheses, and promote sales and prospecting actions</li>
+                        <li>Creation of real-time analytical reports and dashboards to support business decisions</li>
+                        <li>Direct interface with leadership, translating market data into action plans and growth opportunities</li>
+                        <li>Analysis of KPIs and campaign indicators, using data to guide decisions, validate hypotheses, and promote continuous improvement</li>
+                    </ul>
+                </div>
+            </div>
         </section>
     </div>
-
-    <script src="../assets/js/cv-texts.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            var lang = 'en';
-            initializeBasicContent(lang);
-            renderSkills('skills-strategic', 'strategic', lang);
-            renderSkills('skills-tools', 'tools', lang);
-            renderSkills('skills-emerging', 'emerging', lang);
-            renderExperienceTimeline(lang);
-            renderEducation(lang);
-            renderProjects(lang);
-        });
-    </script>
+    <!-- Dynamic Favicon System -->
+    <script src="../assets/js/dynamic-favicon.js"></script>
 </body>
 </html>

--- a/cv_styles/cv_accenture_style_PT.html
+++ b/cv_styles/cv_accenture_style_PT.html
@@ -4,340 +4,668 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pedro Henrique Marconato - CV (Accenture)</title>
-    <meta name="theme-color" content="#A100FF">
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
-
+        @import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@300;400;500;600;700&display=swap');
+        
         :root {
-            /* Accenture Colors — brandbook (docs/accenture_brandbook.md) */
-            --primary-color: #A100FF;   /* Accenture Purple — masterbrand */
-            --secondary-color: #460073; /* Deep Violet */
-            --accent-color: #BD00FF;    /* Magenta glow */
-            --lavender-color: #D89CFF;  /* Light violet — empty dots */
-            --mist-color: #F5EEFF;      /* Mist — alternating section background */
+            /* Accenture — brand tokens */
+            --primary-color: #A100FF;
+            --secondary-color: #460073;
+            --accent-color: #BD00FF;
+            --light-accent: #F4ECFF;
             --text-color: #1E1533;
             --border-color: rgba(161, 0, 255, 0.15);
-            --gradient: linear-gradient(135deg, #A100FF 0%, #460073 100%);
-            --font-display: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            --background-gradient: linear-gradient(135deg, #A100FF 0%, #460073 100%);
+
             --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            --font-display: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+
+            --header-text: #ffffff;
+            --header-text-soft: rgba(255, 255, 255, 0.95);
+            --header-chip-bg: rgba(255, 255, 255, 0.15);
+            --header-chip-border: rgba(255, 255, 255, 0.28);
+
+            --tag-bg: rgba(189, 0, 255, 0.14);
+            --tag-border: rgba(189, 0, 255, 0.30);
         }
-
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-
+        
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
         body {
             font-family: var(--font-body);
             color: var(--text-color);
-            line-height: 1.55;
-            background: #ffffff;
-            font-size: 12px;
+            line-height: 1.6;
+            background: var(--light-accent);
+            min-height: 100vh;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
         }
 
-        .cv-container { max-width: 210mm; margin: 0 auto; background: #ffffff; }
-
-        /* Header — minimalist purple hero with a subtle chevron cut */
+        /* Main container */
+        .cv-container {
+            max-width: 210mm;
+            margin: 0 auto;
+            background: rgba(255, 255, 255, 1);
+            overflow: hidden;
+            position: relative;
+        }
+        
+        /* Header Section */
         .header {
-            background: var(--gradient);
-            padding: 34px 40px 38px;
-            text-align: center;
+            background: var(--background-gradient);
+            padding: 50px 50px 55px 50px;
             position: relative;
             overflow: hidden;
         }
-
-        /* O ">" da Accenture — chevron sutil recortado no canto */
-        .header::after {
-            content: ">";
-            position: absolute;
-            right: 18px;
-            bottom: -18px;
-            font-family: var(--font-display);
-            font-size: 120px;
-            font-weight: 700;
-            line-height: 1;
-            color: rgba(255, 255, 255, 0.10);
-            pointer-events: none;
+        
+        .header-content {
+            position: relative;
+            z-index: 1;
         }
 
-        .brand-logo { width: 132px; height: 46px; margin: 0 auto 14px; position: relative; z-index: 2; }
-        .brand-logo img { width: 100%; height: 100%; object-fit: contain; filter: brightness(0) invert(1); }
-
+.brand-logo {
+            position: absolute;
+            bottom: 20px;
+            right: 40px;
+            width: 150px;
+            height: auto;
+            opacity: 0.95;
+            filter: brightness(0) invert(1);
+        }
+        
         .header h1 {
             font-family: var(--font-display);
-            font-size: 23px;
+            font-size: 32px;
             font-weight: 700;
-            color: #ffffff;
-            letter-spacing: 0.2px;
-            margin-bottom: 6px;
-            position: relative;
-            z-index: 2;
+            color: var(--header-text);
+            margin-bottom: 8px;
+            letter-spacing: -0.5px;
+            text-transform: uppercase;
         }
 
-        .header h2 {
-            font-size: 12.5px;
+        .header-tagline {
+            font-size: 17px;
             font-weight: 400;
-            color: rgba(255, 255, 255, 0.92);
-            margin-bottom: 16px;
-            position: relative;
-            z-index: 2;
+            color: var(--header-text-soft);
+            margin-top: 22px;
+            margin-bottom: 28px;
+            font-style: italic;
+            letter-spacing: 0.5px;
         }
-
+        
         .contact-info {
             display: flex;
             flex-wrap: wrap;
-            justify-content: center;
-            gap: 8px;
-            position: relative;
-            z-index: 2;
+            gap: 10px;
+            align-items: center;
+            margin-top: 12px;
         }
-
-        .contact-info > span,
-        .contact-info > a {
-            display: inline-block;
-            background: rgba(255, 255, 255, 0.14);
-            border: 1px solid rgba(255, 255, 255, 0.24);
-            color: #ffffff;
-            text-decoration: none;
-            font-size: 10.5px;
+        
+        .contact-item {
+            display: inline-flex;
+            align-items: center;
+            background: var(--header-chip-bg);
+            border-radius: 10px;
+            padding: 8px 14px;
+            color: var(--header-text);
+            font-size: 12.5px;
             font-weight: 500;
-            padding: 5px 12px;
-            border-radius: 20px;
+            border: 1px solid var(--header-chip-border);
         }
-
-        /* Sections — generous whitespace, alternating mist */
-        .section { padding: 24px 40px; }
-        .section:nth-of-type(even) { background: var(--mist-color); }
-
-        .section-title {
-            display: inline-block;
-            font-family: var(--font-display);
-            background: var(--primary-color);
-            color: #ffffff;
+        
+        .contact-item i {
+            margin-right: 6px;
             font-size: 12px;
-            font-weight: 700;
-            letter-spacing: 0.4px;
-            text-transform: uppercase;
-            padding: 6px 14px;
-            border-radius: 8px;
-            margin-bottom: 14px;
         }
-
-        #cv-profile { font-size: 11.5px; line-height: 1.65; }
-
-        /* Skills — purple dot scale */
-        .skills-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; }
-
-        #skills-strategic h3,
-        #skills-tools h3,
-        #skills-emerging h3 {
-            font-family: var(--font-display) !important;
-            font-size: 11.5px !important;
-            font-weight: 700 !important;
-            color: var(--secondary-color) !important;
-            text-transform: uppercase;
-            letter-spacing: 0.3px;
-            padding-bottom: 6px;
-            margin-bottom: 10px !important;
+        
+        /* Section Styles */
+        .section {
+            padding: 25px 50px;
             border-bottom: 1px solid var(--border-color);
         }
 
-        .tool-item { margin-bottom: 8px; }
-        .tool-name { display: flex; justify-content: space-between; align-items: baseline; font-size: 10.8px; font-weight: 500; }
-        .tool-percentage { color: var(--accent-color); font-size: 9px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.2px; }
-        .dots-container { display: flex; gap: 3px; margin-top: 3px; }
-        .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--lavender-color); }
-        .dot.filled { background: var(--primary-color); }
+        .section:last-child {
+            border-bottom: none;
+        }
 
-        /* Experience — clean cards, soft shadow */
-        .experience-item {
-            background: #ffffff;
-            border-left: 3px solid var(--primary-color);
-            border-radius: 0 10px 10px 0;
-            padding: 14px 18px;
+        .section-title {
+            font-family: var(--font-display);
+            background: var(--primary-color);
+            color: white;
+            font-size: 15px;
+            font-weight: 600;
+            margin-bottom: 18px;
+            padding: 8px 16px;
+            border-radius: 12px;
+            letter-spacing: 0.3px;
+            display: inline-block;
+            text-transform: uppercase;
+        }
+
+        /* Resumo de Qualificações */
+        .qualifications-list {
+            list-style: none;
+            padding: 0;
+        }
+
+        .qualifications-list li {
+            position: relative;
+            padding-left: 28px;
             margin-bottom: 14px;
-            box-shadow: 0 2px 10px rgba(70, 0, 115, 0.07);
+            font-size: 13.5px;
+            line-height: 1.7;
+            color: var(--text-color);
+        }
+
+        .qualifications-list li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+            font-size: 20px;
+            top: -2px;
+        }
+        
+        /* Skills & Tools Grid */
+        .skills-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 20px;
+        }
+
+        .skills-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 16px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
+        }
+
+        .skills-section h3 {
+            font-size: 12px;
+            color: var(--primary-color);
+            margin-bottom: 10px;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .skill-items {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
+
+        .skill-tag {
+            background: var(--tag-bg);
+            color: var(--primary-color);
+            padding: 4px 10px;
+            border-radius: 12px;
+            font-size: 10.5px;
+            font-weight: 500;
+            border: 1px solid var(--tag-border);
+        }
+
+        /* Cursos Complementares */
+        .courses-section {
+            margin-top: 10px;
+        }
+
+        .course-item {
+            padding: 8px 0;
+            border-bottom: 1px solid var(--border-color);
+            font-size: 11px;
+        }
+
+        .course-item:last-child {
+            border-bottom: none;
+        }
+
+        .course-name {
+            color: var(--text-color);
+            font-weight: 500;
+            display: block;
+            margin-bottom: 2px;
+        }
+
+        .course-info {
+            color: var(--secondary-color);
+            font-size: 10px;
+            font-style: italic;
+        }
+        
+        /* Experience Timeline */
+        .experience-timeline {
+            position: relative;
+            margin-left: 20px;
+            padding-left: 30px;
+        }
+        
+        .experience-timeline::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            top: 0;
+            bottom: 0;
+            width: 3px;
+            background: var(--primary-color);
+            border-radius: 3px;
+        }
+        
+        .experience-item {
+            margin-bottom: 25px;
+            position: relative;
+            padding: 18px;
+            border-radius: 14px;
+            background: #fff;
+            border: 1px solid var(--border-color);
+        }
+        
+        .experience-item::before {
+            content: "";
+            position: absolute;
+            left: -36px;
+            top: 25px;
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background: var(--accent-color);
+            border: 3px solid white;
+        }
+        
+        .job-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-bottom: 10px;
         }
 
         .job-title {
-            display: flex;
-            align-items: center;
-            gap: 8px;
             font-family: var(--font-display);
-            font-size: 13.5px;
-            font-weight: 700;
-            color: var(--secondary-color);
+            font-weight: 600;
+            font-size: 16px;
+            color: var(--primary-color);
             margin-bottom: 4px;
         }
-
-        .job-number {
-            flex-shrink: 0;
-            width: 20px;
-            height: 20px;
-            border-radius: 50%;
-            background: var(--primary-color);
-            color: #ffffff;
-            font-family: var(--font-body);
-            font-size: 10.5px;
-            font-weight: 700;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .company { font-weight: 600; font-size: 11.5px; color: var(--text-color); }
-        .period { font-size: 10.5px; color: var(--accent-color); font-weight: 600; margin-bottom: 6px; }
-        .job-description { font-size: 11px; line-height: 1.55; margin-bottom: 8px; color: var(--text-color); }
-
-        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 8px 16px; }
-        .achievement-item { display: flex; gap: 7px; align-items: flex-start; font-size: 10.3px; }
-        .achievement-icon { flex-shrink: 0; width: 15px; text-align: center; color: var(--primary-color); padding-top: 1px; }
-        .achievement-title { font-weight: 600; color: var(--text-color); }
-        .achievement-description { color: #4a4a4a; line-height: 1.4; }
-        .tooltip { display: none; }
-
-        /* Education */
-        .education-item {
-            background: #ffffff;
-            border-left: 3px solid var(--secondary-color);
-            border-radius: 0 10px 10px 0;
-            padding: 10px 16px;
-            margin-bottom: 10px;
-        }
-        .degree { font-family: var(--font-display); font-weight: 700; font-size: 12px; color: var(--secondary-color); margin-bottom: 2px; }
-        .university { font-size: 11px; margin-bottom: 2px; }
-        .thesis { font-size: 10px; color: #555555; font-style: italic; }
-        .cta-button { display: none; }
-
-        /* Projects */
-        .project-item {
-            background: #ffffff;
-            border-left: 3px solid var(--primary-color);
-            border-radius: 0 10px 10px 0;
-            padding: 12px 16px;
-            margin-bottom: 10px;
-        }
-        .project-title { font-family: var(--font-display); font-weight: 700; font-size: 12px; color: var(--secondary-color); margin-bottom: 4px; }
-        .project-description { font-size: 11px; line-height: 1.5; margin-bottom: 6px; }
-        .tech-tag {
-            display: inline-block;
-            padding: 2px 9px;
-            margin: 3px 4px 0 0;
-            border: 1px solid var(--accent-color);
-            color: var(--secondary-color);
-            border-radius: 10px;
-            font-size: 9px;
+        
+        .company {
             font-weight: 500;
+            font-size: 13px;
+            color: var(--secondary-color);
+        }
+        
+        .period {
+            font-size: 12px;
+            color: var(--secondary-color);
+            font-weight: 600;
+            text-align: right;
+        }
+        
+        .job-description {
+            font-size: 12px;
+            line-height: 1.6;
+            color: var(--text-color);
+            margin-bottom: 12px;
         }
 
-        @media print {
-            body { margin: 0; padding: 0; -webkit-print-color-adjust: exact !important; print-color-adjust: exact !important; }
-            .cv-container { max-width: 100%; margin: 0; }
+        .job-bullets {
+            list-style: none;
+            padding: 0;
+        }
 
-            .header {
+        .job-bullets li {
+            position: relative;
+            padding-left: 20px;
+            margin-bottom: 8px;
+            font-size: 12px;
+            line-height: 1.5;
+            color: var(--text-color);
+        }
+
+        .job-bullets li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+        }
+        
+        /* Education */
+        .education-tech-container {
+            display: grid;
+            grid-template-columns: 1fr 2fr;
+            gap: 25px;
+        }
+        
+        .education-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 20px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
+        }
+
+        .education-item {
+            margin-bottom: 12px;
+            padding-bottom: 12px;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .education-item:last-child {
+            margin-bottom: 0;
+            padding-bottom: 0;
+            border-bottom: none;
+        }
+        
+        .degree {
+            font-family: var(--font-display);
+            font-weight: 600;
+            font-size: 13px;
+            color: var(--primary-color);
+            margin-bottom: 3px;
+        }
+        
+        .university {
+            font-size: 11px;
+            color: var(--text-color);
+            margin-bottom: 2px;
+        }
+        
+        .edu-period {
+            font-size: 10px;
+            color: var(--secondary-color);
+            font-style: italic;
+        }
+
+        .tech-skills-container {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 15px;
+        }
+
+        /* Languages */
+        .language-container {
+            display: flex;
+            justify-content: center;
+            gap: 30px;
+        }
+
+        .language-item {
+            text-align: center;
+        }
+
+        .language-name {
+            font-weight: 600;
+            color: var(--primary-color);
+            font-size: 13px;
+            margin-bottom: 2px;
+        }
+
+        .language-level {
+            font-size: 11px;
+            color: var(--text-color);
+        }
+
+        /* Print Styles */
+        @media print {
+            body {
+                background: white;
+                margin: 0;
+                padding: 0;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
-                padding: 22px 30px 26px !important;
+            }
+
+            .cv-container {
+                max-width: 100%;
+                margin: 0;
+                box-shadow: none;
+            }
+
+            .header {
+                background: var(--background-gradient) !important;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+                padding: 25px 35px !important;
                 page-break-after: avoid;
             }
 
-            .header::after {
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
-            }
-
             .section-title {
+                background: var(--primary-color) !important;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
+                color: white !important;
+                page-break-after: avoid;
             }
 
-            .section:nth-of-type(even) {
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
+            .section {
+                padding: 15px 35px;
+                page-break-inside: avoid;
             }
 
-            .section { padding: 14px 30px !important; page-break-inside: avoid; }
-            .experience-item, .education-item, .project-item { page-break-inside: avoid; }
+            .experience-item {
+                page-break-inside: avoid;
+            }
 
-            .header h1 { font-size: 19px !important; }
-            .header h2 { font-size: 11px !important; }
-            .brand-logo { width: 108px !important; height: 38px !important; margin-bottom: 10px !important; }
-            .contact-info > span, .contact-info > a { font-size: 8.5px !important; padding: 3px 8px !important; }
-            .section-title { font-size: 10.5px !important; padding: 4px 11px !important; margin-bottom: 10px !important; }
+            /* Hide animations */
+            * {
+                animation: none !important;
+            }
 
-            .job-title { font-size: 11.5px !important; }
-            .job-number { width: 16px !important; height: 16px !important; font-size: 9px !important; }
-            .job-description, .achievement-item { font-size: 9px !important; }
-            .company, .period { font-size: 9.5px !important; }
-            .experience-item { padding: 10px 14px !important; margin-bottom: 10px !important; }
-            .education-item, .project-item { padding: 8px 14px !important; margin-bottom: 8px !important; }
-            .degree, .project-title { font-size: 10.5px !important; }
-            .university, .project-description { font-size: 9.5px !important; }
-            .thesis { font-size: 8.5px !important; }
-            .tool-name { font-size: 9.5px !important; }
-            .tool-percentage { font-size: 8px !important; }
-            #skills-strategic h3, #skills-tools h3, #skills-emerging h3 { font-size: 10px !important; }
-
-            @page { size: A4; margin: 8mm; }
+            @page {
+                size: A4;
+                margin: 8mm;
+            }
         }
+        .contact-info { max-width: calc(100% - 180px); }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <!-- Favicon Meta Tags -->
+    <meta name="theme-color" content="#A100FF">
+    <meta name="msapplication-TileColor" content="#A100FF">
+    <meta name="msapplication-config" content="../assets/favicons/browserconfig.xml">
 </head>
 <body>
     <div class="cv-container">
         <header class="header">
-            <div class="brand-logo">
-                <img src="../assets/images/accenture.svg" alt="Accenture">
-            </div>
-            <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
-            <h2 id="cv-role">CRM Management and Data Intelligence</h2>
-            <div class="contact-info">
-                <span id="cv-email">pedrohmarconato@gmail.com</span>
-                <span id="cv-phone">+55 (55) 981147758</span>
-                <span id="cv-location"><span>Cachoeira do Sul, RS</span></span>
-                <a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin">LinkedIn</a>
+            <div class="header-content">
+                <img src="../assets/images/accenture.svg" alt="Accenture" class="brand-logo">
+                <h1>PEDRO HENRIQUE MARCONATO</h1>
+                
+                <div class="header-tagline">CRM | ANALYTICS | BUSINESS INTELLIGENCE | LTV | SQL</div>
+                
+                <div class="contact-info">
+                    <div class="contact-item">
+                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 35 anos
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-phone"></i> +55 (55) 98114-7758
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-envelope"></i> pedrohmarconato@gmail.com
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fab fa-linkedin"></i> linkedin.com/in/pedrohmarconato
+                    </div>
+                </div>
             </div>
         </header>
-
-        <section class="section">
-            <h2 class="section-title" id="section-profile">Professional Profile</h2>
-            <p id="cv-profile"></p>
+        
+        <section class="section" style="padding-top: 35px;">
+            <h2 class="section-title">RESUMO DE QUALIFICAÇÕES</h2>
+            <ul class="qualifications-list">
+                <li>Mestre em Administração de Empresas, com ênfase na área de Analytics, unindo inteligência de dados, CRM, visualização analítica e automação para gerar valor ao negócio</li>
+                <li>Atuação em empresas de grande porte e alta complexidade, como Grupo RBS, Realize CFI (Grupo Lojas Renner S.A.) e Rede Globo, liderando projetos estratégicos nas frentes de CRM, inteligência comercial e performance de marketing</li>
+                <li>Vivência com dados aplicados a marketing, canais, crédito, controle e operações, conectando áreas e traduzindo necessidades técnicas em soluções analíticas de alto impacto</li>
+                <li>Destaques em projetos de visualização, segmentação e comportamento de consumo, com domínio de ferramentas como Databricks, SQL, Responsys, Power BI, Python, Salesforce, Mailchimp, Tableau, SAS, Mix Agents e Kanbanize</li>
+                <li>Conhecimento em metodologias ágeis (Scrum, Kanban), com atuação na priorização de backlog, estruturação de squads e aceleração de entrega com foco no cliente</li>
+                <li>Experiência com integração de dados de múltiplas fontes, construção de pipelines, análises preditivas e mapeamento de comportamento para suportar decisões estratégicas</li>
+                <li>Diferencial na combinação entre capacidade analítica, pensamento estratégico e conhecimento técnico, com atuação reconhecida como liderança mesmo em estruturas consultivas</li>
+                <li>Gestão de pessoas, liderando times multidisciplinares com foco em desenvolvimento, autonomia e geração de resultados consistentes</li>
+            </ul>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-skills">Skills & Tools</h2>
-            <div class="skills-grid">
-                <div id="skills-strategic"></div>
-                <div id="skills-tools"></div>
-                <div id="skills-emerging"></div>
+            <h2 class="section-title">FORMAÇÃO ACADÊMICA & TECNOLOGIA</h2>
+            <div class="education-tech-container">
+                <div class="education-section">
+                    <h3 style="font-size: 12px; color: var(--primary-color); margin-bottom: 12px; font-weight: 600;">FORMAÇÃO</h3>
+                    <div class="education-item">
+                        <div class="degree">Mestrado em Administração de Empresas</div>
+                        <div class="university">Universidade Federal de Santa Maria - UFSM</div>
+                        <div class="edu-period">Conclusão: 2019</div>
+                    </div>
+                    
+                    <div class="education-item">
+                        <div class="degree">Bacharelado em Administração</div>
+                        <div class="university">Universidade Federal de Santa Maria - UFSM</div>
+                        <div class="edu-period">Conclusão: 2015</div>
+                    </div>
+                </div>
+                
+                <div class="tech-skills-container">
+                    <div class="skills-section">
+                        <h3>FERRAMENTAS & PLATAFORMAS</h3>
+                        <div class="skill-items">
+                            <span class="skill-tag">Databricks</span>
+                            <span class="skill-tag">SQL</span>
+                            <span class="skill-tag">Power BI</span>
+                            <span class="skill-tag">Python</span>
+                            <span class="skill-tag">Oracle Responsys</span>
+                            <span class="skill-tag">Kanbanize</span>
+                            <span class="skill-tag">Mailchimp</span>
+                            <span class="skill-tag">Mix Agents</span>
+                            <span class="skill-tag">SAS</span>
+                            <span class="skill-tag">Tableau</span>
+                            <span class="skill-tag">Salesforce CRM</span>
+                        </div>
+                    </div>
+                    
+                    <div class="skills-section">
+                        <h3>CERTIFICAÇÕES & CURSOS</h3>
+                        <div class="courses-section">
+                            <div class="course-item">
+                                <span class="course-name">Statement of Accomplishment - Intermediate R Course</span>
+                                <span class="course-info">Marketing Analytics In Practice - Coursera</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Marketing Analytics em R</span>
+                                <span class="course-info">PPGA - Programa de Pós-Graduação em Administração</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Fundamentos de Solução de Problemas</span>
+                                <span class="course-info">Marketing in a Digital World - Illinois University</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-experience">Professional Experience</h2>
-            <div id="experience-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-education">Education</h2>
-            <div id="education-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-projects">Projects & Innovation</h2>
-            <div id="projects-container"></div>
+            <h2 class="section-title">EXPERIÊNCIA PROFISSIONAL</h2>
+            
+            <div class="experience-timeline">
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">CADASTRA (Agência de Marketing Digital e Performance)</div>
+                        </div>
+                        <div class="period">2025-Atual</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">Coordenador de Data Analytics</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">Set/2025-Atual</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável pela operação de Data Analytics e AI para clientes de grande porte dos setores de tecnologia, varejo e educação, liderando time multidisciplinar (DataViz, Engenharia de Dados, Web Analytics)</li>
+                        <li>Gestão simultânea de contas estratégicas, com interface direta com stakeholders C-level e áreas de negócio (Performance, E-commerce, Comercial)</li>
+                        <li>Definição de arquitetura de dados e governança para projetos de Business Intelligence, Real-Time Analytics e aplicações de inteligência artificial</li>
+                        <li>Diagnóstico técnico e reestruturação de ambientes de dados legados, incluindo migração de infraestrutura (AWS→GCP) com redução projetada de 40% em custos de processamento</li>
+                        <li>Reestruturação de operações de dados com expansão de time (+67%) e ampliação de escopo para múltiplas unidades de negócio em LATAM</li>
+                        <li>Estabilização de ambientes críticos de dados, alcançando economia de 20% em custos operacionais de processamento (Airflow/DAGs)</li>
+                        <li>Desenvolvimento de automações com n8n e AI Agents (LLMs), incluindo Status Report automatizado com geração de resumos executivos por inteligência artificial</li>
+                        <li>Liderança das primeiras iniciativas de aplicação de IA generativa em operações de clientes, posicionando a área como referência em inovação</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">LOJAS RENNER | REALIZE CFI (Empresa Nacional do segmento Financeiro)</div>
+                        </div>
+                        <div class="period">2020-2025</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">CRM Manager</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2021-2025</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável pela liderança da frente estratégica de CRM, com foco na evolução da área, crescimento da base de clientes e geração de valor ao negócio</li>
+                        <li>Definição e acompanhamento dos OKRs da área, conectando metas do negócio a indicadores de relacionamento</li>
+                        <li>Planejamento, execução e otimização de campanhas de relacionamento multicanal (e-mail, SMS, push, entre outros), aplicando segmentações inteligentes e automações para aumentar frequência de uso e vendas</li>
+                        <li>Construção de jornadas personalizadas com base em comportamento e perfil dos clientes, promovendo a evolução do ciclo de vida e fidelização em produtos financeiros (cartões, empréstimos, seguros e consumo no ecossistema Renner)</li>
+                        <li>Gestão do ritmo de gestão ágil (daily, planning, reviews e retrospectives), utilizando frameworks como Scrum e Kanban para manter ritmo de entrega, visibilidade de prioridades e foco em impacto</li>
+                        <li>Gestão do backlog da área, com mapeamento, priorização e organização das demandas de acordo com o valor incremental e alinhamento com o time comercial</li>
+                        <li>Gestão estratégica de fornecedores e parceiros de tecnologia, incluindo plataformas de CRM, automação e enriquecimento de dados, garantindo qualidade das entregas e alinhamento às diretrizes da área</li>
+                        <li>Interface contínua com áreas-chave (TI, Produtos, Analytics, Marketing, Lojas e Comercial), promovendo alinhamento entre as iniciativas de CRM e os objetivos corporativos</li>
+                        <li>Gestão técnica e operacional de ferramentas como Oracle Responsys, Databricks e Power BI, viabilizando segmentações automatizadas, tratamento de dados e dashboards de performance</li>
+                        <li>Monitoramento e análise de KPIs e indicadores de campanhas, utilizando dados para orientar decisões, validar hipóteses e promover a melhoria contínua</li>
+                        <li>Liderança de projetos e iniciativas estratégicas de expansão da base ativa de clientes e ativação de novos canais de comunicação</li>
+                    </ul>
+                    
+                    <div class="job-title" style="margin-top: 15px; margin-bottom: 8px;">Especialista de Analytics</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2020-2021</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável por criar dashboards e indicadores estratégicos para áreas como Marketing, CRM, Crédito e Canais, entregando uma visão integrada e em tempo real para apoiar decisões de negócio</li>
+                        <li>Desenvolvimento de bases segmentadas e relatórios automatizados voltados ao time de CRM, com foco em ganho de eficiência, agilidade nas análises e geração de receita por meio de ações mais precisas</li>
+                        <li>Organização e integração de dados operacionais, comportamentais e transacionais, consolidando múltiplas fontes em uma base confiável para análises completas do ciclo de vida do cliente</li>
+                        <li>Utilização prática de ferramentas como SQL, BigQuery, Python e Power BI para análises exploratórias, automações de rotinas e desenvolvimento de modelos preditivos aplicados ao negócio</li>
+                        <li>Atuação próxima às áreas de Marketing, Produtos, Riscos e Operações, traduzindo necessidades estratégicas em análises aplicáveis, com foco em direcionamento de ações e tomada de decisão</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Especialista de Analytics</div>
+                            <div class="company">DBC COMPANY (Empresa Nacional do segmento de Consultoria em TI)</div>
+                        </div>
+                        <div class="period">2020-2021</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável por apoiar a reestruturação estratégica da área de CRM no cliente Realize, implementando metodologias ágeis (Kanban) e definindo processos que reduziram o time-to-market das campanhas e aumentaram a eficiência operacional</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Analista de Inteligência Comercial</div>
+                            <div class="company">GRUPO RBS (Empresa Nacional do segmento de Mídia)</div>
+                        </div>
+                        <div class="period">2019 - 2020</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável pela estruturação e análise dados de desempenho comercial, audiência e comportamento de mercado, apoiando a liderança na tomada de decisões estratégicas do cliente Rede Globo</li>
+                        <li>Desenvolvimento de estudos de segmentação e mapeamento de potencial de consumo, utilizando dados para orientar decisões, validar hipóteses e promover ações de vendas e prospecção</li>
+                        <li>Criação de relatórios e dashboards analíticos em tempo real para apoiar decisões do negócio</li>
+                        <li>Interface direta com a liderança, traduzindo dados de mercado em planos de ação e oportunidades de crescimento</li>
+                        <li>Análise de KPIs e indicadores de campanhas, utilizando dados para orientar decisões, validar hipóteses e promover a melhoria contínua</li>
+                    </ul>
+                </div>
+            </div>
         </section>
     </div>
-
-    <script src="../assets/js/cv-texts.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            var lang = 'pt';
-            initializeBasicContent(lang);
-            renderSkills('skills-strategic', 'strategic', lang);
-            renderSkills('skills-tools', 'tools', lang);
-            renderSkills('skills-emerging', 'emerging', lang);
-            renderExperienceTimeline(lang);
-            renderEducation(lang);
-            renderProjects(lang);
-        });
-    </script>
+    <!-- Dynamic Favicon System -->
+    <script src="../assets/js/dynamic-favicon.js"></script>
 </body>
 </html>

--- a/cv_styles/cv_google_style_EN.html
+++ b/cv_styles/cv_google_style_EN.html
@@ -3,334 +3,669 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pedro Henrique Marconato - CV</title>
-    <meta name="theme-color" content="#4285F4">
+    <title>Pedro Henrique Marconato - CV (Google)</title>
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@500;600;700&family=Roboto:wght@300;400;500;700&display=swap');
-
+        @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=Roboto:wght@300;400;500;700&display=swap');
+        
         :root {
-            /* Google Colors — brandbook (docs/google_brandbook.md) */
-            --google-blue: #4285F4;     /* Blue */
-            --google-red: #EA4335;      /* Red */
-            --google-yellow: #FBBC05;   /* Yellow */
-            --google-green: #34A853;    /* Green */
-            --primary-color: #4285F4;   /* Blue — primary */
-            --secondary-color: #1A73E8; /* Deep Blue */
-            --accent-color: #EA4335;    /* Red — accent */
-            --ink: #202124;             /* Grey-900 — text */
-            --grey: #5F6368;            /* Grey-700 — subtext */
+            /* Google — brand tokens */
+            --primary-color: #4285F4;
+            --secondary-color: #1A73E8;
+            --accent-color: #EA4335;
+            --light-accent: #F1F6FF;
             --text-color: #202124;
-            --section-alt: #F8F9FA;     /* Very light grey — alternating sections */
-            --border-color: #DADCE0;    /* Hairline border */
-            --line-color: #E8EAED;      /* Softer line */
-            --four-color: linear-gradient(90deg, #4285F4 0%, #EA4335 33%, #FBBC05 66%, #34A853 100%);
-            --font-display: 'Poppins', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            --border-color: #DADCE0;
+            --background-gradient: linear-gradient(135deg, #FFFFFF 0%, #F1F6FF 100%);
+
             --font-body: 'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
+            --font-display: 'Poppins', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+
+            --header-text: #202124;
+            --header-text-soft: #5f6368;
+            --header-chip-bg: #F1F3F4;
+            --header-chip-border: #DADCE0;
+
+            --tag-bg: rgba(66, 133, 244, 0.10);
+            --tag-border: rgba(66, 133, 244, 0.28);
         }
-
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-
+        
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
         body {
             font-family: var(--font-body);
             color: var(--text-color);
-            line-height: 1.55;
-            background: #ffffff;
-            font-size: 12px;
+            line-height: 1.6;
+            background: var(--light-accent);
+            min-height: 100vh;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
         }
 
-        .cv-container { max-width: 210mm; margin: 0 auto; background: #ffffff; }
-
-        /* Header — white hero, dark text, natural logo, 4-color top border */
+        /* Main container */
+        .cv-container {
+            max-width: 210mm;
+            margin: 0 auto;
+            background: rgba(255, 255, 255, 1);
+            overflow: hidden;
+            position: relative;
+        }
+        
+        /* Header Section */
         .header {
-            background: #ffffff;
-            border-top: 4px solid transparent;
-            border-image: var(--four-color) 1;
-            border-bottom: 1px solid var(--line-color);
-            padding: 30px 40px 30px;
-            text-align: center;
+            background: var(--background-gradient);
+            padding: 50px 50px 55px 50px;
+            position: relative;
+            overflow: hidden;
+        }
+        
+        .header-content {
+            position: relative;
+            z-index: 1;
         }
 
-        .brand-logo { width: 116px; height: 46px; margin: 0 auto 14px; }
-        .brand-logo img { width: 100%; height: 100%; object-fit: contain; }
-
+.brand-logo {
+            position: absolute;
+            bottom: 20px;
+            right: 40px;
+            width: 132px;
+            height: auto;
+            opacity: 1;
+        }
+        
         .header h1 {
             font-family: var(--font-display);
-            font-size: 23px;
+            font-size: 32px;
             font-weight: 700;
-            color: var(--ink);
-            letter-spacing: 0.2px;
-            margin-bottom: 6px;
+            color: var(--header-text);
+            margin-bottom: 8px;
+            letter-spacing: -0.5px;
+            text-transform: uppercase;
         }
 
-        .header h2 {
-            font-size: 12.5px;
+        .header-tagline {
+            font-size: 17px;
             font-weight: 400;
-            color: var(--grey);
-            margin-bottom: 16px;
+            color: var(--header-text-soft);
+            margin-top: 22px;
+            margin-bottom: 28px;
+            font-style: italic;
+            letter-spacing: 0.5px;
         }
-
+        
         .contact-info {
             display: flex;
             flex-wrap: wrap;
-            justify-content: center;
-            gap: 8px;
+            gap: 10px;
+            align-items: center;
+            margin-top: 12px;
         }
-
-        .contact-info > span,
-        .contact-info > a {
-            display: inline-block;
-            background: var(--section-alt);
-            border: 1px solid var(--border-color);
-            color: #3C4043;
-            text-decoration: none;
-            font-size: 10.5px;
+        
+        .contact-item {
+            display: inline-flex;
+            align-items: center;
+            background: var(--header-chip-bg);
+            border-radius: 10px;
+            padding: 8px 14px;
+            color: var(--header-text);
+            font-size: 12.5px;
             font-weight: 500;
-            padding: 5px 12px;
-            border-radius: 20px;
+            border: 1px solid var(--header-chip-border);
         }
-
-        /* Sections — generous whitespace, alternating light grey */
-        .section { padding: 24px 40px; }
-        .section:nth-of-type(even) { background: var(--section-alt); }
-
-        /* Section title — blue text + bottom border (clean, saves ink) */
-        .section-title {
-            display: inline-block;
-            font-family: var(--font-display);
-            color: var(--primary-color);
-            font-size: 13px;
-            font-weight: 700;
-            letter-spacing: 0.4px;
-            text-transform: uppercase;
-            padding-bottom: 5px;
-            margin-bottom: 14px;
-            border-bottom: 2px solid var(--primary-color);
+        
+        .contact-item i {
+            margin-right: 6px;
+            font-size: 12px;
         }
-
-        #cv-profile { font-size: 11.5px; line-height: 1.65; }
-
-        /* Skills — blue dot scale */
-        .skills-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; }
-
-        #skills-strategic h3,
-        #skills-tools h3,
-        #skills-emerging h3 {
-            font-family: var(--font-display) !important;
-            font-size: 11.5px !important;
-            font-weight: 700 !important;
-            color: var(--secondary-color) !important;
-            text-transform: uppercase;
-            letter-spacing: 0.3px;
-            padding-bottom: 6px;
-            margin-bottom: 10px !important;
+        
+        /* Section Styles */
+        .section {
+            padding: 25px 50px;
             border-bottom: 1px solid var(--border-color);
         }
 
-        .tool-item { margin-bottom: 8px; }
-        .tool-name { display: flex; justify-content: space-between; align-items: baseline; font-size: 10.8px; font-weight: 500; }
-        .tool-percentage { color: var(--google-blue); font-size: 9px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.2px; }
-        .dots-container { display: flex; gap: 3px; margin-top: 3px; }
-        .dot { width: 7px; height: 7px; border-radius: 50%; background: #DADCE0; }
-        .dot.filled { background: var(--google-blue); }
+        .section:last-child {
+            border-bottom: none;
+        }
 
-        /* Experience — clean cards, soft shadow */
-        .experience-item {
-            background: #ffffff;
-            border-left: 3px solid var(--google-blue);
-            border-radius: 0 10px 10px 0;
-            padding: 14px 18px;
+        .section-title {
+            font-family: var(--font-display);
+            background: var(--primary-color);
+            color: white;
+            font-size: 15px;
+            font-weight: 600;
+            margin-bottom: 18px;
+            padding: 8px 16px;
+            border-radius: 12px;
+            letter-spacing: 0.3px;
+            display: inline-block;
+            text-transform: uppercase;
+        }
+
+        /* Resumo de Qualificações */
+        .qualifications-list {
+            list-style: none;
+            padding: 0;
+        }
+
+        .qualifications-list li {
+            position: relative;
+            padding-left: 28px;
             margin-bottom: 14px;
-            box-shadow: 0 2px 10px rgba(60, 64, 67, 0.07);
+            font-size: 13.5px;
+            line-height: 1.7;
+            color: var(--text-color);
+        }
+
+        .qualifications-list li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+            font-size: 20px;
+            top: -2px;
+        }
+        
+        /* Skills & Tools Grid */
+        .skills-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 20px;
+        }
+
+        .skills-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 16px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
+        }
+
+        .skills-section h3 {
+            font-size: 12px;
+            color: var(--primary-color);
+            margin-bottom: 10px;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .skill-items {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
+
+        .skill-tag {
+            background: var(--tag-bg);
+            color: var(--primary-color);
+            padding: 4px 10px;
+            border-radius: 12px;
+            font-size: 10.5px;
+            font-weight: 500;
+            border: 1px solid var(--tag-border);
+        }
+
+        /* Cursos Complementares */
+        .courses-section {
+            margin-top: 10px;
+        }
+
+        .course-item {
+            padding: 8px 0;
+            border-bottom: 1px solid var(--border-color);
+            font-size: 11px;
+        }
+
+        .course-item:last-child {
+            border-bottom: none;
+        }
+
+        .course-name {
+            color: var(--text-color);
+            font-weight: 500;
+            display: block;
+            margin-bottom: 2px;
+        }
+
+        .course-info {
+            color: var(--secondary-color);
+            font-size: 10px;
+            font-style: italic;
+        }
+        
+        /* Experience Timeline */
+        .experience-timeline {
+            position: relative;
+            margin-left: 20px;
+            padding-left: 30px;
+        }
+        
+        .experience-timeline::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            top: 0;
+            bottom: 0;
+            width: 3px;
+            background: var(--primary-color);
+            border-radius: 3px;
+        }
+
+        .experience-item {
+            margin-bottom: 25px;
+            position: relative;
+            padding: 18px;
+            border-radius: 14px;
+            background: #fff;
+            border: 1px solid var(--border-color);
+        }
+        
+        .experience-item::before {
+            content: "";
+            position: absolute;
+            left: -36px;
+            top: 25px;
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background: var(--accent-color);
+            border: 3px solid white;
+        }
+        
+        .job-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-bottom: 10px;
         }
 
         .job-title {
-            display: flex;
-            align-items: center;
-            gap: 8px;
             font-family: var(--font-display);
-            font-size: 13.5px;
-            font-weight: 700;
-            color: var(--ink);
+            font-weight: 600;
+            font-size: 16px;
+            color: var(--primary-color);
             margin-bottom: 4px;
         }
-
-        .job-number {
-            flex-shrink: 0;
-            width: 20px;
-            height: 20px;
-            border-radius: 50%;
-            background: var(--google-blue);
-            color: #ffffff;
-            font-family: var(--font-body);
-            font-size: 10.5px;
-            font-weight: 700;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .company { font-weight: 600; font-size: 11.5px; color: var(--google-blue); }
-        .period { font-size: 10.5px; color: var(--grey); font-weight: 600; margin-bottom: 6px; }
-        .job-description { font-size: 11px; line-height: 1.55; margin-bottom: 8px; color: var(--text-color); }
-
-        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 8px 16px; }
-        .achievement-item { display: flex; gap: 7px; align-items: flex-start; font-size: 10.3px; }
-        .achievement-icon { flex-shrink: 0; width: 15px; text-align: center; color: var(--google-blue); padding-top: 1px; }
-        .achievement-title { font-weight: 600; color: var(--ink); }
-        .achievement-description { color: #4a4a4a; line-height: 1.4; }
-        .tooltip { display: none; }
-
-        /* Education */
-        .education-item {
-            background: #ffffff;
-            border-left: 3px solid var(--secondary-color);
-            border-radius: 0 10px 10px 0;
-            padding: 10px 16px;
-            margin-bottom: 10px;
-        }
-        .degree { font-family: var(--font-display); font-weight: 700; font-size: 12px; color: var(--ink); margin-bottom: 2px; }
-        .university { font-size: 11px; color: var(--google-blue); margin-bottom: 2px; }
-        .thesis { font-size: 10px; color: #555555; font-style: italic; }
-        .cta-button { display: none; }
-
-        /* Projects */
-        .project-item {
-            background: #ffffff;
-            border-left: 3px solid var(--google-green);
-            border-radius: 0 10px 10px 0;
-            padding: 12px 16px;
-            margin-bottom: 10px;
-        }
-        .project-title { font-family: var(--font-display); font-weight: 700; font-size: 12px; color: var(--ink); margin-bottom: 4px; }
-        .project-description { font-size: 11px; line-height: 1.5; margin-bottom: 6px; }
-        .tech-tag {
-            display: inline-block;
-            padding: 2px 9px;
-            margin: 3px 4px 0 0;
-            background: var(--section-alt);
-            border: 1px solid var(--border-color);
-            color: var(--google-blue);
-            border-radius: 10px;
-            font-size: 9px;
+        
+        .company {
             font-weight: 500;
+            font-size: 13px;
+            color: var(--secondary-color);
+        }
+        
+        .period {
+            font-size: 12px;
+            color: var(--secondary-color);
+            font-weight: 600;
+            text-align: right;
+        }
+        
+        .job-description {
+            font-size: 12px;
+            line-height: 1.6;
+            color: var(--text-color);
+            margin-bottom: 12px;
         }
 
-        @media print {
-            body { margin: 0; padding: 0; -webkit-print-color-adjust: exact !important; print-color-adjust: exact !important; }
-            .cv-container { max-width: 100%; margin: 0; }
+        .job-bullets {
+            list-style: none;
+            padding: 0;
+        }
 
-            .header {
+        .job-bullets li {
+            position: relative;
+            padding-left: 20px;
+            margin-bottom: 8px;
+            font-size: 12px;
+            line-height: 1.5;
+            color: var(--text-color);
+        }
+
+        .job-bullets li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+        }
+        
+        /* Education */
+        .education-tech-container {
+            display: grid;
+            grid-template-columns: 1fr 2fr;
+            gap: 25px;
+        }
+        
+        .education-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 20px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
+        }
+
+        .education-item {
+            margin-bottom: 12px;
+            padding-bottom: 12px;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .education-item:last-child {
+            margin-bottom: 0;
+            padding-bottom: 0;
+            border-bottom: none;
+        }
+        
+        .degree {
+            font-family: var(--font-display);
+            font-weight: 600;
+            font-size: 13px;
+            color: var(--primary-color);
+            margin-bottom: 3px;
+        }
+        
+        .university {
+            font-size: 11px;
+            color: var(--text-color);
+            margin-bottom: 2px;
+        }
+        
+        .edu-period {
+            font-size: 10px;
+            color: var(--secondary-color);
+            font-style: italic;
+        }
+
+        .tech-skills-container {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 15px;
+        }
+
+        /* Languages */
+        .language-container {
+            display: flex;
+            justify-content: center;
+            gap: 30px;
+        }
+
+        .language-item {
+            text-align: center;
+        }
+
+        .language-name {
+            font-weight: 600;
+            color: var(--primary-color);
+            font-size: 13px;
+            margin-bottom: 2px;
+        }
+
+        .language-level {
+            font-size: 11px;
+            color: var(--text-color);
+        }
+
+        /* Print Styles */
+        @media print {
+            body {
+                background: white;
+                margin: 0;
+                padding: 0;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
-                padding: 22px 30px 22px !important;
+            }
+
+            .cv-container {
+                max-width: 100%;
+                margin: 0;
+                box-shadow: none;
+            }
+
+            .header {
+                background: var(--background-gradient) !important;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+                padding: 25px 35px !important;
                 page-break-after: avoid;
             }
 
-            .brand-logo img {
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
-            }
-
             .section-title {
+                background: var(--primary-color) !important;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
+                color: white !important;
+                page-break-after: avoid;
             }
 
-            .section:nth-of-type(even) {
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
+            .section {
+                padding: 15px 35px;
+                page-break-inside: avoid;
             }
 
-            .job-number, .dot.filled, .experience-item, .education-item, .project-item, .tech-tag {
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
+            .experience-item {
+                page-break-inside: avoid;
             }
 
-            .section { padding: 14px 30px !important; page-break-inside: avoid; }
-            .experience-item, .education-item, .project-item { page-break-inside: avoid; }
+            /* Hide animations */
+            * {
+                animation: none !important;
+            }
 
-            .header h1 { font-size: 19px !important; }
-            .header h2 { font-size: 11px !important; }
-            .brand-logo { width: 96px !important; height: 38px !important; margin-bottom: 10px !important; }
-            .contact-info > span, .contact-info > a { font-size: 8.5px !important; padding: 3px 8px !important; }
-            .section-title { font-size: 11px !important; margin-bottom: 10px !important; }
-
-            .job-title { font-size: 11.5px !important; }
-            .job-number { width: 16px !important; height: 16px !important; font-size: 9px !important; }
-            .job-description, .achievement-item { font-size: 9px !important; }
-            .company, .period { font-size: 9.5px !important; }
-            .experience-item { padding: 10px 14px !important; margin-bottom: 10px !important; }
-            .education-item, .project-item { padding: 8px 14px !important; margin-bottom: 8px !important; }
-            .degree, .project-title { font-size: 10.5px !important; }
-            .university, .project-description { font-size: 9.5px !important; }
-            .thesis { font-size: 8.5px !important; }
-            .tool-name { font-size: 9.5px !important; }
-            .tool-percentage { font-size: 8px !important; }
-            #skills-strategic h3, #skills-tools h3, #skills-emerging h3 { font-size: 10px !important; }
-
-            @page { size: A4; margin: 8mm; }
+            @page {
+                size: A4;
+                margin: 8mm;
+            }
         }
+        .contact-info { max-width: calc(100% - 180px); }
+        .header { border-bottom: 3px solid var(--primary-color); }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <!-- Favicon Meta Tags -->
+    <meta name="theme-color" content="#4285F4">
+    <meta name="msapplication-TileColor" content="#4285F4">
+    <meta name="msapplication-config" content="../assets/favicons/browserconfig.xml">
 </head>
 <body>
     <div class="cv-container">
         <header class="header">
-            <div class="brand-logo">
-                <img src="../assets/images/google.png" alt="Google">
-            </div>
-            <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
-            <h2 id="cv-role">CRM Management and Data Intelligence</h2>
-            <div class="contact-info">
-                <span id="cv-email">pedrohmarconato@gmail.com</span>
-                <span id="cv-phone">+55 (55) 981147758</span>
-                <span id="cv-location"><span>Cachoeira do Sul, RS</span></span>
-                <a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin">LinkedIn</a>
+            <div class="header-content">
+                <img src="../assets/images/google.png" alt="Google" class="brand-logo">
+                <h1>PEDRO HENRIQUE MARCONATO</h1>
+                
+                <div class="header-tagline">CRM | ANALYTICS | BUSINESS INTELLIGENCE | LTV | SQL</div>
+                
+                <div class="contact-info">
+                    <div class="contact-item">
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-phone"></i> +55 (55) 98114-7758
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-envelope"></i> pedrohmarconato@gmail.com
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fab fa-linkedin"></i> linkedin.com/in/pedrohmarconato
+                    </div>
+                </div>
             </div>
         </header>
-
-        <section class="section">
-            <h2 class="section-title" id="section-profile">Professional Profile</h2>
-            <p id="cv-profile"></p>
+        
+        <section class="section" style="padding-top: 35px;">
+            <h2 class="section-title">PROFESSIONAL SUMMARY</h2>
+            <ul class="qualifications-list">
+                <li>Master's degree in Business Administration, with an Analytics track, combining data intelligence, CRM, analytical visualization, and automation to generate business value</li>
+                <li>Experience in large and highly complex companies, such as Grupo RBS, Realize CFI (Lojas Renner S.A. Group), and Rede Globo, leading strategic projects in CRM, business intelligence, and marketing performance</li>
+                <li>Experience with data applied to marketing, channels, credit, control, and operations, connecting areas and translating technical needs into high-impact analytical solutions</li>
+                <li>Highlights in visualization, segmentation, and consumer behavior projects, with mastery of tools such as Databricks, SQL, Responsys, Power BI, Python, Salesforce, Mailchimp, Tableau, SAS, Mix Agents, and Kanbanize</li>
+                <li>Knowledge in agile methodologies (Scrum, Kanban), working on backlog prioritization, squad structuring, and accelerating delivery with a focus on the customer</li>
+                <li>Experience with data integration from multiple sources, building pipelines, predictive analytics, and behavior mapping to support strategic decisions</li>
+                <li>Differentiator in combining analytical capacity, strategic thinking, and technical knowledge, with recognized performance as leadership even in consultative structures</li>
+                <li>People management, leading multidisciplinary teams with a focus on development, autonomy, and generating consistent results</li>
+            </ul>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-skills">Skills & Tools</h2>
-            <div class="skills-grid">
-                <div id="skills-strategic"></div>
-                <div id="skills-tools"></div>
-                <div id="skills-emerging"></div>
+            <h2 class="section-title">EDUCATION & TECHNOLOGY</h2>
+            <div class="education-tech-container">
+                <div class="education-section">
+                    <h3 style="font-size: 12px; color: var(--primary-color); margin-bottom: 12px; font-weight: 600;">EDUCATION</h3>
+                    <div class="education-item">
+                        <div class="degree">Master's in Business Administration</div>
+                        <div class="university">Federal University of Santa Maria - UFSM</div>
+                        <div class="edu-period">Completed: 2019</div>
+                    </div>
+                    
+                    <div class="education-item">
+                        <div class="degree">Bachelor's in Business Administration</div>
+                        <div class="university">Federal University of Santa Maria - UFSM</div>
+                        <div class="edu-period">Completed: 2015</div>
+                    </div>
+                </div>
+                
+                <div class="tech-skills-container">
+                    <div class="skills-section">
+                        <h3>TOOLS & PLATFORMS</h3>
+                        <div class="skill-items">
+                            <span class="skill-tag">Databricks</span>
+                            <span class="skill-tag">SQL</span>
+                            <span class="skill-tag">Power BI</span>
+                            <span class="skill-tag">Python</span>
+                            <span class="skill-tag">Oracle Responsys</span>
+                            <span class="skill-tag">Kanbanize</span>
+                            <span class="skill-tag">Mailchimp</span>
+                            <span class="skill-tag">Mix Agents</span>
+                            <span class="skill-tag">SAS</span>
+                            <span class="skill-tag">Tableau</span>
+                            <span class="skill-tag">Salesforce CRM</span>
+                        </div>
+                    </div>
+                    
+                    <div class="skills-section">
+                        <h3>CERTIFICATIONS & COURSES</h3>
+                        <div class="courses-section">
+                            <div class="course-item">
+                                <span class="course-name">Statement of Accomplishment - Intermediate R Course</span>
+                                <span class="course-info">Marketing Analytics In Practice - Coursera</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Marketing Analytics in R</span>
+                                <span class="course-info">PPGA - Graduate Program in Business Administration</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Fundamentals of Problem Solving</span>
+                                <span class="course-info">Marketing in a Digital World - Illinois University</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-experience">Professional Experience</h2>
-            <div id="experience-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-education">Education</h2>
-            <div id="education-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-projects">Projects & Innovation</h2>
-            <div id="projects-container"></div>
+            <h2 class="section-title">PROFESSIONAL EXPERIENCE</h2>
+            
+            <div class="experience-timeline">
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">CADASTRA (Digital Marketing and Performance Agency)</div>
+                        </div>
+                        <div class="period">2025-Present</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">Data Analytics Coordinator</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">Sep/2025-Present</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Leading Data Analytics and AI operations for enterprise clients in technology, retail and education sectors, managing multidisciplinary team (DataViz, Data Engineering, Web Analytics)</li>
+                        <li>Simultaneous management of strategic accounts with direct interface to C-level stakeholders and business areas (Performance, E-commerce, Commercial)</li>
+                        <li>Data architecture and governance definition for Business Intelligence, Real-Time Analytics and AI applications projects</li>
+                        <li>Technical diagnosis and restructuring of legacy data environments, including infrastructure migration (AWS→GCP) with projected 40% reduction in processing costs</li>
+                        <li>Data operations restructuring with team expansion (+67%) and scope extension to multiple LATAM business units</li>
+                        <li>Stabilization of critical data environments, achieving 20% savings in operational processing costs (Airflow/DAGs)</li>
+                        <li>Development of automations with n8n and AI Agents (LLMs), including automated Status Report with AI-generated executive summaries</li>
+                        <li>Leadership of first generative AI initiatives in client operations, positioning the area as innovation reference</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">LOJAS RENNER | REALIZE CFI (National Financial Services Company)</div>
+                        </div>
+                        <div class="period">2020-2025</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">CRM Manager</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2021-2025</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for leading the strategic CRM front, focusing on area evolution, customer base growth, and business value generation</li>
+                        <li>Definition and monitoring of area OKRs, connecting business goals to relationship indicators</li>
+                        <li>Planning, execution, and optimization of multichannel relationship campaigns (email, SMS, push, among others), applying intelligent segmentations and automations to increase usage frequency and sales</li>
+                        <li>Building personalized journeys based on customer behavior and profile, promoting lifecycle evolution and loyalty in financial products (cards, loans, insurance, and consumption in the Renner ecosystem)</li>
+                        <li>Management of agile management rhythm (daily, planning, reviews, and retrospectives), using frameworks such as Scrum and Kanban to maintain delivery pace, priority visibility, and impact focus</li>
+                        <li>Area backlog management, with mapping, prioritization, and organization of demands according to incremental value and alignment with the commercial team</li>
+                        <li>Strategic management of suppliers and technology partners, including CRM platforms, automation, and data enrichment, ensuring delivery quality and alignment with area guidelines</li>
+                        <li>Continuous interface with key areas (IT, Products, Analytics, Marketing, Stores, and Commercial), promoting alignment between CRM initiatives and corporate objectives</li>
+                        <li>Technical and operational management of tools such as Oracle Responsys, Databricks, and Power BI, enabling automated segmentations, data processing, and performance dashboards</li>
+                        <li>Monitoring and analysis of KPIs and campaign indicators, using data to guide decisions, validate hypotheses, and promote continuous improvement</li>
+                        <li>Leadership of strategic projects and initiatives to expand the active customer base and activate new communication channels</li>
+                    </ul>
+                    
+                    <div class="job-title" style="margin-top: 15px; margin-bottom: 8px;">Analytics Specialist</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2020-2021</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for creating dashboards and strategic indicators for areas such as Marketing, CRM, Credit, and Channels, delivering an integrated real-time view to support business decisions</li>
+                        <li>Development of segmented databases and automated reports focused on the CRM team, with a focus on efficiency gains, agility in analyses, and revenue generation through more precise actions</li>
+                        <li>Organization and integration of operational, behavioral, and transactional data, consolidating multiple sources into a reliable base for comprehensive customer lifecycle analyses</li>
+                        <li>Practical use of tools such as SQL, BigQuery, Python, and Power BI for exploratory analyses, routine automations, and development of predictive models applied to the business</li>
+                        <li>Close collaboration with Marketing, Products, Risk, and Operations areas, translating strategic needs into applicable analyses, focusing on action direction and decision-making</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Analytics Specialist</div>
+                            <div class="company">DBC COMPANY (National IT Consulting Company)</div>
+                        </div>
+                        <div class="period">2020-2021</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for supporting the strategic restructuring of the CRM area at client Realize, implementing agile methodologies (Kanban) and defining processes that reduced campaign time-to-market and increased operational efficiency</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Business Intelligence Analyst</div>
+                            <div class="company">GRUPO RBS (National Media Company)</div>
+                        </div>
+                        <div class="period">2019 - 2020</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for structuring and analyzing commercial performance, audience, and market behavior data, supporting leadership in strategic decision-making for client Rede Globo</li>
+                        <li>Development of segmentation studies and consumption potential mapping, using data to guide decisions, validate hypotheses, and promote sales and prospecting actions</li>
+                        <li>Creation of real-time analytical reports and dashboards to support business decisions</li>
+                        <li>Direct interface with leadership, translating market data into action plans and growth opportunities</li>
+                        <li>Analysis of KPIs and campaign indicators, using data to guide decisions, validate hypotheses, and promote continuous improvement</li>
+                    </ul>
+                </div>
+            </div>
         </section>
     </div>
-
-    <script src="../assets/js/cv-texts.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            var lang = 'en';
-            initializeBasicContent(lang);
-            renderSkills('skills-strategic', 'strategic', lang);
-            renderSkills('skills-tools', 'tools', lang);
-            renderSkills('skills-emerging', 'emerging', lang);
-            renderExperienceTimeline(lang);
-            renderEducation(lang);
-            renderProjects(lang);
-        });
-    </script>
+    <!-- Dynamic Favicon System -->
+    <script src="../assets/js/dynamic-favicon.js"></script>
 </body>
 </html>

--- a/cv_styles/cv_google_style_PT.html
+++ b/cv_styles/cv_google_style_PT.html
@@ -3,334 +3,669 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pedro Henrique Marconato - CV</title>
-    <meta name="theme-color" content="#4285F4">
+    <title>Pedro Henrique Marconato - CV (Google)</title>
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@500;600;700&family=Roboto:wght@300;400;500;700&display=swap');
-
+        @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=Roboto:wght@300;400;500;700&display=swap');
+        
         :root {
-            /* Google Colors — brandbook (docs/google_brandbook.md) */
-            --google-blue: #4285F4;     /* Blue */
-            --google-red: #EA4335;      /* Red */
-            --google-yellow: #FBBC05;   /* Yellow */
-            --google-green: #34A853;    /* Green */
-            --primary-color: #4285F4;   /* Blue — primary */
-            --secondary-color: #1A73E8; /* Deep Blue */
-            --accent-color: #EA4335;    /* Red — accent */
-            --ink: #202124;             /* Grey-900 — text */
-            --grey: #5F6368;            /* Grey-700 — subtext */
+            /* Google — brand tokens */
+            --primary-color: #4285F4;
+            --secondary-color: #1A73E8;
+            --accent-color: #EA4335;
+            --light-accent: #F1F6FF;
             --text-color: #202124;
-            --section-alt: #F8F9FA;     /* Very light grey — alternating sections */
-            --border-color: #DADCE0;    /* Hairline border */
-            --line-color: #E8EAED;      /* Softer line */
-            --four-color: linear-gradient(90deg, #4285F4 0%, #EA4335 33%, #FBBC05 66%, #34A853 100%);
-            --font-display: 'Poppins', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            --border-color: #DADCE0;
+            --background-gradient: linear-gradient(135deg, #FFFFFF 0%, #F1F6FF 100%);
+
             --font-body: 'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
+            --font-display: 'Poppins', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+
+            --header-text: #202124;
+            --header-text-soft: #5f6368;
+            --header-chip-bg: #F1F3F4;
+            --header-chip-border: #DADCE0;
+
+            --tag-bg: rgba(66, 133, 244, 0.10);
+            --tag-border: rgba(66, 133, 244, 0.28);
         }
-
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-
+        
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
         body {
             font-family: var(--font-body);
             color: var(--text-color);
-            line-height: 1.55;
-            background: #ffffff;
-            font-size: 12px;
+            line-height: 1.6;
+            background: var(--light-accent);
+            min-height: 100vh;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
         }
 
-        .cv-container { max-width: 210mm; margin: 0 auto; background: #ffffff; }
-
-        /* Header — white hero, dark text, natural logo, 4-color top border */
+        /* Main container */
+        .cv-container {
+            max-width: 210mm;
+            margin: 0 auto;
+            background: rgba(255, 255, 255, 1);
+            overflow: hidden;
+            position: relative;
+        }
+        
+        /* Header Section */
         .header {
-            background: #ffffff;
-            border-top: 4px solid transparent;
-            border-image: var(--four-color) 1;
-            border-bottom: 1px solid var(--line-color);
-            padding: 30px 40px 30px;
-            text-align: center;
+            background: var(--background-gradient);
+            padding: 50px 50px 55px 50px;
+            position: relative;
+            overflow: hidden;
+        }
+        
+        .header-content {
+            position: relative;
+            z-index: 1;
         }
 
-        .brand-logo { width: 116px; height: 46px; margin: 0 auto 14px; }
-        .brand-logo img { width: 100%; height: 100%; object-fit: contain; }
-
+.brand-logo {
+            position: absolute;
+            bottom: 20px;
+            right: 40px;
+            width: 132px;
+            height: auto;
+            opacity: 1;
+        }
+        
         .header h1 {
             font-family: var(--font-display);
-            font-size: 23px;
+            font-size: 32px;
             font-weight: 700;
-            color: var(--ink);
-            letter-spacing: 0.2px;
-            margin-bottom: 6px;
+            color: var(--header-text);
+            margin-bottom: 8px;
+            letter-spacing: -0.5px;
+            text-transform: uppercase;
         }
 
-        .header h2 {
-            font-size: 12.5px;
+        .header-tagline {
+            font-size: 17px;
             font-weight: 400;
-            color: var(--grey);
-            margin-bottom: 16px;
+            color: var(--header-text-soft);
+            margin-top: 22px;
+            margin-bottom: 28px;
+            font-style: italic;
+            letter-spacing: 0.5px;
         }
-
+        
         .contact-info {
             display: flex;
             flex-wrap: wrap;
-            justify-content: center;
-            gap: 8px;
+            gap: 10px;
+            align-items: center;
+            margin-top: 12px;
         }
-
-        .contact-info > span,
-        .contact-info > a {
-            display: inline-block;
-            background: var(--section-alt);
-            border: 1px solid var(--border-color);
-            color: #3C4043;
-            text-decoration: none;
-            font-size: 10.5px;
+        
+        .contact-item {
+            display: inline-flex;
+            align-items: center;
+            background: var(--header-chip-bg);
+            border-radius: 10px;
+            padding: 8px 14px;
+            color: var(--header-text);
+            font-size: 12.5px;
             font-weight: 500;
-            padding: 5px 12px;
-            border-radius: 20px;
+            border: 1px solid var(--header-chip-border);
         }
-
-        /* Sections — generous whitespace, alternating light grey */
-        .section { padding: 24px 40px; }
-        .section:nth-of-type(even) { background: var(--section-alt); }
-
-        /* Section title — blue text + bottom border (clean, saves ink) */
-        .section-title {
-            display: inline-block;
-            font-family: var(--font-display);
-            color: var(--primary-color);
-            font-size: 13px;
-            font-weight: 700;
-            letter-spacing: 0.4px;
-            text-transform: uppercase;
-            padding-bottom: 5px;
-            margin-bottom: 14px;
-            border-bottom: 2px solid var(--primary-color);
+        
+        .contact-item i {
+            margin-right: 6px;
+            font-size: 12px;
         }
-
-        #cv-profile { font-size: 11.5px; line-height: 1.65; }
-
-        /* Skills — blue dot scale */
-        .skills-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; }
-
-        #skills-strategic h3,
-        #skills-tools h3,
-        #skills-emerging h3 {
-            font-family: var(--font-display) !important;
-            font-size: 11.5px !important;
-            font-weight: 700 !important;
-            color: var(--secondary-color) !important;
-            text-transform: uppercase;
-            letter-spacing: 0.3px;
-            padding-bottom: 6px;
-            margin-bottom: 10px !important;
+        
+        /* Section Styles */
+        .section {
+            padding: 25px 50px;
             border-bottom: 1px solid var(--border-color);
         }
 
-        .tool-item { margin-bottom: 8px; }
-        .tool-name { display: flex; justify-content: space-between; align-items: baseline; font-size: 10.8px; font-weight: 500; }
-        .tool-percentage { color: var(--google-blue); font-size: 9px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.2px; }
-        .dots-container { display: flex; gap: 3px; margin-top: 3px; }
-        .dot { width: 7px; height: 7px; border-radius: 50%; background: #DADCE0; }
-        .dot.filled { background: var(--google-blue); }
+        .section:last-child {
+            border-bottom: none;
+        }
 
-        /* Experience — clean cards, soft shadow */
-        .experience-item {
-            background: #ffffff;
-            border-left: 3px solid var(--google-blue);
-            border-radius: 0 10px 10px 0;
-            padding: 14px 18px;
+        .section-title {
+            font-family: var(--font-display);
+            background: var(--primary-color);
+            color: white;
+            font-size: 15px;
+            font-weight: 600;
+            margin-bottom: 18px;
+            padding: 8px 16px;
+            border-radius: 12px;
+            letter-spacing: 0.3px;
+            display: inline-block;
+            text-transform: uppercase;
+        }
+
+        /* Resumo de Qualificações */
+        .qualifications-list {
+            list-style: none;
+            padding: 0;
+        }
+
+        .qualifications-list li {
+            position: relative;
+            padding-left: 28px;
             margin-bottom: 14px;
-            box-shadow: 0 2px 10px rgba(60, 64, 67, 0.07);
+            font-size: 13.5px;
+            line-height: 1.7;
+            color: var(--text-color);
+        }
+
+        .qualifications-list li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+            font-size: 20px;
+            top: -2px;
+        }
+        
+        /* Skills & Tools Grid */
+        .skills-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 20px;
+        }
+
+        .skills-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 16px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
+        }
+
+        .skills-section h3 {
+            font-size: 12px;
+            color: var(--primary-color);
+            margin-bottom: 10px;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .skill-items {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
+
+        .skill-tag {
+            background: var(--tag-bg);
+            color: var(--primary-color);
+            padding: 4px 10px;
+            border-radius: 12px;
+            font-size: 10.5px;
+            font-weight: 500;
+            border: 1px solid var(--tag-border);
+        }
+
+        /* Cursos Complementares */
+        .courses-section {
+            margin-top: 10px;
+        }
+
+        .course-item {
+            padding: 8px 0;
+            border-bottom: 1px solid var(--border-color);
+            font-size: 11px;
+        }
+
+        .course-item:last-child {
+            border-bottom: none;
+        }
+
+        .course-name {
+            color: var(--text-color);
+            font-weight: 500;
+            display: block;
+            margin-bottom: 2px;
+        }
+
+        .course-info {
+            color: var(--secondary-color);
+            font-size: 10px;
+            font-style: italic;
+        }
+        
+        /* Experience Timeline */
+        .experience-timeline {
+            position: relative;
+            margin-left: 20px;
+            padding-left: 30px;
+        }
+        
+        .experience-timeline::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            top: 0;
+            bottom: 0;
+            width: 3px;
+            background: var(--primary-color);
+            border-radius: 3px;
+        }
+        
+        .experience-item {
+            margin-bottom: 25px;
+            position: relative;
+            padding: 18px;
+            border-radius: 14px;
+            background: #fff;
+            border: 1px solid var(--border-color);
+        }
+        
+        .experience-item::before {
+            content: "";
+            position: absolute;
+            left: -36px;
+            top: 25px;
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background: var(--accent-color);
+            border: 3px solid white;
+        }
+        
+        .job-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-bottom: 10px;
         }
 
         .job-title {
-            display: flex;
-            align-items: center;
-            gap: 8px;
             font-family: var(--font-display);
-            font-size: 13.5px;
-            font-weight: 700;
-            color: var(--ink);
+            font-weight: 600;
+            font-size: 16px;
+            color: var(--primary-color);
             margin-bottom: 4px;
         }
-
-        .job-number {
-            flex-shrink: 0;
-            width: 20px;
-            height: 20px;
-            border-radius: 50%;
-            background: var(--google-blue);
-            color: #ffffff;
-            font-family: var(--font-body);
-            font-size: 10.5px;
-            font-weight: 700;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .company { font-weight: 600; font-size: 11.5px; color: var(--google-blue); }
-        .period { font-size: 10.5px; color: var(--grey); font-weight: 600; margin-bottom: 6px; }
-        .job-description { font-size: 11px; line-height: 1.55; margin-bottom: 8px; color: var(--text-color); }
-
-        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 8px 16px; }
-        .achievement-item { display: flex; gap: 7px; align-items: flex-start; font-size: 10.3px; }
-        .achievement-icon { flex-shrink: 0; width: 15px; text-align: center; color: var(--google-blue); padding-top: 1px; }
-        .achievement-title { font-weight: 600; color: var(--ink); }
-        .achievement-description { color: #4a4a4a; line-height: 1.4; }
-        .tooltip { display: none; }
-
-        /* Education */
-        .education-item {
-            background: #ffffff;
-            border-left: 3px solid var(--secondary-color);
-            border-radius: 0 10px 10px 0;
-            padding: 10px 16px;
-            margin-bottom: 10px;
-        }
-        .degree { font-family: var(--font-display); font-weight: 700; font-size: 12px; color: var(--ink); margin-bottom: 2px; }
-        .university { font-size: 11px; color: var(--google-blue); margin-bottom: 2px; }
-        .thesis { font-size: 10px; color: #555555; font-style: italic; }
-        .cta-button { display: none; }
-
-        /* Projects */
-        .project-item {
-            background: #ffffff;
-            border-left: 3px solid var(--google-green);
-            border-radius: 0 10px 10px 0;
-            padding: 12px 16px;
-            margin-bottom: 10px;
-        }
-        .project-title { font-family: var(--font-display); font-weight: 700; font-size: 12px; color: var(--ink); margin-bottom: 4px; }
-        .project-description { font-size: 11px; line-height: 1.5; margin-bottom: 6px; }
-        .tech-tag {
-            display: inline-block;
-            padding: 2px 9px;
-            margin: 3px 4px 0 0;
-            background: var(--section-alt);
-            border: 1px solid var(--border-color);
-            color: var(--google-blue);
-            border-radius: 10px;
-            font-size: 9px;
+        
+        .company {
             font-weight: 500;
+            font-size: 13px;
+            color: var(--secondary-color);
+        }
+        
+        .period {
+            font-size: 12px;
+            color: var(--secondary-color);
+            font-weight: 600;
+            text-align: right;
+        }
+        
+        .job-description {
+            font-size: 12px;
+            line-height: 1.6;
+            color: var(--text-color);
+            margin-bottom: 12px;
         }
 
-        @media print {
-            body { margin: 0; padding: 0; -webkit-print-color-adjust: exact !important; print-color-adjust: exact !important; }
-            .cv-container { max-width: 100%; margin: 0; }
+        .job-bullets {
+            list-style: none;
+            padding: 0;
+        }
 
-            .header {
+        .job-bullets li {
+            position: relative;
+            padding-left: 20px;
+            margin-bottom: 8px;
+            font-size: 12px;
+            line-height: 1.5;
+            color: var(--text-color);
+        }
+
+        .job-bullets li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+        }
+        
+        /* Education */
+        .education-tech-container {
+            display: grid;
+            grid-template-columns: 1fr 2fr;
+            gap: 25px;
+        }
+        
+        .education-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 20px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
+        }
+
+        .education-item {
+            margin-bottom: 12px;
+            padding-bottom: 12px;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .education-item:last-child {
+            margin-bottom: 0;
+            padding-bottom: 0;
+            border-bottom: none;
+        }
+        
+        .degree {
+            font-family: var(--font-display);
+            font-weight: 600;
+            font-size: 13px;
+            color: var(--primary-color);
+            margin-bottom: 3px;
+        }
+        
+        .university {
+            font-size: 11px;
+            color: var(--text-color);
+            margin-bottom: 2px;
+        }
+        
+        .edu-period {
+            font-size: 10px;
+            color: var(--secondary-color);
+            font-style: italic;
+        }
+
+        .tech-skills-container {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 15px;
+        }
+
+        /* Languages */
+        .language-container {
+            display: flex;
+            justify-content: center;
+            gap: 30px;
+        }
+
+        .language-item {
+            text-align: center;
+        }
+
+        .language-name {
+            font-weight: 600;
+            color: var(--primary-color);
+            font-size: 13px;
+            margin-bottom: 2px;
+        }
+
+        .language-level {
+            font-size: 11px;
+            color: var(--text-color);
+        }
+
+        /* Print Styles */
+        @media print {
+            body {
+                background: white;
+                margin: 0;
+                padding: 0;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
-                padding: 22px 30px 22px !important;
+            }
+
+            .cv-container {
+                max-width: 100%;
+                margin: 0;
+                box-shadow: none;
+            }
+
+            .header {
+                background: var(--background-gradient) !important;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+                padding: 25px 35px !important;
                 page-break-after: avoid;
             }
 
-            .brand-logo img {
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
-            }
-
             .section-title {
+                background: var(--primary-color) !important;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
+                color: white !important;
+                page-break-after: avoid;
             }
 
-            .section:nth-of-type(even) {
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
+            .section {
+                padding: 15px 35px;
+                page-break-inside: avoid;
             }
 
-            .job-number, .dot.filled, .experience-item, .education-item, .project-item, .tech-tag {
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
+            .experience-item {
+                page-break-inside: avoid;
             }
 
-            .section { padding: 14px 30px !important; page-break-inside: avoid; }
-            .experience-item, .education-item, .project-item { page-break-inside: avoid; }
+            /* Hide animations */
+            * {
+                animation: none !important;
+            }
 
-            .header h1 { font-size: 19px !important; }
-            .header h2 { font-size: 11px !important; }
-            .brand-logo { width: 96px !important; height: 38px !important; margin-bottom: 10px !important; }
-            .contact-info > span, .contact-info > a { font-size: 8.5px !important; padding: 3px 8px !important; }
-            .section-title { font-size: 11px !important; margin-bottom: 10px !important; }
-
-            .job-title { font-size: 11.5px !important; }
-            .job-number { width: 16px !important; height: 16px !important; font-size: 9px !important; }
-            .job-description, .achievement-item { font-size: 9px !important; }
-            .company, .period { font-size: 9.5px !important; }
-            .experience-item { padding: 10px 14px !important; margin-bottom: 10px !important; }
-            .education-item, .project-item { padding: 8px 14px !important; margin-bottom: 8px !important; }
-            .degree, .project-title { font-size: 10.5px !important; }
-            .university, .project-description { font-size: 9.5px !important; }
-            .thesis { font-size: 8.5px !important; }
-            .tool-name { font-size: 9.5px !important; }
-            .tool-percentage { font-size: 8px !important; }
-            #skills-strategic h3, #skills-tools h3, #skills-emerging h3 { font-size: 10px !important; }
-
-            @page { size: A4; margin: 8mm; }
+            @page {
+                size: A4;
+                margin: 8mm;
+            }
         }
+        .contact-info { max-width: calc(100% - 180px); }
+        .header { border-bottom: 3px solid var(--primary-color); }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <!-- Favicon Meta Tags -->
+    <meta name="theme-color" content="#4285F4">
+    <meta name="msapplication-TileColor" content="#4285F4">
+    <meta name="msapplication-config" content="../assets/favicons/browserconfig.xml">
 </head>
 <body>
     <div class="cv-container">
         <header class="header">
-            <div class="brand-logo">
-                <img src="../assets/images/google.png" alt="Google">
-            </div>
-            <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
-            <h2 id="cv-role">Gestão de CRM e Inteligência de Dados</h2>
-            <div class="contact-info">
-                <span id="cv-email">pedrohmarconato@gmail.com</span>
-                <span id="cv-phone">+55 (55) 981147758</span>
-                <span id="cv-location"><span>Cachoeira do Sul, RS</span></span>
-                <a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin">LinkedIn</a>
+            <div class="header-content">
+                <img src="../assets/images/google.png" alt="Google" class="brand-logo">
+                <h1>PEDRO HENRIQUE MARCONATO</h1>
+                
+                <div class="header-tagline">CRM | ANALYTICS | BUSINESS INTELLIGENCE | LTV | SQL</div>
+                
+                <div class="contact-info">
+                    <div class="contact-item">
+                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 35 anos
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-phone"></i> +55 (55) 98114-7758
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-envelope"></i> pedrohmarconato@gmail.com
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fab fa-linkedin"></i> linkedin.com/in/pedrohmarconato
+                    </div>
+                </div>
             </div>
         </header>
-
-        <section class="section">
-            <h2 class="section-title" id="section-profile">Perfil Profissional</h2>
-            <p id="cv-profile"></p>
+        
+        <section class="section" style="padding-top: 35px;">
+            <h2 class="section-title">RESUMO DE QUALIFICAÇÕES</h2>
+            <ul class="qualifications-list">
+                <li>Mestre em Administração de Empresas, com ênfase na área de Analytics, unindo inteligência de dados, CRM, visualização analítica e automação para gerar valor ao negócio</li>
+                <li>Atuação em empresas de grande porte e alta complexidade, como Grupo RBS, Realize CFI (Grupo Lojas Renner S.A.) e Rede Globo, liderando projetos estratégicos nas frentes de CRM, inteligência comercial e performance de marketing</li>
+                <li>Vivência com dados aplicados a marketing, canais, crédito, controle e operações, conectando áreas e traduzindo necessidades técnicas em soluções analíticas de alto impacto</li>
+                <li>Destaques em projetos de visualização, segmentação e comportamento de consumo, com domínio de ferramentas como Databricks, SQL, Responsys, Power BI, Python, Salesforce, Mailchimp, Tableau, SAS, Mix Agents e Kanbanize</li>
+                <li>Conhecimento em metodologias ágeis (Scrum, Kanban), com atuação na priorização de backlog, estruturação de squads e aceleração de entrega com foco no cliente</li>
+                <li>Experiência com integração de dados de múltiplas fontes, construção de pipelines, análises preditivas e mapeamento de comportamento para suportar decisões estratégicas</li>
+                <li>Diferencial na combinação entre capacidade analítica, pensamento estratégico e conhecimento técnico, com atuação reconhecida como liderança mesmo em estruturas consultivas</li>
+                <li>Gestão de pessoas, liderando times multidisciplinares com foco em desenvolvimento, autonomia e geração de resultados consistentes</li>
+            </ul>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-skills">Competências e Ferramentas</h2>
-            <div class="skills-grid">
-                <div id="skills-strategic"></div>
-                <div id="skills-tools"></div>
-                <div id="skills-emerging"></div>
+            <h2 class="section-title">FORMAÇÃO ACADÊMICA & TECNOLOGIA</h2>
+            <div class="education-tech-container">
+                <div class="education-section">
+                    <h3 style="font-size: 12px; color: var(--primary-color); margin-bottom: 12px; font-weight: 600;">FORMAÇÃO</h3>
+                    <div class="education-item">
+                        <div class="degree">Mestrado em Administração de Empresas</div>
+                        <div class="university">Universidade Federal de Santa Maria - UFSM</div>
+                        <div class="edu-period">Conclusão: 2019</div>
+                    </div>
+                    
+                    <div class="education-item">
+                        <div class="degree">Bacharelado em Administração</div>
+                        <div class="university">Universidade Federal de Santa Maria - UFSM</div>
+                        <div class="edu-period">Conclusão: 2015</div>
+                    </div>
+                </div>
+                
+                <div class="tech-skills-container">
+                    <div class="skills-section">
+                        <h3>FERRAMENTAS & PLATAFORMAS</h3>
+                        <div class="skill-items">
+                            <span class="skill-tag">Databricks</span>
+                            <span class="skill-tag">SQL</span>
+                            <span class="skill-tag">Power BI</span>
+                            <span class="skill-tag">Python</span>
+                            <span class="skill-tag">Oracle Responsys</span>
+                            <span class="skill-tag">Kanbanize</span>
+                            <span class="skill-tag">Mailchimp</span>
+                            <span class="skill-tag">Mix Agents</span>
+                            <span class="skill-tag">SAS</span>
+                            <span class="skill-tag">Tableau</span>
+                            <span class="skill-tag">Salesforce CRM</span>
+                        </div>
+                    </div>
+                    
+                    <div class="skills-section">
+                        <h3>CERTIFICAÇÕES & CURSOS</h3>
+                        <div class="courses-section">
+                            <div class="course-item">
+                                <span class="course-name">Statement of Accomplishment - Intermediate R Course</span>
+                                <span class="course-info">Marketing Analytics In Practice - Coursera</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Marketing Analytics em R</span>
+                                <span class="course-info">PPGA - Programa de Pós-Graduação em Administração</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Fundamentos de Solução de Problemas</span>
+                                <span class="course-info">Marketing in a Digital World - Illinois University</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-experience">Experiência Profissional</h2>
-            <div id="experience-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-education">Formação</h2>
-            <div id="education-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-projects">Projetos e Inovação</h2>
-            <div id="projects-container"></div>
+            <h2 class="section-title">EXPERIÊNCIA PROFISSIONAL</h2>
+            
+            <div class="experience-timeline">
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">CADASTRA (Agência de Marketing Digital e Performance)</div>
+                        </div>
+                        <div class="period">2025-Atual</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">Coordenador de Data Analytics</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">Set/2025-Atual</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável pela operação de Data Analytics e AI para clientes de grande porte dos setores de tecnologia, varejo e educação, liderando time multidisciplinar (DataViz, Engenharia de Dados, Web Analytics)</li>
+                        <li>Gestão simultânea de contas estratégicas, com interface direta com stakeholders C-level e áreas de negócio (Performance, E-commerce, Comercial)</li>
+                        <li>Definição de arquitetura de dados e governança para projetos de Business Intelligence, Real-Time Analytics e aplicações de inteligência artificial</li>
+                        <li>Diagnóstico técnico e reestruturação de ambientes de dados legados, incluindo migração de infraestrutura (AWS→GCP) com redução projetada de 40% em custos de processamento</li>
+                        <li>Reestruturação de operações de dados com expansão de time (+67%) e ampliação de escopo para múltiplas unidades de negócio em LATAM</li>
+                        <li>Estabilização de ambientes críticos de dados, alcançando economia de 20% em custos operacionais de processamento (Airflow/DAGs)</li>
+                        <li>Desenvolvimento de automações com n8n e AI Agents (LLMs), incluindo Status Report automatizado com geração de resumos executivos por inteligência artificial</li>
+                        <li>Liderança das primeiras iniciativas de aplicação de IA generativa em operações de clientes, posicionando a área como referência em inovação</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">LOJAS RENNER | REALIZE CFI (Empresa Nacional do segmento Financeiro)</div>
+                        </div>
+                        <div class="period">2020-2025</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">CRM Manager</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2021-2025</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável pela liderança da frente estratégica de CRM, com foco na evolução da área, crescimento da base de clientes e geração de valor ao negócio</li>
+                        <li>Definição e acompanhamento dos OKRs da área, conectando metas do negócio a indicadores de relacionamento</li>
+                        <li>Planejamento, execução e otimização de campanhas de relacionamento multicanal (e-mail, SMS, push, entre outros), aplicando segmentações inteligentes e automações para aumentar frequência de uso e vendas</li>
+                        <li>Construção de jornadas personalizadas com base em comportamento e perfil dos clientes, promovendo a evolução do ciclo de vida e fidelização em produtos financeiros (cartões, empréstimos, seguros e consumo no ecossistema Renner)</li>
+                        <li>Gestão do ritmo de gestão ágil (daily, planning, reviews e retrospectives), utilizando frameworks como Scrum e Kanban para manter ritmo de entrega, visibilidade de prioridades e foco em impacto</li>
+                        <li>Gestão do backlog da área, com mapeamento, priorização e organização das demandas de acordo com o valor incremental e alinhamento com o time comercial</li>
+                        <li>Gestão estratégica de fornecedores e parceiros de tecnologia, incluindo plataformas de CRM, automação e enriquecimento de dados, garantindo qualidade das entregas e alinhamento às diretrizes da área</li>
+                        <li>Interface contínua com áreas-chave (TI, Produtos, Analytics, Marketing, Lojas e Comercial), promovendo alinhamento entre as iniciativas de CRM e os objetivos corporativos</li>
+                        <li>Gestão técnica e operacional de ferramentas como Oracle Responsys, Databricks e Power BI, viabilizando segmentações automatizadas, tratamento de dados e dashboards de performance</li>
+                        <li>Monitoramento e análise de KPIs e indicadores de campanhas, utilizando dados para orientar decisões, validar hipóteses e promover a melhoria contínua</li>
+                        <li>Liderança de projetos e iniciativas estratégicas de expansão da base ativa de clientes e ativação de novos canais de comunicação</li>
+                    </ul>
+                    
+                    <div class="job-title" style="margin-top: 15px; margin-bottom: 8px;">Especialista de Analytics</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2020-2021</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável por criar dashboards e indicadores estratégicos para áreas como Marketing, CRM, Crédito e Canais, entregando uma visão integrada e em tempo real para apoiar decisões de negócio</li>
+                        <li>Desenvolvimento de bases segmentadas e relatórios automatizados voltados ao time de CRM, com foco em ganho de eficiência, agilidade nas análises e geração de receita por meio de ações mais precisas</li>
+                        <li>Organização e integração de dados operacionais, comportamentais e transacionais, consolidando múltiplas fontes em uma base confiável para análises completas do ciclo de vida do cliente</li>
+                        <li>Utilização prática de ferramentas como SQL, BigQuery, Python e Power BI para análises exploratórias, automações de rotinas e desenvolvimento de modelos preditivos aplicados ao negócio</li>
+                        <li>Atuação próxima às áreas de Marketing, Produtos, Riscos e Operações, traduzindo necessidades estratégicas em análises aplicáveis, com foco em direcionamento de ações e tomada de decisão</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Especialista de Analytics</div>
+                            <div class="company">DBC COMPANY (Empresa Nacional do segmento de Consultoria em TI)</div>
+                        </div>
+                        <div class="period">2020-2021</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável por apoiar a reestruturação estratégica da área de CRM no cliente Realize, implementando metodologias ágeis (Kanban) e definindo processos que reduziram o time-to-market das campanhas e aumentaram a eficiência operacional</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Analista de Inteligência Comercial</div>
+                            <div class="company">GRUPO RBS (Empresa Nacional do segmento de Mídia)</div>
+                        </div>
+                        <div class="period">2019 - 2020</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável pela estruturação e análise dados de desempenho comercial, audiência e comportamento de mercado, apoiando a liderança na tomada de decisões estratégicas do cliente Rede Globo</li>
+                        <li>Desenvolvimento de estudos de segmentação e mapeamento de potencial de consumo, utilizando dados para orientar decisões, validar hipóteses e promover ações de vendas e prospecção</li>
+                        <li>Criação de relatórios e dashboards analíticos em tempo real para apoiar decisões do negócio</li>
+                        <li>Interface direta com a liderança, traduzindo dados de mercado em planos de ação e oportunidades de crescimento</li>
+                        <li>Análise de KPIs e indicadores de campanhas, utilizando dados para orientar decisões, validar hipóteses e promover a melhoria contínua</li>
+                    </ul>
+                </div>
+            </div>
         </section>
     </div>
-
-    <script src="../assets/js/cv-texts.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            var lang = 'pt';
-            initializeBasicContent(lang);
-            renderSkills('skills-strategic', 'strategic', lang);
-            renderSkills('skills-tools', 'tools', lang);
-            renderSkills('skills-emerging', 'emerging', lang);
-            renderExperienceTimeline(lang);
-            renderEducation(lang);
-            renderProjects(lang);
-        });
-    </script>
+    <!-- Dynamic Favicon System -->
+    <script src="../assets/js/dynamic-favicon.js"></script>
 </body>
 </html>

--- a/cv_styles/cv_grupo-rbs_style_EN.html
+++ b/cv_styles/cv_grupo-rbs_style_EN.html
@@ -3,532 +3,669 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pedro Henrique Marconato - CV</title>
+    <title>Pedro Henrique Marconato - CV (Grupo RBS)</title>
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@400;500;600;700&display=swap');
-        @import url('https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,600;0,8..60,700;1,8..60,400&display=swap');
-        @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&display=swap');
-
+        @import url('https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,600;8..60,700&display=swap');
+        
         :root {
-            /* Grupo RBS — institutional navy + derived editorial palette (brandbook) */
-            --rbs-navy: #003563;
-            --rbs-navy-deep: #00294D;
-            --rbs-blue: #0A5394;
-            --rbs-sky: #2E77B8;
-            --rbs-ice: #EAF2F9;
-            --rbs-red: #D64545;
-            --rbs-ink: #16283C;
-
-            --primary-color: var(--rbs-navy);
-            --secondary-color: var(--rbs-blue);
-            --accent-color: var(--rbs-red);
-            --text-color: var(--rbs-ink);
+            /* Grupo RBS — brand tokens */
+            --primary-color: #003563;
+            --secondary-color: #0A5394;
+            --accent-color: #D64545;
+            --light-accent: #EAF2F9;
+            --text-color: #16283C;
             --border-color: rgba(0, 53, 99, 0.18);
-            --background-gradient: linear-gradient(150deg, var(--rbs-navy-deep) 0%, var(--rbs-navy) 55%, var(--rbs-blue) 100%);
+            --background-gradient: linear-gradient(150deg, #00294D 0%, #003563 55%, #0A5394 100%);
 
             --font-body: 'Source Sans 3', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            --font-serif: 'Source Serif 4', Georgia, 'Times New Roman', serif;
-            --font-mono: 'IBM Plex Mono', 'SF Mono', Menlo, monospace;
+            --font-display: 'Source Serif 4', Georgia, 'Times New Roman', serif;
+
+            --header-text: #ffffff;
+            --header-text-soft: rgba(255, 255, 255, 0.95);
+            --header-chip-bg: rgba(255, 255, 255, 0.15);
+            --header-chip-border: rgba(255, 255, 255, 0.28);
+
+            --tag-bg: rgba(214, 69, 69, 0.12);
+            --tag-border: rgba(214, 69, 69, 0.28);
         }
-
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-
+        
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
         body {
             font-family: var(--font-body);
             color: var(--text-color);
-            line-height: 1.5;
-            background: #e7edf3;
-            font-size: 12px;
-            -webkit-print-color-adjust: exact;
-            print-color-adjust: exact;
+            line-height: 1.6;
+            background: var(--light-accent);
+            min-height: 100vh;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
         }
 
+        /* Main container */
         .cv-container {
             max-width: 210mm;
-            margin: 14px auto;
-            background: #ffffff;
-            box-shadow: 0 4px 24px rgba(0, 53, 99, 0.14);
-            border-radius: 4px;
+            margin: 0 auto;
+            background: rgba(255, 255, 255, 1);
             overflow: hidden;
+            position: relative;
         }
-
-        /* ===== Header — navy masthead ===== */
+        
+        /* Header Section */
         .header {
             background: var(--background-gradient);
-            color: #ffffff;
-            padding: 28px 40px 32px;
-            text-align: center;
+            padding: 50px 50px 55px 50px;
             position: relative;
+            overflow: hidden;
+        }
+        
+        .header-content {
+            position: relative;
+            z-index: 1;
         }
 
-        .brand-logo {
-            width: 150px;
-            margin: 0 auto 14px;
-        }
-
-        .brand-logo img {
-            width: 100%;
+.brand-logo {
+            position: absolute;
+            bottom: 20px;
+            right: 40px;
+            width: 148px;
             height: auto;
-            display: block;
-            margin: 0 auto;
+            opacity: 0.95;
             filter: brightness(0) invert(1);
         }
-
-        #cv-name {
-            font-family: var(--font-serif);
-            font-size: 25px;
+        
+        .header h1 {
+            font-family: var(--font-display);
+            font-size: 32px;
             font-weight: 700;
-            letter-spacing: -0.3px;
-            display: inline-block;
-            position: relative;
-            padding-bottom: 10px;
-            margin-bottom: 10px;
+            color: var(--header-text);
+            margin-bottom: 8px;
+            letter-spacing: -0.5px;
+            text-transform: uppercase;
         }
 
-        #cv-name::after {
-            content: '';
-            position: absolute;
-            bottom: 0;
-            left: 50%;
-            transform: translateX(-50%);
-            width: 64px;
-            height: 3px;
-            border-radius: 2px;
-            background: linear-gradient(90deg, var(--rbs-sky), var(--rbs-red));
-        }
-
-        #cv-role {
-            font-family: var(--font-serif);
-            font-style: italic;
+        .header-tagline {
+            font-size: 17px;
             font-weight: 400;
-            font-size: 13px;
-            color: rgba(255, 255, 255, 0.92);
-            margin-bottom: 16px;
+            color: var(--header-text-soft);
+            margin-top: 22px;
+            margin-bottom: 28px;
+            font-style: italic;
+            letter-spacing: 0.5px;
         }
-
+        
         .contact-info {
             display: flex;
             flex-wrap: wrap;
-            justify-content: center;
-            gap: 8px;
+            gap: 10px;
+            align-items: center;
+            margin-top: 12px;
         }
-
-        .contact-pill {
+        
+        .contact-item {
             display: inline-flex;
             align-items: center;
-            gap: 5px;
-            background: rgba(255, 255, 255, 0.14);
-            border: 1px solid rgba(255, 255, 255, 0.28);
-            border-radius: 20px;
-            padding: 4px 11px;
-            font-size: 10px;
-        }
-
-        .contact-pill i { font-size: 9.5px; color: #9CC4E8; }
-        .contact-pill a { color: #ffffff; text-decoration: none; }
-
-        /* ===== Sections ===== */
-        .section { padding: 14px 34px; }
-        .section:not(:last-of-type) { border-bottom: 1px solid var(--border-color); }
-
-        .section-title {
-            display: inline-block;
-            font-family: var(--font-serif);
+            background: var(--header-chip-bg);
+            border-radius: 10px;
+            padding: 8px 14px;
+            color: var(--header-text);
             font-size: 12.5px;
-            font-weight: 700;
-            letter-spacing: 0.4px;
-            text-transform: uppercase;
-            color: #ffffff;
-            background: var(--rbs-navy);
-            border-left: 4px solid var(--rbs-red);
-            border-radius: 3px 10px 10px 3px;
-            padding: 5px 14px 5px 12px;
-            margin-bottom: 10px;
+            font-weight: 500;
+            border: 1px solid var(--header-chip-border);
         }
-
-        #cv-profile {
-            font-size: 11px;
-            line-height: 1.65;
-            text-align: justify;
+        
+        .contact-item i {
+            margin-right: 6px;
+            font-size: 12px;
         }
-
-        /* ===== Skills ===== */
-        .skills-grid {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 12px;
-        }
-
-        .skills-column {
-            background: linear-gradient(165deg, var(--rbs-ice), rgba(234, 242, 249, 0.35));
-            border: 1px solid var(--border-color);
-            border-top: 3px solid var(--rbs-navy);
-            border-radius: 6px;
-            padding: 10px 12px;
-        }
-
-        .skills-column:nth-child(2) { border-top-color: var(--rbs-blue); }
-        .skills-column:nth-child(3) { border-top-color: var(--rbs-sky); }
-
-        .skills-column h3 {
-            font-family: var(--font-serif) !important;
-            font-size: 11.5px !important;
-            font-weight: 700 !important;
-            color: var(--rbs-navy) !important;
-            text-transform: uppercase;
-            letter-spacing: 0.3px;
-            padding-bottom: 4px;
-            margin-bottom: 8px !important;
+        
+        /* Section Styles */
+        .section {
+            padding: 25px 50px;
             border-bottom: 1px solid var(--border-color);
         }
 
-        .tool-item { margin-bottom: 7px; }
+        .section:last-child {
+            border-bottom: none;
+        }
 
-        .tool-name {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            gap: 6px;
+        .section-title {
+            font-family: var(--font-display);
+            background: var(--primary-color);
+            color: white;
+            font-size: 15px;
             font-weight: 600;
-            font-size: 10px;
-            margin-bottom: 3px;
-        }
-
-        .tool-percentage {
-            font-family: var(--font-mono);
-            font-size: 7.5px;
-            font-weight: 600;
-            text-transform: uppercase;
-            letter-spacing: 0.4px;
-            color: var(--rbs-blue);
-            background: rgba(10, 83, 148, 0.08);
-            border: 1px solid rgba(10, 83, 148, 0.22);
-            padding: 1px 6px;
-            border-radius: 3px;
-            white-space: nowrap;
-        }
-
-        .dots-container { display: flex; gap: 3px; }
-        .dot { width: 5px; height: 5px; border-radius: 50%; background: rgba(0, 53, 99, 0.16); }
-        .dot.filled { background: var(--rbs-navy); }
-
-        /* Tooltip does not work on paper */
-        .tooltip { display: none; }
-
-        /* ===== Experience ===== */
-        .experience-item {
-            position: relative;
-            margin-bottom: 12px;
-            padding: 11px 14px 11px 16px;
-            background: linear-gradient(155deg, #ffffff, rgba(234, 242, 249, 0.5));
-            border: 1px solid var(--border-color);
-            border-left: 3px solid var(--rbs-navy);
-            border-radius: 5px;
-            page-break-inside: avoid;
-        }
-
-        .job-title {
-            display: flex;
-            align-items: center;
-            gap: 7px;
-            font-family: var(--font-serif);
-            font-weight: 700;
-            font-size: 12.5px;
-            color: var(--rbs-navy);
-            margin-bottom: 4px;
-        }
-
-        .job-number {
-            display: inline-flex;
-            align-items: center;
-            background: var(--rbs-navy);
-            color: #ffffff;
-            font-family: var(--font-mono);
-            font-size: 8.5px;
-            font-weight: 600;
-            padding: 2px 6px;
-            border-radius: 3px;
-            flex-shrink: 0;
-        }
-
-        .job-number::before {
-            content: 'ED. ';
-            font-size: 7px;
-            opacity: 0.75;
-        }
-
-        .company {
-            font-weight: 600;
-            font-size: 10.5px;
-            color: var(--rbs-blue);
-            margin-bottom: 2px;
-        }
-
-        .period {
+            margin-bottom: 18px;
+            padding: 8px 16px;
+            border-radius: 12px;
+            letter-spacing: 0.3px;
             display: inline-block;
-            font-family: var(--font-mono);
-            font-size: 8.5px;
-            color: #51667E;
-            background: rgba(0, 53, 99, 0.06);
-            border: 1px solid rgba(0, 53, 99, 0.16);
-            padding: 2px 8px;
-            border-radius: 3px;
-            margin-bottom: 7px;
+            text-transform: uppercase;
         }
 
-        .job-description {
-            font-size: 10px;
-            line-height: 1.5;
-            margin-bottom: 7px;
+        /* Resumo de Qualificações */
+        .qualifications-list {
+            list-style: none;
+            padding: 0;
         }
 
-        .achievements-container {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 6px;
-        }
-
-        .achievement-item {
-            display: flex;
-            gap: 6px;
-            background: rgba(0, 53, 99, 0.045);
-            border: 1px solid rgba(0, 53, 99, 0.13);
-            border-radius: 5px;
-            padding: 6px 8px;
-        }
-
-        .achievement-icon {
-            color: var(--rbs-blue);
-            font-size: 10.5px;
-            padding-top: 1px;
-            flex-shrink: 0;
-        }
-
-        .achievement-content { flex: 1; }
-
-        .achievement-title {
-            font-weight: 600;
-            font-size: 9px;
-            color: var(--rbs-navy);
-            margin-bottom: 2px;
-        }
-
-        .achievement-description {
-            font-size: 8.5px;
-            line-height: 1.4;
+        .qualifications-list li {
+            position: relative;
+            padding-left: 28px;
+            margin-bottom: 14px;
+            font-size: 13.5px;
+            line-height: 1.7;
             color: var(--text-color);
         }
 
-        /* ===== Education ===== */
-        #education-container {
+        .qualifications-list li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+            font-size: 20px;
+            top: -2px;
+        }
+        
+        /* Skills & Tools Grid */
+        .skills-grid {
             display: grid;
             grid-template-columns: 1fr 1fr;
-            gap: 10px;
+            gap: 20px;
+        }
+
+        .skills-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 16px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
+        }
+
+        .skills-section h3 {
+            font-size: 12px;
+            color: var(--primary-color);
+            margin-bottom: 10px;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .skill-items {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
+
+        .skill-tag {
+            background: var(--tag-bg);
+            color: var(--primary-color);
+            padding: 4px 10px;
+            border-radius: 12px;
+            font-size: 10.5px;
+            font-weight: 500;
+            border: 1px solid var(--tag-border);
+        }
+
+        /* Cursos Complementares */
+        .courses-section {
+            margin-top: 10px;
+        }
+
+        .course-item {
+            padding: 8px 0;
+            border-bottom: 1px solid var(--border-color);
+            font-size: 11px;
+        }
+
+        .course-item:last-child {
+            border-bottom: none;
+        }
+
+        .course-name {
+            color: var(--text-color);
+            font-weight: 500;
+            display: block;
+            margin-bottom: 2px;
+        }
+
+        .course-info {
+            color: var(--secondary-color);
+            font-size: 10px;
+            font-style: italic;
+        }
+        
+        /* Experience Timeline */
+        .experience-timeline {
+            position: relative;
+            margin-left: 20px;
+            padding-left: 30px;
+        }
+        
+        .experience-timeline::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            top: 0;
+            bottom: 0;
+            width: 3px;
+            background: var(--primary-color);
+            border-radius: 3px;
+        }
+
+        .experience-item {
+            margin-bottom: 25px;
+            position: relative;
+            padding: 18px;
+            border-radius: 14px;
+            background: #fff;
+            border: 1px solid var(--border-color);
+        }
+        
+        .experience-item::before {
+            content: "";
+            position: absolute;
+            left: -36px;
+            top: 25px;
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background: var(--accent-color);
+            border: 3px solid white;
+        }
+        
+        .job-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-bottom: 10px;
+        }
+
+        .job-title {
+            font-family: var(--font-display);
+            font-weight: 600;
+            font-size: 16px;
+            color: var(--primary-color);
+            margin-bottom: 4px;
+        }
+        
+        .company {
+            font-weight: 500;
+            font-size: 13px;
+            color: var(--secondary-color);
+        }
+        
+        .period {
+            font-size: 12px;
+            color: var(--secondary-color);
+            font-weight: 600;
+            text-align: right;
+        }
+        
+        .job-description {
+            font-size: 12px;
+            line-height: 1.6;
+            color: var(--text-color);
+            margin-bottom: 12px;
+        }
+
+        .job-bullets {
+            list-style: none;
+            padding: 0;
+        }
+
+        .job-bullets li {
+            position: relative;
+            padding-left: 20px;
+            margin-bottom: 8px;
+            font-size: 12px;
+            line-height: 1.5;
+            color: var(--text-color);
+        }
+
+        .job-bullets li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+        }
+        
+        /* Education */
+        .education-tech-container {
+            display: grid;
+            grid-template-columns: 1fr 2fr;
+            gap: 25px;
+        }
+        
+        .education-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 20px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
         }
 
         .education-item {
-            background: linear-gradient(165deg, rgba(234, 242, 249, 0.9), rgba(234, 242, 249, 0.35));
-            border: 1px solid var(--border-color);
-            border-left: 3px solid var(--rbs-blue);
-            border-radius: 5px;
-            padding: 10px 12px;
-            page-break-inside: avoid;
+            margin-bottom: 12px;
+            padding-bottom: 12px;
+            border-bottom: 1px solid var(--border-color);
         }
 
+        .education-item:last-child {
+            margin-bottom: 0;
+            padding-bottom: 0;
+            border-bottom: none;
+        }
+        
         .degree {
-            font-family: var(--font-serif);
-            font-weight: 700;
-            font-size: 11px;
-            color: var(--rbs-navy);
+            font-family: var(--font-display);
+            font-weight: 600;
+            font-size: 13px;
+            color: var(--primary-color);
             margin-bottom: 3px;
         }
-
-        .university { font-size: 9.5px; margin-bottom: 3px; }
-        .thesis { font-size: 9px; font-style: italic; color: #51667E; }
-
-        .cta-button {
-            display: inline-flex;
-            align-items: center;
-            gap: 4px;
-            margin-top: 5px;
-            padding: 2px 7px;
-            background: var(--rbs-navy);
-            color: #ffffff;
-            border-radius: 3px;
-            text-decoration: none;
-            font-size: 8px;
+        
+        .university {
+            font-size: 11px;
+            color: var(--text-color);
+            margin-bottom: 2px;
+        }
+        
+        .edu-period {
+            font-size: 10px;
+            color: var(--secondary-color);
+            font-style: italic;
         }
 
-        /* ===== Projects ===== */
-        #projects-container {
+        .tech-skills-container {
             display: grid;
-            grid-template-columns: 1fr 1fr 1fr;
-            gap: 10px;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 15px;
         }
 
-        .project-item {
-            position: relative;
-            background: #ffffff;
-            border: 1px solid var(--border-color);
-            border-radius: 5px;
-            padding: 10px 12px;
-            overflow: hidden;
-            page-break-inside: avoid;
+        /* Languages */
+        .language-container {
+            display: flex;
+            justify-content: center;
+            gap: 30px;
         }
 
-        .project-item::before {
-            content: '';
-            position: absolute;
-            top: 0; left: 0; right: 0;
-            height: 2.5px;
-            background: linear-gradient(90deg, var(--rbs-navy), var(--rbs-blue), var(--rbs-sky));
+        .language-item {
+            text-align: center;
         }
 
-        .project-title {
-            font-family: var(--font-serif);
-            font-weight: 700;
-            font-size: 10.5px;
-            color: var(--rbs-navy);
-            margin-top: 4px;
-            margin-bottom: 4px;
+        .language-name {
+            font-weight: 600;
+            color: var(--primary-color);
+            font-size: 13px;
+            margin-bottom: 2px;
         }
 
-        .project-description {
-            font-size: 9px;
-            line-height: 1.4;
-            margin-bottom: 6px;
+        .language-level {
+            font-size: 11px;
+            color: var(--text-color);
         }
 
-        .tech-tag {
-            display: inline-block;
-            font-family: var(--font-mono);
-            font-size: 7.5px;
-            padding: 2px 6px;
-            margin: 0 4px 4px 0;
-            background: rgba(0, 53, 99, 0.06);
-            color: var(--rbs-blue);
-            border: 1px solid rgba(0, 53, 99, 0.18);
-            border-radius: 3px;
-        }
-
-        /* ===== Print ===== */
+        /* Print Styles */
         @media print {
             body {
+                background: white;
                 margin: 0;
                 padding: 0;
-                background: #ffffff;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
             }
 
-            .cv-container { max-width: none; margin: 0; box-shadow: none; border-radius: 0; }
+            .cv-container {
+                max-width: 100%;
+                margin: 0;
+                box-shadow: none;
+            }
 
             .header {
                 background: var(--background-gradient) !important;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
-                padding: 16px 30px 20px !important;
+                padding: 25px 35px !important;
+                page-break-after: avoid;
             }
-
-            #cv-name { font-size: 20px !important; padding-bottom: 8px !important; }
-            #cv-role { font-size: 11px !important; margin-bottom: 10px !important; }
-            .contact-pill { font-size: 8.5px !important; padding: 3px 9px !important; }
 
             .section-title {
-                background: var(--rbs-navy) !important;
+                background: var(--primary-color) !important;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
-                font-size: 10.5px !important;
-                padding: 4px 11px 4px 10px !important;
-                margin-bottom: 8px !important;
+                color: white !important;
+                page-break-after: avoid;
             }
 
-            .section { padding: 9px 26px !important; }
-            #cv-profile { font-size: 9.5px !important; }
-
-            .skills-column { padding: 8px 10px !important; }
-            .skills-column h3 { font-size: 10px !important; margin-bottom: 6px !important; }
-            .tool-item { margin-bottom: 5px !important; }
-
-            .experience-item, .education-item, .project-item {
+            .section {
+                padding: 15px 35px;
                 page-break-inside: avoid;
-                margin-bottom: 8px !important;
             }
 
-            .job-title { font-size: 11px !important; }
-            .company { font-size: 9.5px !important; }
-            .job-description { font-size: 9px !important; }
-            .achievement-title { font-size: 8.5px !important; }
-            .achievement-description { font-size: 8px !important; }
-            .degree { font-size: 10px !important; }
-            .project-title { font-size: 10px !important; }
+            .experience-item {
+                page-break-inside: avoid;
+            }
 
-            * { animation: none !important; transition: none !important; }
+            /* Hide animations */
+            * {
+                animation: none !important;
+            }
 
-            @page { size: A4; margin: 8mm; }
+            @page {
+                size: A4;
+                margin: 8mm;
+            }
         }
+        .contact-info { max-width: calc(100% - 180px); }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <!-- Favicon Meta Tags -->
+    <meta name="theme-color" content="#003563">
+    <meta name="msapplication-TileColor" content="#003563">
+    <meta name="msapplication-config" content="../assets/favicons/browserconfig.xml">
 </head>
 <body>
     <div class="cv-container">
         <header class="header">
-            <div class="brand-logo">
-                <img src="../assets/images/grupo-rbs.png" alt="Grupo RBS">
-            </div>
-            <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
-            <h2 id="cv-role">CRM Management and Data Intelligence</h2>
-            <div class="contact-info">
-                <span class="contact-pill"><i class="fas fa-envelope"></i><span id="cv-email">pedrohmarconato@gmail.com</span></span>
-                <span class="contact-pill"><i class="fas fa-phone"></i><span id="cv-phone">+55 (55) 981147758</span></span>
-                <span class="contact-pill"><i class="fas fa-map-marker-alt"></i><span id="cv-location"><span>Cachoeira do Sul, RS</span></span></span>
-                <span class="contact-pill"><i class="fab fa-linkedin"></i><a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin">LinkedIn</a></span>
-                <span class="contact-pill"><i class="fab fa-github"></i><a href="https://github.com/pedrohmarconato" id="cv-repository">Repository</a></span>
+            <div class="header-content">
+                <img src="../assets/images/grupo-rbs.png" alt="Grupo RBS" class="brand-logo">
+                <h1>PEDRO HENRIQUE MARCONATO</h1>
+                
+                <div class="header-tagline">CRM | ANALYTICS | BUSINESS INTELLIGENCE | LTV | SQL</div>
+                
+                <div class="contact-info">
+                    <div class="contact-item">
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-phone"></i> +55 (55) 98114-7758
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-envelope"></i> pedrohmarconato@gmail.com
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fab fa-linkedin"></i> linkedin.com/in/pedrohmarconato
+                    </div>
+                </div>
             </div>
         </header>
-
-        <section class="section">
-            <h2 class="section-title" id="section-profile">Professional Profile</h2>
-            <p id="cv-profile"></p>
+        
+        <section class="section" style="padding-top: 35px;">
+            <h2 class="section-title">PROFESSIONAL SUMMARY</h2>
+            <ul class="qualifications-list">
+                <li>Master's degree in Business Administration, with an Analytics track, combining data intelligence, CRM, analytical visualization, and automation to generate business value</li>
+                <li>Experience in large and highly complex companies, such as Grupo RBS, Realize CFI (Lojas Renner S.A. Group), and Rede Globo, leading strategic projects in CRM, business intelligence, and marketing performance</li>
+                <li>Experience with data applied to marketing, channels, credit, control, and operations, connecting areas and translating technical needs into high-impact analytical solutions</li>
+                <li>Highlights in visualization, segmentation, and consumer behavior projects, with mastery of tools such as Databricks, SQL, Responsys, Power BI, Python, Salesforce, Mailchimp, Tableau, SAS, Mix Agents, and Kanbanize</li>
+                <li>Knowledge in agile methodologies (Scrum, Kanban), working on backlog prioritization, squad structuring, and accelerating delivery with a focus on the customer</li>
+                <li>Experience with data integration from multiple sources, building pipelines, predictive analytics, and behavior mapping to support strategic decisions</li>
+                <li>Differentiator in combining analytical capacity, strategic thinking, and technical knowledge, with recognized performance as leadership even in consultative structures</li>
+                <li>People management, leading multidisciplinary teams with a focus on development, autonomy, and generating consistent results</li>
+            </ul>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-skills">Skills & Tools</h2>
-            <div class="skills-grid">
-                <div class="skills-column" id="skills-strategic"></div>
-                <div class="skills-column" id="skills-tools"></div>
-                <div class="skills-column" id="skills-emerging"></div>
+            <h2 class="section-title">EDUCATION & TECHNOLOGY</h2>
+            <div class="education-tech-container">
+                <div class="education-section">
+                    <h3 style="font-size: 12px; color: var(--primary-color); margin-bottom: 12px; font-weight: 600;">EDUCATION</h3>
+                    <div class="education-item">
+                        <div class="degree">Master's in Business Administration</div>
+                        <div class="university">Federal University of Santa Maria - UFSM</div>
+                        <div class="edu-period">Completed: 2019</div>
+                    </div>
+                    
+                    <div class="education-item">
+                        <div class="degree">Bachelor's in Business Administration</div>
+                        <div class="university">Federal University of Santa Maria - UFSM</div>
+                        <div class="edu-period">Completed: 2015</div>
+                    </div>
+                </div>
+                
+                <div class="tech-skills-container">
+                    <div class="skills-section">
+                        <h3>TOOLS & PLATFORMS</h3>
+                        <div class="skill-items">
+                            <span class="skill-tag">Databricks</span>
+                            <span class="skill-tag">SQL</span>
+                            <span class="skill-tag">Power BI</span>
+                            <span class="skill-tag">Python</span>
+                            <span class="skill-tag">Oracle Responsys</span>
+                            <span class="skill-tag">Kanbanize</span>
+                            <span class="skill-tag">Mailchimp</span>
+                            <span class="skill-tag">Mix Agents</span>
+                            <span class="skill-tag">SAS</span>
+                            <span class="skill-tag">Tableau</span>
+                            <span class="skill-tag">Salesforce CRM</span>
+                        </div>
+                    </div>
+                    
+                    <div class="skills-section">
+                        <h3>CERTIFICATIONS & COURSES</h3>
+                        <div class="courses-section">
+                            <div class="course-item">
+                                <span class="course-name">Statement of Accomplishment - Intermediate R Course</span>
+                                <span class="course-info">Marketing Analytics In Practice - Coursera</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Marketing Analytics in R</span>
+                                <span class="course-info">PPGA - Graduate Program in Business Administration</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Fundamentals of Problem Solving</span>
+                                <span class="course-info">Marketing in a Digital World - Illinois University</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-experience">Professional Experience</h2>
-            <div id="experience-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-education">Education</h2>
-            <div id="education-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-projects">Projects & Innovation</h2>
-            <div id="projects-container"></div>
+            <h2 class="section-title">PROFESSIONAL EXPERIENCE</h2>
+            
+            <div class="experience-timeline">
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">CADASTRA (Digital Marketing and Performance Agency)</div>
+                        </div>
+                        <div class="period">2025-Present</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">Data Analytics Coordinator</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">Sep/2025-Present</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Leading Data Analytics and AI operations for enterprise clients in technology, retail and education sectors, managing multidisciplinary team (DataViz, Data Engineering, Web Analytics)</li>
+                        <li>Simultaneous management of strategic accounts with direct interface to C-level stakeholders and business areas (Performance, E-commerce, Commercial)</li>
+                        <li>Data architecture and governance definition for Business Intelligence, Real-Time Analytics and AI applications projects</li>
+                        <li>Technical diagnosis and restructuring of legacy data environments, including infrastructure migration (AWS→GCP) with projected 40% reduction in processing costs</li>
+                        <li>Data operations restructuring with team expansion (+67%) and scope extension to multiple LATAM business units</li>
+                        <li>Stabilization of critical data environments, achieving 20% savings in operational processing costs (Airflow/DAGs)</li>
+                        <li>Development of automations with n8n and AI Agents (LLMs), including automated Status Report with AI-generated executive summaries</li>
+                        <li>Leadership of first generative AI initiatives in client operations, positioning the area as innovation reference</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">LOJAS RENNER | REALIZE CFI (National Financial Services Company)</div>
+                        </div>
+                        <div class="period">2020-2025</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">CRM Manager</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2021-2025</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for leading the strategic CRM front, focusing on area evolution, customer base growth, and business value generation</li>
+                        <li>Definition and monitoring of area OKRs, connecting business goals to relationship indicators</li>
+                        <li>Planning, execution, and optimization of multichannel relationship campaigns (email, SMS, push, among others), applying intelligent segmentations and automations to increase usage frequency and sales</li>
+                        <li>Building personalized journeys based on customer behavior and profile, promoting lifecycle evolution and loyalty in financial products (cards, loans, insurance, and consumption in the Renner ecosystem)</li>
+                        <li>Management of agile management rhythm (daily, planning, reviews, and retrospectives), using frameworks such as Scrum and Kanban to maintain delivery pace, priority visibility, and impact focus</li>
+                        <li>Area backlog management, with mapping, prioritization, and organization of demands according to incremental value and alignment with the commercial team</li>
+                        <li>Strategic management of suppliers and technology partners, including CRM platforms, automation, and data enrichment, ensuring delivery quality and alignment with area guidelines</li>
+                        <li>Continuous interface with key areas (IT, Products, Analytics, Marketing, Stores, and Commercial), promoting alignment between CRM initiatives and corporate objectives</li>
+                        <li>Technical and operational management of tools such as Oracle Responsys, Databricks, and Power BI, enabling automated segmentations, data processing, and performance dashboards</li>
+                        <li>Monitoring and analysis of KPIs and campaign indicators, using data to guide decisions, validate hypotheses, and promote continuous improvement</li>
+                        <li>Leadership of strategic projects and initiatives to expand the active customer base and activate new communication channels</li>
+                    </ul>
+                    
+                    <div class="job-title" style="margin-top: 15px; margin-bottom: 8px;">Analytics Specialist</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2020-2021</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for creating dashboards and strategic indicators for areas such as Marketing, CRM, Credit, and Channels, delivering an integrated real-time view to support business decisions</li>
+                        <li>Development of segmented databases and automated reports focused on the CRM team, with a focus on efficiency gains, agility in analyses, and revenue generation through more precise actions</li>
+                        <li>Organization and integration of operational, behavioral, and transactional data, consolidating multiple sources into a reliable base for comprehensive customer lifecycle analyses</li>
+                        <li>Practical use of tools such as SQL, BigQuery, Python, and Power BI for exploratory analyses, routine automations, and development of predictive models applied to the business</li>
+                        <li>Close collaboration with Marketing, Products, Risk, and Operations areas, translating strategic needs into applicable analyses, focusing on action direction and decision-making</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Analytics Specialist</div>
+                            <div class="company">DBC COMPANY (National IT Consulting Company)</div>
+                        </div>
+                        <div class="period">2020-2021</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for supporting the strategic restructuring of the CRM area at client Realize, implementing agile methodologies (Kanban) and defining processes that reduced campaign time-to-market and increased operational efficiency</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Business Intelligence Analyst</div>
+                            <div class="company">GRUPO RBS (National Media Company)</div>
+                        </div>
+                        <div class="period">2019 - 2020</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for structuring and analyzing commercial performance, audience, and market behavior data, supporting leadership in strategic decision-making for client Rede Globo</li>
+                        <li>Development of segmentation studies and consumption potential mapping, using data to guide decisions, validate hypotheses, and promote sales and prospecting actions</li>
+                        <li>Creation of real-time analytical reports and dashboards to support business decisions</li>
+                        <li>Direct interface with leadership, translating market data into action plans and growth opportunities</li>
+                        <li>Analysis of KPIs and campaign indicators, using data to guide decisions, validate hypotheses, and promote continuous improvement</li>
+                    </ul>
+                </div>
+            </div>
         </section>
     </div>
-
-    <script src="../assets/js/cv-texts.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            var lang = 'en';
-            initializeBasicContent(lang);
-            renderSkills('skills-strategic', 'strategic', lang);
-            renderSkills('skills-tools', 'tools', lang);
-            renderSkills('skills-emerging', 'emerging', lang);
-            renderExperienceTimeline(lang);
-            renderEducation(lang);
-            renderProjects(lang);
-        });
-    </script>
+    <!-- Dynamic Favicon System -->
+    <script src="../assets/js/dynamic-favicon.js"></script>
 </body>
 </html>

--- a/cv_styles/cv_grupo-rbs_style_PT.html
+++ b/cv_styles/cv_grupo-rbs_style_PT.html
@@ -3,532 +3,669 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pedro Henrique Marconato - CV</title>
+    <title>Pedro Henrique Marconato - CV (Grupo RBS)</title>
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@400;500;600;700&display=swap');
-        @import url('https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,600;0,8..60,700;1,8..60,400&display=swap');
-        @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&display=swap');
-
+        @import url('https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,600;8..60,700&display=swap');
+        
         :root {
-            /* Grupo RBS — navy institucional + paleta editorial derivada (brandbook) */
-            --rbs-navy: #003563;
-            --rbs-navy-deep: #00294D;
-            --rbs-blue: #0A5394;
-            --rbs-sky: #2E77B8;
-            --rbs-ice: #EAF2F9;
-            --rbs-red: #D64545;
-            --rbs-ink: #16283C;
-
-            --primary-color: var(--rbs-navy);
-            --secondary-color: var(--rbs-blue);
-            --accent-color: var(--rbs-red);
-            --text-color: var(--rbs-ink);
+            /* Grupo RBS — brand tokens */
+            --primary-color: #003563;
+            --secondary-color: #0A5394;
+            --accent-color: #D64545;
+            --light-accent: #EAF2F9;
+            --text-color: #16283C;
             --border-color: rgba(0, 53, 99, 0.18);
-            --background-gradient: linear-gradient(150deg, var(--rbs-navy-deep) 0%, var(--rbs-navy) 55%, var(--rbs-blue) 100%);
+            --background-gradient: linear-gradient(150deg, #00294D 0%, #003563 55%, #0A5394 100%);
 
             --font-body: 'Source Sans 3', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            --font-serif: 'Source Serif 4', Georgia, 'Times New Roman', serif;
-            --font-mono: 'IBM Plex Mono', 'SF Mono', Menlo, monospace;
+            --font-display: 'Source Serif 4', Georgia, 'Times New Roman', serif;
+
+            --header-text: #ffffff;
+            --header-text-soft: rgba(255, 255, 255, 0.95);
+            --header-chip-bg: rgba(255, 255, 255, 0.15);
+            --header-chip-border: rgba(255, 255, 255, 0.28);
+
+            --tag-bg: rgba(214, 69, 69, 0.12);
+            --tag-border: rgba(214, 69, 69, 0.28);
         }
-
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-
+        
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
         body {
             font-family: var(--font-body);
             color: var(--text-color);
-            line-height: 1.5;
-            background: #e7edf3;
-            font-size: 12px;
-            -webkit-print-color-adjust: exact;
-            print-color-adjust: exact;
+            line-height: 1.6;
+            background: var(--light-accent);
+            min-height: 100vh;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
         }
 
+        /* Main container */
         .cv-container {
             max-width: 210mm;
-            margin: 14px auto;
-            background: #ffffff;
-            box-shadow: 0 4px 24px rgba(0, 53, 99, 0.14);
-            border-radius: 4px;
+            margin: 0 auto;
+            background: rgba(255, 255, 255, 1);
             overflow: hidden;
+            position: relative;
         }
-
-        /* ===== Header — masthead navy ===== */
+        
+        /* Header Section */
         .header {
             background: var(--background-gradient);
-            color: #ffffff;
-            padding: 28px 40px 32px;
-            text-align: center;
+            padding: 50px 50px 55px 50px;
             position: relative;
+            overflow: hidden;
+        }
+        
+        .header-content {
+            position: relative;
+            z-index: 1;
         }
 
-        .brand-logo {
-            width: 150px;
-            margin: 0 auto 14px;
-        }
-
-        .brand-logo img {
-            width: 100%;
+.brand-logo {
+            position: absolute;
+            bottom: 20px;
+            right: 40px;
+            width: 148px;
             height: auto;
-            display: block;
-            margin: 0 auto;
+            opacity: 0.95;
             filter: brightness(0) invert(1);
         }
-
-        #cv-name {
-            font-family: var(--font-serif);
-            font-size: 25px;
+        
+        .header h1 {
+            font-family: var(--font-display);
+            font-size: 32px;
             font-weight: 700;
-            letter-spacing: -0.3px;
-            display: inline-block;
-            position: relative;
-            padding-bottom: 10px;
-            margin-bottom: 10px;
+            color: var(--header-text);
+            margin-bottom: 8px;
+            letter-spacing: -0.5px;
+            text-transform: uppercase;
         }
 
-        #cv-name::after {
-            content: '';
-            position: absolute;
-            bottom: 0;
-            left: 50%;
-            transform: translateX(-50%);
-            width: 64px;
-            height: 3px;
-            border-radius: 2px;
-            background: linear-gradient(90deg, var(--rbs-sky), var(--rbs-red));
-        }
-
-        #cv-role {
-            font-family: var(--font-serif);
-            font-style: italic;
+        .header-tagline {
+            font-size: 17px;
             font-weight: 400;
-            font-size: 13px;
-            color: rgba(255, 255, 255, 0.92);
-            margin-bottom: 16px;
+            color: var(--header-text-soft);
+            margin-top: 22px;
+            margin-bottom: 28px;
+            font-style: italic;
+            letter-spacing: 0.5px;
         }
-
+        
         .contact-info {
             display: flex;
             flex-wrap: wrap;
-            justify-content: center;
-            gap: 8px;
+            gap: 10px;
+            align-items: center;
+            margin-top: 12px;
         }
-
-        .contact-pill {
+        
+        .contact-item {
             display: inline-flex;
             align-items: center;
-            gap: 5px;
-            background: rgba(255, 255, 255, 0.14);
-            border: 1px solid rgba(255, 255, 255, 0.28);
-            border-radius: 20px;
-            padding: 4px 11px;
-            font-size: 10px;
-        }
-
-        .contact-pill i { font-size: 9.5px; color: #9CC4E8; }
-        .contact-pill a { color: #ffffff; text-decoration: none; }
-
-        /* ===== Sections ===== */
-        .section { padding: 14px 34px; }
-        .section:not(:last-of-type) { border-bottom: 1px solid var(--border-color); }
-
-        .section-title {
-            display: inline-block;
-            font-family: var(--font-serif);
+            background: var(--header-chip-bg);
+            border-radius: 10px;
+            padding: 8px 14px;
+            color: var(--header-text);
             font-size: 12.5px;
-            font-weight: 700;
-            letter-spacing: 0.4px;
-            text-transform: uppercase;
-            color: #ffffff;
-            background: var(--rbs-navy);
-            border-left: 4px solid var(--rbs-red);
-            border-radius: 3px 10px 10px 3px;
-            padding: 5px 14px 5px 12px;
-            margin-bottom: 10px;
+            font-weight: 500;
+            border: 1px solid var(--header-chip-border);
         }
-
-        #cv-profile {
-            font-size: 11px;
-            line-height: 1.65;
-            text-align: justify;
+        
+        .contact-item i {
+            margin-right: 6px;
+            font-size: 12px;
         }
-
-        /* ===== Skills ===== */
-        .skills-grid {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 12px;
-        }
-
-        .skills-column {
-            background: linear-gradient(165deg, var(--rbs-ice), rgba(234, 242, 249, 0.35));
-            border: 1px solid var(--border-color);
-            border-top: 3px solid var(--rbs-navy);
-            border-radius: 6px;
-            padding: 10px 12px;
-        }
-
-        .skills-column:nth-child(2) { border-top-color: var(--rbs-blue); }
-        .skills-column:nth-child(3) { border-top-color: var(--rbs-sky); }
-
-        .skills-column h3 {
-            font-family: var(--font-serif) !important;
-            font-size: 11.5px !important;
-            font-weight: 700 !important;
-            color: var(--rbs-navy) !important;
-            text-transform: uppercase;
-            letter-spacing: 0.3px;
-            padding-bottom: 4px;
-            margin-bottom: 8px !important;
+        
+        /* Section Styles */
+        .section {
+            padding: 25px 50px;
             border-bottom: 1px solid var(--border-color);
         }
 
-        .tool-item { margin-bottom: 7px; }
+        .section:last-child {
+            border-bottom: none;
+        }
 
-        .tool-name {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            gap: 6px;
+        .section-title {
+            font-family: var(--font-display);
+            background: var(--primary-color);
+            color: white;
+            font-size: 15px;
             font-weight: 600;
-            font-size: 10px;
-            margin-bottom: 3px;
-        }
-
-        .tool-percentage {
-            font-family: var(--font-mono);
-            font-size: 7.5px;
-            font-weight: 600;
-            text-transform: uppercase;
-            letter-spacing: 0.4px;
-            color: var(--rbs-blue);
-            background: rgba(10, 83, 148, 0.08);
-            border: 1px solid rgba(10, 83, 148, 0.22);
-            padding: 1px 6px;
-            border-radius: 3px;
-            white-space: nowrap;
-        }
-
-        .dots-container { display: flex; gap: 3px; }
-        .dot { width: 5px; height: 5px; border-radius: 50%; background: rgba(0, 53, 99, 0.16); }
-        .dot.filled { background: var(--rbs-navy); }
-
-        /* Tooltip não funciona no papel */
-        .tooltip { display: none; }
-
-        /* ===== Experiência ===== */
-        .experience-item {
-            position: relative;
-            margin-bottom: 12px;
-            padding: 11px 14px 11px 16px;
-            background: linear-gradient(155deg, #ffffff, rgba(234, 242, 249, 0.5));
-            border: 1px solid var(--border-color);
-            border-left: 3px solid var(--rbs-navy);
-            border-radius: 5px;
-            page-break-inside: avoid;
-        }
-
-        .job-title {
-            display: flex;
-            align-items: center;
-            gap: 7px;
-            font-family: var(--font-serif);
-            font-weight: 700;
-            font-size: 12.5px;
-            color: var(--rbs-navy);
-            margin-bottom: 4px;
-        }
-
-        .job-number {
-            display: inline-flex;
-            align-items: center;
-            background: var(--rbs-navy);
-            color: #ffffff;
-            font-family: var(--font-mono);
-            font-size: 8.5px;
-            font-weight: 600;
-            padding: 2px 6px;
-            border-radius: 3px;
-            flex-shrink: 0;
-        }
-
-        .job-number::before {
-            content: 'ED. ';
-            font-size: 7px;
-            opacity: 0.75;
-        }
-
-        .company {
-            font-weight: 600;
-            font-size: 10.5px;
-            color: var(--rbs-blue);
-            margin-bottom: 2px;
-        }
-
-        .period {
+            margin-bottom: 18px;
+            padding: 8px 16px;
+            border-radius: 12px;
+            letter-spacing: 0.3px;
             display: inline-block;
-            font-family: var(--font-mono);
-            font-size: 8.5px;
-            color: #51667E;
-            background: rgba(0, 53, 99, 0.06);
-            border: 1px solid rgba(0, 53, 99, 0.16);
-            padding: 2px 8px;
-            border-radius: 3px;
-            margin-bottom: 7px;
+            text-transform: uppercase;
         }
 
-        .job-description {
-            font-size: 10px;
-            line-height: 1.5;
-            margin-bottom: 7px;
+        /* Resumo de Qualificações */
+        .qualifications-list {
+            list-style: none;
+            padding: 0;
         }
 
-        .achievements-container {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 6px;
-        }
-
-        .achievement-item {
-            display: flex;
-            gap: 6px;
-            background: rgba(0, 53, 99, 0.045);
-            border: 1px solid rgba(0, 53, 99, 0.13);
-            border-radius: 5px;
-            padding: 6px 8px;
-        }
-
-        .achievement-icon {
-            color: var(--rbs-blue);
-            font-size: 10.5px;
-            padding-top: 1px;
-            flex-shrink: 0;
-        }
-
-        .achievement-content { flex: 1; }
-
-        .achievement-title {
-            font-weight: 600;
-            font-size: 9px;
-            color: var(--rbs-navy);
-            margin-bottom: 2px;
-        }
-
-        .achievement-description {
-            font-size: 8.5px;
-            line-height: 1.4;
+        .qualifications-list li {
+            position: relative;
+            padding-left: 28px;
+            margin-bottom: 14px;
+            font-size: 13.5px;
+            line-height: 1.7;
             color: var(--text-color);
         }
 
-        /* ===== Formação ===== */
-        #education-container {
+        .qualifications-list li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+            font-size: 20px;
+            top: -2px;
+        }
+        
+        /* Skills & Tools Grid */
+        .skills-grid {
             display: grid;
             grid-template-columns: 1fr 1fr;
-            gap: 10px;
+            gap: 20px;
+        }
+
+        .skills-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 16px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
+        }
+
+        .skills-section h3 {
+            font-size: 12px;
+            color: var(--primary-color);
+            margin-bottom: 10px;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .skill-items {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
+
+        .skill-tag {
+            background: var(--tag-bg);
+            color: var(--primary-color);
+            padding: 4px 10px;
+            border-radius: 12px;
+            font-size: 10.5px;
+            font-weight: 500;
+            border: 1px solid var(--tag-border);
+        }
+
+        /* Cursos Complementares */
+        .courses-section {
+            margin-top: 10px;
+        }
+
+        .course-item {
+            padding: 8px 0;
+            border-bottom: 1px solid var(--border-color);
+            font-size: 11px;
+        }
+
+        .course-item:last-child {
+            border-bottom: none;
+        }
+
+        .course-name {
+            color: var(--text-color);
+            font-weight: 500;
+            display: block;
+            margin-bottom: 2px;
+        }
+
+        .course-info {
+            color: var(--secondary-color);
+            font-size: 10px;
+            font-style: italic;
+        }
+        
+        /* Experience Timeline */
+        .experience-timeline {
+            position: relative;
+            margin-left: 20px;
+            padding-left: 30px;
+        }
+        
+        .experience-timeline::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            top: 0;
+            bottom: 0;
+            width: 3px;
+            background: var(--primary-color);
+            border-radius: 3px;
+        }
+        
+        .experience-item {
+            margin-bottom: 25px;
+            position: relative;
+            padding: 18px;
+            border-radius: 14px;
+            background: #fff;
+            border: 1px solid var(--border-color);
+        }
+        
+        .experience-item::before {
+            content: "";
+            position: absolute;
+            left: -36px;
+            top: 25px;
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background: var(--accent-color);
+            border: 3px solid white;
+        }
+        
+        .job-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-bottom: 10px;
+        }
+
+        .job-title {
+            font-family: var(--font-display);
+            font-weight: 600;
+            font-size: 16px;
+            color: var(--primary-color);
+            margin-bottom: 4px;
+        }
+        
+        .company {
+            font-weight: 500;
+            font-size: 13px;
+            color: var(--secondary-color);
+        }
+        
+        .period {
+            font-size: 12px;
+            color: var(--secondary-color);
+            font-weight: 600;
+            text-align: right;
+        }
+        
+        .job-description {
+            font-size: 12px;
+            line-height: 1.6;
+            color: var(--text-color);
+            margin-bottom: 12px;
+        }
+
+        .job-bullets {
+            list-style: none;
+            padding: 0;
+        }
+
+        .job-bullets li {
+            position: relative;
+            padding-left: 20px;
+            margin-bottom: 8px;
+            font-size: 12px;
+            line-height: 1.5;
+            color: var(--text-color);
+        }
+
+        .job-bullets li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+        }
+        
+        /* Education */
+        .education-tech-container {
+            display: grid;
+            grid-template-columns: 1fr 2fr;
+            gap: 25px;
+        }
+        
+        .education-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 20px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
         }
 
         .education-item {
-            background: linear-gradient(165deg, rgba(234, 242, 249, 0.9), rgba(234, 242, 249, 0.35));
-            border: 1px solid var(--border-color);
-            border-left: 3px solid var(--rbs-blue);
-            border-radius: 5px;
-            padding: 10px 12px;
-            page-break-inside: avoid;
+            margin-bottom: 12px;
+            padding-bottom: 12px;
+            border-bottom: 1px solid var(--border-color);
         }
 
+        .education-item:last-child {
+            margin-bottom: 0;
+            padding-bottom: 0;
+            border-bottom: none;
+        }
+        
         .degree {
-            font-family: var(--font-serif);
-            font-weight: 700;
-            font-size: 11px;
-            color: var(--rbs-navy);
+            font-family: var(--font-display);
+            font-weight: 600;
+            font-size: 13px;
+            color: var(--primary-color);
             margin-bottom: 3px;
         }
-
-        .university { font-size: 9.5px; margin-bottom: 3px; }
-        .thesis { font-size: 9px; font-style: italic; color: #51667E; }
-
-        .cta-button {
-            display: inline-flex;
-            align-items: center;
-            gap: 4px;
-            margin-top: 5px;
-            padding: 2px 7px;
-            background: var(--rbs-navy);
-            color: #ffffff;
-            border-radius: 3px;
-            text-decoration: none;
-            font-size: 8px;
+        
+        .university {
+            font-size: 11px;
+            color: var(--text-color);
+            margin-bottom: 2px;
+        }
+        
+        .edu-period {
+            font-size: 10px;
+            color: var(--secondary-color);
+            font-style: italic;
         }
 
-        /* ===== Projetos ===== */
-        #projects-container {
+        .tech-skills-container {
             display: grid;
-            grid-template-columns: 1fr 1fr 1fr;
-            gap: 10px;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 15px;
         }
 
-        .project-item {
-            position: relative;
-            background: #ffffff;
-            border: 1px solid var(--border-color);
-            border-radius: 5px;
-            padding: 10px 12px;
-            overflow: hidden;
-            page-break-inside: avoid;
+        /* Languages */
+        .language-container {
+            display: flex;
+            justify-content: center;
+            gap: 30px;
         }
 
-        .project-item::before {
-            content: '';
-            position: absolute;
-            top: 0; left: 0; right: 0;
-            height: 2.5px;
-            background: linear-gradient(90deg, var(--rbs-navy), var(--rbs-blue), var(--rbs-sky));
+        .language-item {
+            text-align: center;
         }
 
-        .project-title {
-            font-family: var(--font-serif);
-            font-weight: 700;
-            font-size: 10.5px;
-            color: var(--rbs-navy);
-            margin-top: 4px;
-            margin-bottom: 4px;
+        .language-name {
+            font-weight: 600;
+            color: var(--primary-color);
+            font-size: 13px;
+            margin-bottom: 2px;
         }
 
-        .project-description {
-            font-size: 9px;
-            line-height: 1.4;
-            margin-bottom: 6px;
+        .language-level {
+            font-size: 11px;
+            color: var(--text-color);
         }
 
-        .tech-tag {
-            display: inline-block;
-            font-family: var(--font-mono);
-            font-size: 7.5px;
-            padding: 2px 6px;
-            margin: 0 4px 4px 0;
-            background: rgba(0, 53, 99, 0.06);
-            color: var(--rbs-blue);
-            border: 1px solid rgba(0, 53, 99, 0.18);
-            border-radius: 3px;
-        }
-
-        /* ===== Print ===== */
+        /* Print Styles */
         @media print {
             body {
+                background: white;
                 margin: 0;
                 padding: 0;
-                background: #ffffff;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
             }
 
-            .cv-container { max-width: none; margin: 0; box-shadow: none; border-radius: 0; }
+            .cv-container {
+                max-width: 100%;
+                margin: 0;
+                box-shadow: none;
+            }
 
             .header {
                 background: var(--background-gradient) !important;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
-                padding: 16px 30px 20px !important;
+                padding: 25px 35px !important;
+                page-break-after: avoid;
             }
-
-            #cv-name { font-size: 20px !important; padding-bottom: 8px !important; }
-            #cv-role { font-size: 11px !important; margin-bottom: 10px !important; }
-            .contact-pill { font-size: 8.5px !important; padding: 3px 9px !important; }
 
             .section-title {
-                background: var(--rbs-navy) !important;
+                background: var(--primary-color) !important;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
-                font-size: 10.5px !important;
-                padding: 4px 11px 4px 10px !important;
-                margin-bottom: 8px !important;
+                color: white !important;
+                page-break-after: avoid;
             }
 
-            .section { padding: 9px 26px !important; }
-            #cv-profile { font-size: 9.5px !important; }
-
-            .skills-column { padding: 8px 10px !important; }
-            .skills-column h3 { font-size: 10px !important; margin-bottom: 6px !important; }
-            .tool-item { margin-bottom: 5px !important; }
-
-            .experience-item, .education-item, .project-item {
+            .section {
+                padding: 15px 35px;
                 page-break-inside: avoid;
-                margin-bottom: 8px !important;
             }
 
-            .job-title { font-size: 11px !important; }
-            .company { font-size: 9.5px !important; }
-            .job-description { font-size: 9px !important; }
-            .achievement-title { font-size: 8.5px !important; }
-            .achievement-description { font-size: 8px !important; }
-            .degree { font-size: 10px !important; }
-            .project-title { font-size: 10px !important; }
+            .experience-item {
+                page-break-inside: avoid;
+            }
 
-            * { animation: none !important; transition: none !important; }
+            /* Hide animations */
+            * {
+                animation: none !important;
+            }
 
-            @page { size: A4; margin: 8mm; }
+            @page {
+                size: A4;
+                margin: 8mm;
+            }
         }
+        .contact-info { max-width: calc(100% - 180px); }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <!-- Favicon Meta Tags -->
+    <meta name="theme-color" content="#003563">
+    <meta name="msapplication-TileColor" content="#003563">
+    <meta name="msapplication-config" content="../assets/favicons/browserconfig.xml">
 </head>
 <body>
     <div class="cv-container">
         <header class="header">
-            <div class="brand-logo">
-                <img src="../assets/images/grupo-rbs.png" alt="Grupo RBS">
-            </div>
-            <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
-            <h2 id="cv-role">Gestão de CRM e Inteligência de Dados</h2>
-            <div class="contact-info">
-                <span class="contact-pill"><i class="fas fa-envelope"></i><span id="cv-email">pedrohmarconato@gmail.com</span></span>
-                <span class="contact-pill"><i class="fas fa-phone"></i><span id="cv-phone">+55 (55) 981147758</span></span>
-                <span class="contact-pill"><i class="fas fa-map-marker-alt"></i><span id="cv-location"><span>Cachoeira do Sul, RS</span></span></span>
-                <span class="contact-pill"><i class="fab fa-linkedin"></i><a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin">LinkedIn</a></span>
-                <span class="contact-pill"><i class="fab fa-github"></i><a href="https://github.com/pedrohmarconato" id="cv-repository">Repositório</a></span>
+            <div class="header-content">
+                <img src="../assets/images/grupo-rbs.png" alt="Grupo RBS" class="brand-logo">
+                <h1>PEDRO HENRIQUE MARCONATO</h1>
+                
+                <div class="header-tagline">CRM | ANALYTICS | BUSINESS INTELLIGENCE | LTV | SQL</div>
+                
+                <div class="contact-info">
+                    <div class="contact-item">
+                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 35 anos
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-phone"></i> +55 (55) 98114-7758
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-envelope"></i> pedrohmarconato@gmail.com
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fab fa-linkedin"></i> linkedin.com/in/pedrohmarconato
+                    </div>
+                </div>
             </div>
         </header>
-
-        <section class="section">
-            <h2 class="section-title" id="section-profile">Perfil Profissional</h2>
-            <p id="cv-profile"></p>
+        
+        <section class="section" style="padding-top: 35px;">
+            <h2 class="section-title">RESUMO DE QUALIFICAÇÕES</h2>
+            <ul class="qualifications-list">
+                <li>Mestre em Administração de Empresas, com ênfase na área de Analytics, unindo inteligência de dados, CRM, visualização analítica e automação para gerar valor ao negócio</li>
+                <li>Atuação em empresas de grande porte e alta complexidade, como Grupo RBS, Realize CFI (Grupo Lojas Renner S.A.) e Rede Globo, liderando projetos estratégicos nas frentes de CRM, inteligência comercial e performance de marketing</li>
+                <li>Vivência com dados aplicados a marketing, canais, crédito, controle e operações, conectando áreas e traduzindo necessidades técnicas em soluções analíticas de alto impacto</li>
+                <li>Destaques em projetos de visualização, segmentação e comportamento de consumo, com domínio de ferramentas como Databricks, SQL, Responsys, Power BI, Python, Salesforce, Mailchimp, Tableau, SAS, Mix Agents e Kanbanize</li>
+                <li>Conhecimento em metodologias ágeis (Scrum, Kanban), com atuação na priorização de backlog, estruturação de squads e aceleração de entrega com foco no cliente</li>
+                <li>Experiência com integração de dados de múltiplas fontes, construção de pipelines, análises preditivas e mapeamento de comportamento para suportar decisões estratégicas</li>
+                <li>Diferencial na combinação entre capacidade analítica, pensamento estratégico e conhecimento técnico, com atuação reconhecida como liderança mesmo em estruturas consultivas</li>
+                <li>Gestão de pessoas, liderando times multidisciplinares com foco em desenvolvimento, autonomia e geração de resultados consistentes</li>
+            </ul>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-skills">Habilidades e Ferramentas</h2>
-            <div class="skills-grid">
-                <div class="skills-column" id="skills-strategic"></div>
-                <div class="skills-column" id="skills-tools"></div>
-                <div class="skills-column" id="skills-emerging"></div>
+            <h2 class="section-title">FORMAÇÃO ACADÊMICA & TECNOLOGIA</h2>
+            <div class="education-tech-container">
+                <div class="education-section">
+                    <h3 style="font-size: 12px; color: var(--primary-color); margin-bottom: 12px; font-weight: 600;">FORMAÇÃO</h3>
+                    <div class="education-item">
+                        <div class="degree">Mestrado em Administração de Empresas</div>
+                        <div class="university">Universidade Federal de Santa Maria - UFSM</div>
+                        <div class="edu-period">Conclusão: 2019</div>
+                    </div>
+                    
+                    <div class="education-item">
+                        <div class="degree">Bacharelado em Administração</div>
+                        <div class="university">Universidade Federal de Santa Maria - UFSM</div>
+                        <div class="edu-period">Conclusão: 2015</div>
+                    </div>
+                </div>
+                
+                <div class="tech-skills-container">
+                    <div class="skills-section">
+                        <h3>FERRAMENTAS & PLATAFORMAS</h3>
+                        <div class="skill-items">
+                            <span class="skill-tag">Databricks</span>
+                            <span class="skill-tag">SQL</span>
+                            <span class="skill-tag">Power BI</span>
+                            <span class="skill-tag">Python</span>
+                            <span class="skill-tag">Oracle Responsys</span>
+                            <span class="skill-tag">Kanbanize</span>
+                            <span class="skill-tag">Mailchimp</span>
+                            <span class="skill-tag">Mix Agents</span>
+                            <span class="skill-tag">SAS</span>
+                            <span class="skill-tag">Tableau</span>
+                            <span class="skill-tag">Salesforce CRM</span>
+                        </div>
+                    </div>
+                    
+                    <div class="skills-section">
+                        <h3>CERTIFICAÇÕES & CURSOS</h3>
+                        <div class="courses-section">
+                            <div class="course-item">
+                                <span class="course-name">Statement of Accomplishment - Intermediate R Course</span>
+                                <span class="course-info">Marketing Analytics In Practice - Coursera</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Marketing Analytics em R</span>
+                                <span class="course-info">PPGA - Programa de Pós-Graduação em Administração</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Fundamentos de Solução de Problemas</span>
+                                <span class="course-info">Marketing in a Digital World - Illinois University</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-experience">Experiência Profissional</h2>
-            <div id="experience-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-education">Formação Acadêmica</h2>
-            <div id="education-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-projects">Projetos e Inovação</h2>
-            <div id="projects-container"></div>
+            <h2 class="section-title">EXPERIÊNCIA PROFISSIONAL</h2>
+            
+            <div class="experience-timeline">
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">CADASTRA (Agência de Marketing Digital e Performance)</div>
+                        </div>
+                        <div class="period">2025-Atual</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">Coordenador de Data Analytics</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">Set/2025-Atual</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável pela operação de Data Analytics e AI para clientes de grande porte dos setores de tecnologia, varejo e educação, liderando time multidisciplinar (DataViz, Engenharia de Dados, Web Analytics)</li>
+                        <li>Gestão simultânea de contas estratégicas, com interface direta com stakeholders C-level e áreas de negócio (Performance, E-commerce, Comercial)</li>
+                        <li>Definição de arquitetura de dados e governança para projetos de Business Intelligence, Real-Time Analytics e aplicações de inteligência artificial</li>
+                        <li>Diagnóstico técnico e reestruturação de ambientes de dados legados, incluindo migração de infraestrutura (AWS→GCP) com redução projetada de 40% em custos de processamento</li>
+                        <li>Reestruturação de operações de dados com expansão de time (+67%) e ampliação de escopo para múltiplas unidades de negócio em LATAM</li>
+                        <li>Estabilização de ambientes críticos de dados, alcançando economia de 20% em custos operacionais de processamento (Airflow/DAGs)</li>
+                        <li>Desenvolvimento de automações com n8n e AI Agents (LLMs), incluindo Status Report automatizado com geração de resumos executivos por inteligência artificial</li>
+                        <li>Liderança das primeiras iniciativas de aplicação de IA generativa em operações de clientes, posicionando a área como referência em inovação</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">LOJAS RENNER | REALIZE CFI (Empresa Nacional do segmento Financeiro)</div>
+                        </div>
+                        <div class="period">2020-2025</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">CRM Manager</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2021-2025</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável pela liderança da frente estratégica de CRM, com foco na evolução da área, crescimento da base de clientes e geração de valor ao negócio</li>
+                        <li>Definição e acompanhamento dos OKRs da área, conectando metas do negócio a indicadores de relacionamento</li>
+                        <li>Planejamento, execução e otimização de campanhas de relacionamento multicanal (e-mail, SMS, push, entre outros), aplicando segmentações inteligentes e automações para aumentar frequência de uso e vendas</li>
+                        <li>Construção de jornadas personalizadas com base em comportamento e perfil dos clientes, promovendo a evolução do ciclo de vida e fidelização em produtos financeiros (cartões, empréstimos, seguros e consumo no ecossistema Renner)</li>
+                        <li>Gestão do ritmo de gestão ágil (daily, planning, reviews e retrospectives), utilizando frameworks como Scrum e Kanban para manter ritmo de entrega, visibilidade de prioridades e foco em impacto</li>
+                        <li>Gestão do backlog da área, com mapeamento, priorização e organização das demandas de acordo com o valor incremental e alinhamento com o time comercial</li>
+                        <li>Gestão estratégica de fornecedores e parceiros de tecnologia, incluindo plataformas de CRM, automação e enriquecimento de dados, garantindo qualidade das entregas e alinhamento às diretrizes da área</li>
+                        <li>Interface contínua com áreas-chave (TI, Produtos, Analytics, Marketing, Lojas e Comercial), promovendo alinhamento entre as iniciativas de CRM e os objetivos corporativos</li>
+                        <li>Gestão técnica e operacional de ferramentas como Oracle Responsys, Databricks e Power BI, viabilizando segmentações automatizadas, tratamento de dados e dashboards de performance</li>
+                        <li>Monitoramento e análise de KPIs e indicadores de campanhas, utilizando dados para orientar decisões, validar hipóteses e promover a melhoria contínua</li>
+                        <li>Liderança de projetos e iniciativas estratégicas de expansão da base ativa de clientes e ativação de novos canais de comunicação</li>
+                    </ul>
+                    
+                    <div class="job-title" style="margin-top: 15px; margin-bottom: 8px;">Especialista de Analytics</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2020-2021</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável por criar dashboards e indicadores estratégicos para áreas como Marketing, CRM, Crédito e Canais, entregando uma visão integrada e em tempo real para apoiar decisões de negócio</li>
+                        <li>Desenvolvimento de bases segmentadas e relatórios automatizados voltados ao time de CRM, com foco em ganho de eficiência, agilidade nas análises e geração de receita por meio de ações mais precisas</li>
+                        <li>Organização e integração de dados operacionais, comportamentais e transacionais, consolidando múltiplas fontes em uma base confiável para análises completas do ciclo de vida do cliente</li>
+                        <li>Utilização prática de ferramentas como SQL, BigQuery, Python e Power BI para análises exploratórias, automações de rotinas e desenvolvimento de modelos preditivos aplicados ao negócio</li>
+                        <li>Atuação próxima às áreas de Marketing, Produtos, Riscos e Operações, traduzindo necessidades estratégicas em análises aplicáveis, com foco em direcionamento de ações e tomada de decisão</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Especialista de Analytics</div>
+                            <div class="company">DBC COMPANY (Empresa Nacional do segmento de Consultoria em TI)</div>
+                        </div>
+                        <div class="period">2020-2021</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável por apoiar a reestruturação estratégica da área de CRM no cliente Realize, implementando metodologias ágeis (Kanban) e definindo processos que reduziram o time-to-market das campanhas e aumentaram a eficiência operacional</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Analista de Inteligência Comercial</div>
+                            <div class="company">GRUPO RBS (Empresa Nacional do segmento de Mídia)</div>
+                        </div>
+                        <div class="period">2019 - 2020</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável pela estruturação e análise dados de desempenho comercial, audiência e comportamento de mercado, apoiando a liderança na tomada de decisões estratégicas do cliente Rede Globo</li>
+                        <li>Desenvolvimento de estudos de segmentação e mapeamento de potencial de consumo, utilizando dados para orientar decisões, validar hipóteses e promover ações de vendas e prospecção</li>
+                        <li>Criação de relatórios e dashboards analíticos em tempo real para apoiar decisões do negócio</li>
+                        <li>Interface direta com a liderança, traduzindo dados de mercado em planos de ação e oportunidades de crescimento</li>
+                        <li>Análise de KPIs e indicadores de campanhas, utilizando dados para orientar decisões, validar hipóteses e promover a melhoria contínua</li>
+                    </ul>
+                </div>
+            </div>
         </section>
     </div>
-
-    <script src="../assets/js/cv-texts.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            var lang = 'pt';
-            initializeBasicContent(lang);
-            renderSkills('skills-strategic', 'strategic', lang);
-            renderSkills('skills-tools', 'tools', lang);
-            renderSkills('skills-emerging', 'emerging', lang);
-            renderExperienceTimeline(lang);
-            renderEducation(lang);
-            renderProjects(lang);
-        });
-    </script>
+    <!-- Dynamic Favicon System -->
+    <script src="../assets/js/dynamic-favicon.js"></script>
 </body>
 </html>

--- a/cv_styles/cv_itau_style_EN.html
+++ b/cv_styles/cv_itau_style_EN.html
@@ -3,482 +3,672 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pedro Henrique Marconato - CV</title>
+    <title>Pedro Henrique Marconato - CV (Itaú)</title>
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,400&display=swap');
-
+        @import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap');
+        
         :root {
-            /* Itaú — 2023 rebrand, "river stones" */
-            --itau-orange: #FF6200;
-            --itau-burnt: #C24E00;
-            --itau-terracotta: #8F3A00;
-            --itau-amber: #FFB300;
-            --itau-blue: #1E5BC6;
-            --itau-green: #00A868;
-            --itau-pink: #FF4D8D;
-            --itau-sand: #FFF4EC;
-            --itau-ink: #33261C;
-
-            --primary-color: var(--itau-orange);
-            --secondary-color: var(--itau-burnt);
-            --accent-color: var(--itau-amber);
-            --text-color: var(--itau-ink);
+            /* Itaú — brand tokens */
+            --primary-color: #FF6200;
+            --secondary-color: #C24E00;
+            --accent-color: #FFB300;
+            --light-accent: #FFF4EC;
+            --text-color: #33261C;
             --border-color: rgba(194, 78, 0, 0.16);
-            --background-gradient: linear-gradient(135deg, var(--itau-orange) 0%, var(--itau-burnt) 100%);
-            --stone-radius: 58% 42% 44% 56% / 52% 58% 42% 48%;
+            --background-gradient: linear-gradient(135deg, #FF6200 0%, #C24E00 100%);
+
+            --font-body: 'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            --font-display: 'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+
+            --header-text: #ffffff;
+            --header-text-soft: rgba(255, 255, 255, 0.95);
+            --header-chip-bg: rgba(255, 255, 255, 0.15);
+            --header-chip-border: rgba(255, 255, 255, 0.28);
+
+            --tag-bg: rgba(255, 179, 0, 0.16);
+            --tag-border: rgba(255, 179, 0, 0.34);
         }
-
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-
+        
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
         body {
-            font-family: 'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            font-family: var(--font-body);
             color: var(--text-color);
-            line-height: 1.5;
-            background: var(--itau-sand);
-            font-size: 12px;
+            line-height: 1.6;
+            background: var(--light-accent);
+            min-height: 100vh;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
         }
 
-        h1, .section-title, .job-title, .degree, .project-title {
-            font-weight: 800;
-        }
-
+        /* Main container */
         .cv-container {
             max-width: 210mm;
             margin: 0 auto;
-            background: #ffffff;
-            border-radius: 22px;
+            background: rgba(255, 255, 255, 1);
             overflow: hidden;
-            box-shadow: 0 14px 40px rgba(194, 78, 0, 0.16);
-        }
-
-        /* ===== Header ===== */
-        .header {
-            background:
-                radial-gradient(circle at 14% 18%, rgba(255, 158, 74, 0.5) 0%, transparent 46%),
-                radial-gradient(circle at 90% 88%, rgba(194, 78, 0, 0.55) 0%, transparent 52%),
-                var(--background-gradient);
-            padding: 20px 28px 24px;
-            border-radius: 0 0 40px 64px;
             position: relative;
         }
-
-        .header-top {
-            display: flex;
-            align-items: center;
-            gap: 16px;
-            margin-bottom: 12px;
+        
+        /* Header Section */
+        .header {
+            background: var(--background-gradient);
+            padding: 50px 50px 55px 50px;
+            position: relative;
+            overflow: hidden;
+        }
+        
+        .header-content {
+            position: relative;
+            z-index: 1;
         }
 
-        .brand-logo {
-            flex-shrink: 0;
+.brand-logo {
+            position: absolute;
+            bottom: 16px;
+            right: 34px;
+            width: 46px;
+            height: 46px;
+            padding: 8px;
             background: rgba(255, 255, 255, 0.96);
-            padding: 7px;
-            border-radius: 32% 68% 64% 36% / 48% 40% 60% 52%;
-            box-shadow: 0 6px 16px rgba(143, 58, 0, 0.32);
-            line-height: 0;
+            border-radius: 16px;
+            box-shadow: 0 6px 16px rgba(143, 58, 0, 0.3);
+            object-fit: contain;
         }
-
-        .brand-logo img { width: 42px; height: 42px; display: block; }
-
-        .header-text { flex: 1; min-width: 0; }
-
-        .tagline {
-            display: inline-flex;
-            align-items: center;
-            gap: 7px;
-            font-size: 8.5px;
-            font-weight: 600;
-            letter-spacing: 1.6px;
-            text-transform: lowercase;
-            color: rgba(255, 255, 255, 0.95);
-            background: rgba(143, 58, 0, 0.26);
-            border: 1px solid rgba(255, 255, 255, 0.3);
-            border-radius: 999px;
-            padding: 3px 11px;
-            margin-bottom: 7px;
-        }
-
-        .tagline-dot {
-            width: 5px;
-            height: 5px;
-            border-radius: 50%;
-            background: var(--itau-amber);
-            flex-shrink: 0;
-        }
-
+        
         .header h1 {
-            font-size: 20px;
-            color: white;
-            letter-spacing: -0.3px;
+            font-family: var(--font-display);
+            font-size: 32px;
+            font-weight: 700;
+            color: var(--header-text);
+            margin-bottom: 8px;
+            letter-spacing: -0.5px;
             text-transform: uppercase;
-            line-height: 1.15;
-            margin-bottom: 3px;
-            text-shadow: 0 2px 10px rgba(143, 58, 0, 0.3);
         }
 
-        .header h2 {
-            font-size: 11.5px;
-            font-weight: 500;
-            color: rgba(255, 255, 255, 0.95);
+        .header-tagline {
+            font-size: 17px;
+            font-weight: 400;
+            color: var(--header-text-soft);
+            margin-top: 22px;
+            margin-bottom: 28px;
+            font-style: italic;
+            letter-spacing: 0.5px;
         }
-
+        
         .contact-info {
             display: flex;
             flex-wrap: wrap;
-            gap: 7px;
+            gap: 10px;
+            align-items: center;
+            margin-top: 12px;
         }
-
+        
         .contact-item {
             display: inline-flex;
             align-items: center;
-            gap: 5px;
-            background: rgba(255, 255, 255, 0.16);
-            border: 1px solid rgba(255, 255, 255, 0.24);
-            border-radius: 999px;
-            padding: 3px 11px;
-            color: white;
-            font-size: 9px;
+            background: var(--header-chip-bg);
+            border-radius: 10px;
+            padding: 8px 14px;
+            color: var(--header-text);
+            font-size: 12.5px;
             font-weight: 500;
+            border: 1px solid var(--header-chip-border);
+        }
+        
+        .contact-item i {
+            margin-right: 6px;
+            font-size: 12px;
+        }
+        
+        /* Section Styles */
+        .section {
+            padding: 25px 50px;
+            border-bottom: 1px solid var(--border-color);
         }
 
-        .contact-item i { font-size: 8.5px; }
-
-        .contact-item a { color: white; text-decoration: none; }
-
-        /* ===== Sections ===== */
-        .section { padding: 14px 28px; }
-
-        .section:not(:last-child) { border-bottom: 1px solid var(--border-color); }
+        .section:last-child {
+            border-bottom: none;
+        }
 
         .section-title {
-            display: inline-block;
-            background: var(--background-gradient);
+            font-family: var(--font-display);
+            background: var(--primary-color);
             color: white;
-            font-size: 11px;
-            font-weight: 700;
-            letter-spacing: 0.8px;
-            text-transform: lowercase;
-            padding: 6px 18px;
-            border-radius: 999px;
-            margin-bottom: 10px;
-            box-shadow: 0 4px 12px rgba(255, 98, 0, 0.28);
+            font-size: 15px;
+            font-weight: 600;
+            margin-bottom: 18px;
+            padding: 8px 16px;
+            border-radius: 12px;
+            letter-spacing: 0.3px;
+            display: inline-block;
+            text-transform: uppercase;
         }
 
-        #cv-profile { font-size: 11px; line-height: 1.6; text-align: justify; }
+        /* Resumo de Qualificações */
+        .qualifications-list {
+            list-style: none;
+            padding: 0;
+        }
 
-        /* ===== Skills ===== */
+        .qualifications-list li {
+            position: relative;
+            padding-left: 28px;
+            margin-bottom: 14px;
+            font-size: 13.5px;
+            line-height: 1.7;
+            color: var(--text-color);
+        }
+
+        .qualifications-list li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+            font-size: 20px;
+            top: -2px;
+        }
+        
+        /* Skills & Tools Grid */
         .skills-grid {
             display: grid;
-            grid-template-columns: 1fr 1fr 1fr;
-            gap: 10px;
+            grid-template-columns: 1fr 1fr;
+            gap: 20px;
         }
 
-        #skills-strategic, #skills-tools, #skills-emerging {
-            background: linear-gradient(160deg, rgba(255, 244, 236, 0.9), rgba(255, 244, 236, 0.35));
-            border: 1px solid rgba(255, 98, 0, 0.14);
-            border-top: 3px solid var(--itau-orange);
+        .skills-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 16px;
             border-radius: 14px;
-            padding: 11px;
+            border: 1px solid var(--border-color);
         }
 
-        #skills-tools { border-top-color: var(--itau-amber); }
-        #skills-emerging { border-top-color: var(--itau-green); }
-
-        #skills-strategic h3, #skills-tools h3, #skills-emerging h3 {
-            font-size: 10px !important;
-            font-weight: 700 !important;
-            text-transform: uppercase;
-            letter-spacing: 0.3px;
-            color: var(--itau-terracotta) !important;
-            margin-bottom: 8px !important;
-        }
-
-        .tool-item { margin-bottom: 7px; }
-
-        .tool-name {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            gap: 6px;
-            font-weight: 500;
-            font-size: 9.5px;
-            margin-bottom: 3px;
-        }
-
-        .tool-percentage {
-            font-size: 7.5px;
-            font-weight: 700;
-            color: var(--itau-terracotta);
-            background: rgba(255, 179, 0, 0.22);
-            border: 1px solid rgba(255, 98, 0, 0.2);
-            border-radius: 999px;
-            padding: 1px 7px;
-            white-space: nowrap;
-            flex-shrink: 0;
-        }
-
-        .dots-container { display: flex; gap: 2px; flex-wrap: nowrap; }
-
-        .dot {
-            width: 6px;
-            height: 6px;
-            border-radius: 50%;
-            background-color: rgba(194, 78, 0, 0.15);
-            flex-shrink: 0;
-        }
-
-        .dot.filled {
-            background: linear-gradient(135deg, var(--itau-orange) 0%, var(--itau-amber) 100%);
-        }
-
-        /* ===== Experience ===== */
-        #experience-container { position: relative; }
-
-        .experience-item {
-            padding: 12px 14px;
+        .skills-section h3 {
+            font-size: 12px;
+            color: var(--primary-color);
             margin-bottom: 10px;
-            border-radius: 16px;
-            background: linear-gradient(150deg, #ffffff, rgba(255, 244, 236, 0.6));
-            border: 1px solid rgba(255, 98, 0, 0.16);
-            border-left: 4px solid var(--itau-orange);
-            page-break-inside: avoid;
-        }
-
-        .job-title {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            font-size: 12.5px;
-            color: var(--itau-terracotta);
-            margin-bottom: 4px;
-        }
-
-        .job-number {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            width: 20px;
-            height: 18px;
-            background: linear-gradient(135deg, var(--itau-orange), var(--itau-amber));
-            color: white;
-            border-radius: var(--stone-radius);
-            font-size: 9.5px;
-            font-weight: 800;
-            flex-shrink: 0;
-        }
-
-        .experience-item .company {
             font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .skill-items {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
+
+        .skill-tag {
+            background: var(--tag-bg);
+            color: var(--primary-color);
+            padding: 4px 10px;
+            border-radius: 12px;
+            font-size: 10.5px;
+            font-weight: 500;
+            border: 1px solid var(--tag-border);
+        }
+
+        /* Cursos Complementares */
+        .courses-section {
+            margin-top: 10px;
+        }
+
+        .course-item {
+            padding: 8px 0;
+            border-bottom: 1px solid var(--border-color);
             font-size: 11px;
-            color: var(--itau-orange);
+        }
+
+        .course-item:last-child {
+            border-bottom: none;
+        }
+
+        .course-name {
+            color: var(--text-color);
+            font-weight: 500;
+            display: block;
             margin-bottom: 2px;
         }
 
-        .experience-item .period {
-            display: inline-block;
-            font-size: 9px;
-            font-weight: 600;
-            color: var(--itau-terracotta);
-            background: rgba(255, 98, 0, 0.08);
-            border: 1px solid rgba(255, 98, 0, 0.16);
-            border-radius: 999px;
-            padding: 1px 9px;
-            margin-bottom: 6px;
-        }
-
-        .job-description {
+        .course-info {
+            color: var(--secondary-color);
             font-size: 10px;
-            line-height: 1.45;
-            margin-bottom: 6px;
+            font-style: italic;
+        }
+        
+        /* Experience Timeline */
+        .experience-timeline {
+            position: relative;
+            margin-left: 20px;
+            padding-left: 30px;
+        }
+        
+        .experience-timeline::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            top: 0;
+            bottom: 0;
+            width: 3px;
+            background: var(--primary-color);
+            border-radius: 3px;
         }
 
-        .achievements-container {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 6px;
+        .experience-item {
+            margin-bottom: 25px;
+            position: relative;
+            padding: 18px;
+            border-radius: 14px;
+            background: #fff;
+            border: 1px solid var(--border-color);
         }
-
-        .achievement-item {
+        
+        .experience-item::before {
+            content: "";
+            position: absolute;
+            left: -36px;
+            top: 25px;
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background: var(--accent-color);
+            border: 3px solid white;
+        }
+        
+        .job-header {
             display: flex;
-            gap: 6px;
-            background: rgba(255, 98, 0, 0.05);
-            border: 1px solid rgba(255, 98, 0, 0.12);
-            border-radius: 10px;
-            padding: 6px 8px;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-bottom: 10px;
         }
 
-        .achievement-icon {
-            color: var(--itau-orange);
-            font-size: 10px;
-            padding-top: 1px;
-            flex-shrink: 0;
+        .job-title {
+            font-family: var(--font-display);
+            font-weight: 600;
+            font-size: 16px;
+            color: var(--primary-color);
+            margin-bottom: 4px;
+        }
+        
+        .company {
+            font-weight: 500;
+            font-size: 13px;
+            color: var(--secondary-color);
+        }
+        
+        .period {
+            font-size: 12px;
+            color: var(--secondary-color);
+            font-weight: 600;
+            text-align: right;
+        }
+        
+        .job-description {
+            font-size: 12px;
+            line-height: 1.6;
+            color: var(--text-color);
+            margin-bottom: 12px;
         }
 
-        .achievement-title {
-            font-weight: 700;
-            font-size: 9.5px;
-            color: var(--itau-terracotta);
-            margin-bottom: 1px;
+        .job-bullets {
+            list-style: none;
+            padding: 0;
         }
 
-        .achievement-description { font-size: 8.8px; line-height: 1.35; }
+        .job-bullets li {
+            position: relative;
+            padding-left: 20px;
+            margin-bottom: 8px;
+            font-size: 12px;
+            line-height: 1.5;
+            color: var(--text-color);
+        }
 
-        .tooltip { display: none !important; }
-
-        /* ===== Education ===== */
-        #education-container {
+        .job-bullets li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+        }
+        
+        /* Education */
+        .education-tech-container {
             display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 10px;
+            grid-template-columns: 1fr 2fr;
+            gap: 25px;
+        }
+        
+        .education-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 20px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
         }
 
         .education-item {
-            padding: 10px 12px;
-            border-radius: 12px;
-            background: linear-gradient(160deg, rgba(255, 244, 236, 0.9), rgba(255, 244, 236, 0.3));
-            border: 1px solid rgba(255, 98, 0, 0.14);
-            border-left: 4px solid var(--itau-amber);
-            page-break-inside: avoid;
+            margin-bottom: 12px;
+            padding-bottom: 12px;
+            border-bottom: 1px solid var(--border-color);
         }
 
-        .degree { font-size: 11.5px; color: var(--itau-terracotta); margin-bottom: 2px; }
-        .university { font-size: 10px; margin-bottom: 2px; }
-        .thesis { font-size: 9.5px; font-style: italic; color: #8a7263; }
-        .cta-button { display: none; }
-
-        /* ===== Projects ===== */
-        #projects-container {
-            display: grid;
-            grid-template-columns: 1fr 1fr 1fr;
-            gap: 10px;
+        .education-item:last-child {
+            margin-bottom: 0;
+            padding-bottom: 0;
+            border-bottom: none;
         }
-
-        .project-item {
-            padding: 10px 12px;
-            border-radius: 14px;
-            background: linear-gradient(150deg, #ffffff, rgba(255, 244, 236, 0.5));
-            border: 1px solid rgba(255, 98, 0, 0.14);
-            page-break-inside: avoid;
-        }
-
-        .project-title { font-size: 10.5px; color: var(--itau-terracotta); margin-bottom: 4px; }
-        .project-description { font-size: 9.5px; line-height: 1.4; margin-bottom: 6px; }
-
-        .tech-tag {
-            display: inline-block;
-            background: rgba(255, 98, 0, 0.08);
-            color: var(--itau-terracotta);
-            border: 1px solid rgba(255, 98, 0, 0.2);
-            border-radius: 999px;
-            padding: 2px 8px;
-            margin: 2px 3px 0 0;
-            font-size: 8px;
+        
+        .degree {
+            font-family: var(--font-display);
             font-weight: 600;
+            font-size: 13px;
+            color: var(--primary-color);
+            margin-bottom: 3px;
+        }
+        
+        .university {
+            font-size: 11px;
+            color: var(--text-color);
+            margin-bottom: 2px;
+        }
+        
+        .edu-period {
+            font-size: 10px;
+            color: var(--secondary-color);
+            font-style: italic;
         }
 
-        /* ===== Print ===== */
+        .tech-skills-container {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 15px;
+        }
+
+        /* Languages */
+        .language-container {
+            display: flex;
+            justify-content: center;
+            gap: 30px;
+        }
+
+        .language-item {
+            text-align: center;
+        }
+
+        .language-name {
+            font-weight: 600;
+            color: var(--primary-color);
+            font-size: 13px;
+            margin-bottom: 2px;
+        }
+
+        .language-level {
+            font-size: 11px;
+            color: var(--text-color);
+        }
+
+        /* Print Styles */
         @media print {
-            * {
+            body {
+                background: white;
+                margin: 0;
+                padding: 0;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
             }
 
-            body { margin: 0; padding: 0; background: white; }
-
             .cv-container {
+                max-width: 100%;
                 margin: 0;
-                max-width: none;
-                border-radius: 0;
                 box-shadow: none;
             }
 
-            .header { border-radius: 0 0 28px 46px; padding: 16px 24px 20px; }
-            .header h1 { font-size: 18px !important; }
-            .header h2 { font-size: 10.5px !important; }
-
-            .section { padding: 10px 24px !important; }
-            .section-title { font-size: 10px !important; padding: 5px 16px !important; margin-bottom: 8px !important; }
-
-            .experience-item, .education-item, .project-item {
-                page-break-inside: avoid;
-                margin-bottom: 8px !important;
+            .header {
+                background: var(--background-gradient) !important;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+                padding: 25px 35px !important;
+                page-break-after: avoid;
             }
 
-            .job-description, .achievement-description { font-size: 9px !important; }
+            .section-title {
+                background: var(--primary-color) !important;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+                color: white !important;
+                page-break-after: avoid;
+            }
+
+            .section {
+                padding: 15px 35px;
+                page-break-inside: avoid;
+            }
+
+            .experience-item {
+                page-break-inside: avoid;
+            }
+
+            /* Hide animations */
+            * {
+                animation: none !important;
+            }
 
             @page {
                 size: A4;
                 margin: 8mm;
             }
         }
+        .contact-info { max-width: calc(100% - 180px); }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <!-- Favicon Meta Tags -->
     <meta name="theme-color" content="#FF6200">
+    <meta name="msapplication-TileColor" content="#FF6200">
+    <meta name="msapplication-config" content="../assets/favicons/browserconfig.xml">
 </head>
 <body>
     <div class="cv-container">
         <header class="header">
-            <div class="header-top">
-                <div class="brand-logo">
-                    <img src="../assets/images/itau.png" alt="Itaú">
+            <div class="header-content">
+                <img src="../assets/images/itau.png" alt="Itaú" class="brand-logo">
+                <h1>PEDRO HENRIQUE MARCONATO</h1>
+                
+                <div class="header-tagline">CRM | ANALYTICS | BUSINESS INTELLIGENCE | LTV | SQL</div>
+                
+                <div class="contact-info">
+                    <div class="contact-item">
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-phone"></i> +55 (55) 98114-7758
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-envelope"></i> pedrohmarconato@gmail.com
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fab fa-linkedin"></i> linkedin.com/in/pedrohmarconato
+                    </div>
                 </div>
-                <div class="header-text">
-                    <div class="tagline"><span class="tagline-dot"></span>made of future</div>
-                    <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
-                    <h2 id="cv-role">CRM Management and Data Intelligence</h2>
-                </div>
-            </div>
-            <div class="contact-info">
-                <span class="contact-item"><i class="fas fa-envelope"></i><span id="cv-email">pedrohmarconato@gmail.com</span></span>
-                <span class="contact-item"><i class="fas fa-phone"></i><span id="cv-phone">+55 (55) 981147758</span></span>
-                <span class="contact-item" id="cv-location"><i class="fas fa-map-marker-alt"></i><span>Cachoeira do Sul, RS</span></span>
-                <span class="contact-item"><i class="fab fa-linkedin"></i><a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin" target="_blank">LinkedIn</a></span>
-                <span class="contact-item"><i class="fab fa-github"></i><a href="https://github.com/pedrohmarconato/Pedro-Marconato-CV" id="cv-repository" target="_blank">Repository</a></span>
             </div>
         </header>
-
-        <section class="section">
-            <h2 class="section-title" id="section-profile">Professional Profile</h2>
-            <p id="cv-profile"></p>
+        
+        <section class="section" style="padding-top: 35px;">
+            <h2 class="section-title">PROFESSIONAL SUMMARY</h2>
+            <ul class="qualifications-list">
+                <li>Master's degree in Business Administration, with an Analytics track, combining data intelligence, CRM, analytical visualization, and automation to generate business value</li>
+                <li>Experience in large and highly complex companies, such as Grupo RBS, Realize CFI (Lojas Renner S.A. Group), and Rede Globo, leading strategic projects in CRM, business intelligence, and marketing performance</li>
+                <li>Experience with data applied to marketing, channels, credit, control, and operations, connecting areas and translating technical needs into high-impact analytical solutions</li>
+                <li>Highlights in visualization, segmentation, and consumer behavior projects, with mastery of tools such as Databricks, SQL, Responsys, Power BI, Python, Salesforce, Mailchimp, Tableau, SAS, Mix Agents, and Kanbanize</li>
+                <li>Knowledge in agile methodologies (Scrum, Kanban), working on backlog prioritization, squad structuring, and accelerating delivery with a focus on the customer</li>
+                <li>Experience with data integration from multiple sources, building pipelines, predictive analytics, and behavior mapping to support strategic decisions</li>
+                <li>Differentiator in combining analytical capacity, strategic thinking, and technical knowledge, with recognized performance as leadership even in consultative structures</li>
+                <li>People management, leading multidisciplinary teams with a focus on development, autonomy, and generating consistent results</li>
+            </ul>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-skills">Skills & Tools</h2>
-            <div class="skills-grid">
-                <div id="skills-strategic"></div>
-                <div id="skills-tools"></div>
-                <div id="skills-emerging"></div>
+            <h2 class="section-title">EDUCATION & TECHNOLOGY</h2>
+            <div class="education-tech-container">
+                <div class="education-section">
+                    <h3 style="font-size: 12px; color: var(--primary-color); margin-bottom: 12px; font-weight: 600;">EDUCATION</h3>
+                    <div class="education-item">
+                        <div class="degree">Master's in Business Administration</div>
+                        <div class="university">Federal University of Santa Maria - UFSM</div>
+                        <div class="edu-period">Completed: 2019</div>
+                    </div>
+                    
+                    <div class="education-item">
+                        <div class="degree">Bachelor's in Business Administration</div>
+                        <div class="university">Federal University of Santa Maria - UFSM</div>
+                        <div class="edu-period">Completed: 2015</div>
+                    </div>
+                </div>
+                
+                <div class="tech-skills-container">
+                    <div class="skills-section">
+                        <h3>TOOLS & PLATFORMS</h3>
+                        <div class="skill-items">
+                            <span class="skill-tag">Databricks</span>
+                            <span class="skill-tag">SQL</span>
+                            <span class="skill-tag">Power BI</span>
+                            <span class="skill-tag">Python</span>
+                            <span class="skill-tag">Oracle Responsys</span>
+                            <span class="skill-tag">Kanbanize</span>
+                            <span class="skill-tag">Mailchimp</span>
+                            <span class="skill-tag">Mix Agents</span>
+                            <span class="skill-tag">SAS</span>
+                            <span class="skill-tag">Tableau</span>
+                            <span class="skill-tag">Salesforce CRM</span>
+                        </div>
+                    </div>
+                    
+                    <div class="skills-section">
+                        <h3>CERTIFICATIONS & COURSES</h3>
+                        <div class="courses-section">
+                            <div class="course-item">
+                                <span class="course-name">Statement of Accomplishment - Intermediate R Course</span>
+                                <span class="course-info">Marketing Analytics In Practice - Coursera</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Marketing Analytics in R</span>
+                                <span class="course-info">PPGA - Graduate Program in Business Administration</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Fundamentals of Problem Solving</span>
+                                <span class="course-info">Marketing in a Digital World - Illinois University</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-experience">Professional Experience</h2>
-            <div id="experience-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-education">Education</h2>
-            <div id="education-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-projects">Projects & Innovation</h2>
-            <div id="projects-container"></div>
+            <h2 class="section-title">PROFESSIONAL EXPERIENCE</h2>
+            
+            <div class="experience-timeline">
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">CADASTRA (Digital Marketing and Performance Agency)</div>
+                        </div>
+                        <div class="period">2025-Present</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">Data Analytics Coordinator</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">Sep/2025-Present</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Leading Data Analytics and AI operations for enterprise clients in technology, retail and education sectors, managing multidisciplinary team (DataViz, Data Engineering, Web Analytics)</li>
+                        <li>Simultaneous management of strategic accounts with direct interface to C-level stakeholders and business areas (Performance, E-commerce, Commercial)</li>
+                        <li>Data architecture and governance definition for Business Intelligence, Real-Time Analytics and AI applications projects</li>
+                        <li>Technical diagnosis and restructuring of legacy data environments, including infrastructure migration (AWS→GCP) with projected 40% reduction in processing costs</li>
+                        <li>Data operations restructuring with team expansion (+67%) and scope extension to multiple LATAM business units</li>
+                        <li>Stabilization of critical data environments, achieving 20% savings in operational processing costs (Airflow/DAGs)</li>
+                        <li>Development of automations with n8n and AI Agents (LLMs), including automated Status Report with AI-generated executive summaries</li>
+                        <li>Leadership of first generative AI initiatives in client operations, positioning the area as innovation reference</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">LOJAS RENNER | REALIZE CFI (National Financial Services Company)</div>
+                        </div>
+                        <div class="period">2020-2025</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">CRM Manager</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2021-2025</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for leading the strategic CRM front, focusing on area evolution, customer base growth, and business value generation</li>
+                        <li>Definition and monitoring of area OKRs, connecting business goals to relationship indicators</li>
+                        <li>Planning, execution, and optimization of multichannel relationship campaigns (email, SMS, push, among others), applying intelligent segmentations and automations to increase usage frequency and sales</li>
+                        <li>Building personalized journeys based on customer behavior and profile, promoting lifecycle evolution and loyalty in financial products (cards, loans, insurance, and consumption in the Renner ecosystem)</li>
+                        <li>Management of agile management rhythm (daily, planning, reviews, and retrospectives), using frameworks such as Scrum and Kanban to maintain delivery pace, priority visibility, and impact focus</li>
+                        <li>Area backlog management, with mapping, prioritization, and organization of demands according to incremental value and alignment with the commercial team</li>
+                        <li>Strategic management of suppliers and technology partners, including CRM platforms, automation, and data enrichment, ensuring delivery quality and alignment with area guidelines</li>
+                        <li>Continuous interface with key areas (IT, Products, Analytics, Marketing, Stores, and Commercial), promoting alignment between CRM initiatives and corporate objectives</li>
+                        <li>Technical and operational management of tools such as Oracle Responsys, Databricks, and Power BI, enabling automated segmentations, data processing, and performance dashboards</li>
+                        <li>Monitoring and analysis of KPIs and campaign indicators, using data to guide decisions, validate hypotheses, and promote continuous improvement</li>
+                        <li>Leadership of strategic projects and initiatives to expand the active customer base and activate new communication channels</li>
+                    </ul>
+                    
+                    <div class="job-title" style="margin-top: 15px; margin-bottom: 8px;">Analytics Specialist</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2020-2021</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for creating dashboards and strategic indicators for areas such as Marketing, CRM, Credit, and Channels, delivering an integrated real-time view to support business decisions</li>
+                        <li>Development of segmented databases and automated reports focused on the CRM team, with a focus on efficiency gains, agility in analyses, and revenue generation through more precise actions</li>
+                        <li>Organization and integration of operational, behavioral, and transactional data, consolidating multiple sources into a reliable base for comprehensive customer lifecycle analyses</li>
+                        <li>Practical use of tools such as SQL, BigQuery, Python, and Power BI for exploratory analyses, routine automations, and development of predictive models applied to the business</li>
+                        <li>Close collaboration with Marketing, Products, Risk, and Operations areas, translating strategic needs into applicable analyses, focusing on action direction and decision-making</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Analytics Specialist</div>
+                            <div class="company">DBC COMPANY (National IT Consulting Company)</div>
+                        </div>
+                        <div class="period">2020-2021</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for supporting the strategic restructuring of the CRM area at client Realize, implementing agile methodologies (Kanban) and defining processes that reduced campaign time-to-market and increased operational efficiency</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Business Intelligence Analyst</div>
+                            <div class="company">GRUPO RBS (National Media Company)</div>
+                        </div>
+                        <div class="period">2019 - 2020</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for structuring and analyzing commercial performance, audience, and market behavior data, supporting leadership in strategic decision-making for client Rede Globo</li>
+                        <li>Development of segmentation studies and consumption potential mapping, using data to guide decisions, validate hypotheses, and promote sales and prospecting actions</li>
+                        <li>Creation of real-time analytical reports and dashboards to support business decisions</li>
+                        <li>Direct interface with leadership, translating market data into action plans and growth opportunities</li>
+                        <li>Analysis of KPIs and campaign indicators, using data to guide decisions, validate hypotheses, and promote continuous improvement</li>
+                    </ul>
+                </div>
+            </div>
         </section>
     </div>
-
-    <script src="../assets/js/cv-texts.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            var lang = 'en';
-            initializeBasicContent(lang);
-            renderSkills('skills-strategic', 'strategic', lang);
-            renderSkills('skills-tools', 'tools', lang);
-            renderSkills('skills-emerging', 'emerging', lang);
-            renderExperienceTimeline(lang);
-            renderEducation(lang);
-            renderProjects(lang);
-        });
-    </script>
+    <!-- Dynamic Favicon System -->
+    <script src="../assets/js/dynamic-favicon.js"></script>
 </body>
 </html>

--- a/cv_styles/cv_itau_style_PT.html
+++ b/cv_styles/cv_itau_style_PT.html
@@ -3,482 +3,672 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pedro Henrique Marconato - CV</title>
+    <title>Pedro Henrique Marconato - CV (Itaú)</title>
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,400&display=swap');
-
+        @import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap');
+        
         :root {
-            /* Itaú — rebrand 2023, "pedras de rio" */
-            --itau-orange: #FF6200;
-            --itau-burnt: #C24E00;
-            --itau-terracotta: #8F3A00;
-            --itau-amber: #FFB300;
-            --itau-blue: #1E5BC6;
-            --itau-green: #00A868;
-            --itau-pink: #FF4D8D;
-            --itau-sand: #FFF4EC;
-            --itau-ink: #33261C;
-
-            --primary-color: var(--itau-orange);
-            --secondary-color: var(--itau-burnt);
-            --accent-color: var(--itau-amber);
-            --text-color: var(--itau-ink);
+            /* Itaú — brand tokens */
+            --primary-color: #FF6200;
+            --secondary-color: #C24E00;
+            --accent-color: #FFB300;
+            --light-accent: #FFF4EC;
+            --text-color: #33261C;
             --border-color: rgba(194, 78, 0, 0.16);
-            --background-gradient: linear-gradient(135deg, var(--itau-orange) 0%, var(--itau-burnt) 100%);
-            --stone-radius: 58% 42% 44% 56% / 52% 58% 42% 48%;
+            --background-gradient: linear-gradient(135deg, #FF6200 0%, #C24E00 100%);
+
+            --font-body: 'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            --font-display: 'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+
+            --header-text: #ffffff;
+            --header-text-soft: rgba(255, 255, 255, 0.95);
+            --header-chip-bg: rgba(255, 255, 255, 0.15);
+            --header-chip-border: rgba(255, 255, 255, 0.28);
+
+            --tag-bg: rgba(255, 179, 0, 0.16);
+            --tag-border: rgba(255, 179, 0, 0.34);
         }
-
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-
+        
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
         body {
-            font-family: 'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            font-family: var(--font-body);
             color: var(--text-color);
-            line-height: 1.5;
-            background: var(--itau-sand);
-            font-size: 12px;
+            line-height: 1.6;
+            background: var(--light-accent);
+            min-height: 100vh;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
         }
 
-        h1, .section-title, .job-title, .degree, .project-title {
-            font-weight: 800;
-        }
-
+        /* Main container */
         .cv-container {
             max-width: 210mm;
             margin: 0 auto;
-            background: #ffffff;
-            border-radius: 22px;
+            background: rgba(255, 255, 255, 1);
             overflow: hidden;
-            box-shadow: 0 14px 40px rgba(194, 78, 0, 0.16);
-        }
-
-        /* ===== Header ===== */
-        .header {
-            background:
-                radial-gradient(circle at 14% 18%, rgba(255, 158, 74, 0.5) 0%, transparent 46%),
-                radial-gradient(circle at 90% 88%, rgba(194, 78, 0, 0.55) 0%, transparent 52%),
-                var(--background-gradient);
-            padding: 20px 28px 24px;
-            border-radius: 0 0 40px 64px;
             position: relative;
         }
-
-        .header-top {
-            display: flex;
-            align-items: center;
-            gap: 16px;
-            margin-bottom: 12px;
+        
+        /* Header Section */
+        .header {
+            background: var(--background-gradient);
+            padding: 50px 50px 55px 50px;
+            position: relative;
+            overflow: hidden;
+        }
+        
+        .header-content {
+            position: relative;
+            z-index: 1;
         }
 
-        .brand-logo {
-            flex-shrink: 0;
+.brand-logo {
+            position: absolute;
+            bottom: 16px;
+            right: 34px;
+            width: 46px;
+            height: 46px;
+            padding: 8px;
             background: rgba(255, 255, 255, 0.96);
-            padding: 7px;
-            border-radius: 32% 68% 64% 36% / 48% 40% 60% 52%;
-            box-shadow: 0 6px 16px rgba(143, 58, 0, 0.32);
-            line-height: 0;
+            border-radius: 16px;
+            box-shadow: 0 6px 16px rgba(143, 58, 0, 0.3);
+            object-fit: contain;
         }
-
-        .brand-logo img { width: 42px; height: 42px; display: block; }
-
-        .header-text { flex: 1; min-width: 0; }
-
-        .tagline {
-            display: inline-flex;
-            align-items: center;
-            gap: 7px;
-            font-size: 8.5px;
-            font-weight: 600;
-            letter-spacing: 1.6px;
-            text-transform: lowercase;
-            color: rgba(255, 255, 255, 0.95);
-            background: rgba(143, 58, 0, 0.26);
-            border: 1px solid rgba(255, 255, 255, 0.3);
-            border-radius: 999px;
-            padding: 3px 11px;
-            margin-bottom: 7px;
-        }
-
-        .tagline-dot {
-            width: 5px;
-            height: 5px;
-            border-radius: 50%;
-            background: var(--itau-amber);
-            flex-shrink: 0;
-        }
-
+        
         .header h1 {
-            font-size: 20px;
-            color: white;
-            letter-spacing: -0.3px;
+            font-family: var(--font-display);
+            font-size: 32px;
+            font-weight: 700;
+            color: var(--header-text);
+            margin-bottom: 8px;
+            letter-spacing: -0.5px;
             text-transform: uppercase;
-            line-height: 1.15;
-            margin-bottom: 3px;
-            text-shadow: 0 2px 10px rgba(143, 58, 0, 0.3);
         }
 
-        .header h2 {
-            font-size: 11.5px;
-            font-weight: 500;
-            color: rgba(255, 255, 255, 0.95);
+        .header-tagline {
+            font-size: 17px;
+            font-weight: 400;
+            color: var(--header-text-soft);
+            margin-top: 22px;
+            margin-bottom: 28px;
+            font-style: italic;
+            letter-spacing: 0.5px;
         }
-
+        
         .contact-info {
             display: flex;
             flex-wrap: wrap;
-            gap: 7px;
+            gap: 10px;
+            align-items: center;
+            margin-top: 12px;
         }
-
+        
         .contact-item {
             display: inline-flex;
             align-items: center;
-            gap: 5px;
-            background: rgba(255, 255, 255, 0.16);
-            border: 1px solid rgba(255, 255, 255, 0.24);
-            border-radius: 999px;
-            padding: 3px 11px;
-            color: white;
-            font-size: 9px;
+            background: var(--header-chip-bg);
+            border-radius: 10px;
+            padding: 8px 14px;
+            color: var(--header-text);
+            font-size: 12.5px;
             font-weight: 500;
+            border: 1px solid var(--header-chip-border);
+        }
+        
+        .contact-item i {
+            margin-right: 6px;
+            font-size: 12px;
+        }
+        
+        /* Section Styles */
+        .section {
+            padding: 25px 50px;
+            border-bottom: 1px solid var(--border-color);
         }
 
-        .contact-item i { font-size: 8.5px; }
-
-        .contact-item a { color: white; text-decoration: none; }
-
-        /* ===== Sections ===== */
-        .section { padding: 14px 28px; }
-
-        .section:not(:last-child) { border-bottom: 1px solid var(--border-color); }
+        .section:last-child {
+            border-bottom: none;
+        }
 
         .section-title {
-            display: inline-block;
-            background: var(--background-gradient);
+            font-family: var(--font-display);
+            background: var(--primary-color);
             color: white;
-            font-size: 11px;
-            font-weight: 700;
-            letter-spacing: 0.8px;
-            text-transform: lowercase;
-            padding: 6px 18px;
-            border-radius: 999px;
-            margin-bottom: 10px;
-            box-shadow: 0 4px 12px rgba(255, 98, 0, 0.28);
+            font-size: 15px;
+            font-weight: 600;
+            margin-bottom: 18px;
+            padding: 8px 16px;
+            border-radius: 12px;
+            letter-spacing: 0.3px;
+            display: inline-block;
+            text-transform: uppercase;
         }
 
-        #cv-profile { font-size: 11px; line-height: 1.6; text-align: justify; }
+        /* Resumo de Qualificações */
+        .qualifications-list {
+            list-style: none;
+            padding: 0;
+        }
 
-        /* ===== Skills ===== */
+        .qualifications-list li {
+            position: relative;
+            padding-left: 28px;
+            margin-bottom: 14px;
+            font-size: 13.5px;
+            line-height: 1.7;
+            color: var(--text-color);
+        }
+
+        .qualifications-list li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+            font-size: 20px;
+            top: -2px;
+        }
+        
+        /* Skills & Tools Grid */
         .skills-grid {
             display: grid;
-            grid-template-columns: 1fr 1fr 1fr;
-            gap: 10px;
+            grid-template-columns: 1fr 1fr;
+            gap: 20px;
         }
 
-        #skills-strategic, #skills-tools, #skills-emerging {
-            background: linear-gradient(160deg, rgba(255, 244, 236, 0.9), rgba(255, 244, 236, 0.35));
-            border: 1px solid rgba(255, 98, 0, 0.14);
-            border-top: 3px solid var(--itau-orange);
+        .skills-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 16px;
             border-radius: 14px;
-            padding: 11px;
+            border: 1px solid var(--border-color);
         }
 
-        #skills-tools { border-top-color: var(--itau-amber); }
-        #skills-emerging { border-top-color: var(--itau-green); }
-
-        #skills-strategic h3, #skills-tools h3, #skills-emerging h3 {
-            font-size: 10px !important;
-            font-weight: 700 !important;
-            text-transform: uppercase;
-            letter-spacing: 0.3px;
-            color: var(--itau-terracotta) !important;
-            margin-bottom: 8px !important;
-        }
-
-        .tool-item { margin-bottom: 7px; }
-
-        .tool-name {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            gap: 6px;
-            font-weight: 500;
-            font-size: 9.5px;
-            margin-bottom: 3px;
-        }
-
-        .tool-percentage {
-            font-size: 7.5px;
-            font-weight: 700;
-            color: var(--itau-terracotta);
-            background: rgba(255, 179, 0, 0.22);
-            border: 1px solid rgba(255, 98, 0, 0.2);
-            border-radius: 999px;
-            padding: 1px 7px;
-            white-space: nowrap;
-            flex-shrink: 0;
-        }
-
-        .dots-container { display: flex; gap: 2px; flex-wrap: nowrap; }
-
-        .dot {
-            width: 6px;
-            height: 6px;
-            border-radius: 50%;
-            background-color: rgba(194, 78, 0, 0.15);
-            flex-shrink: 0;
-        }
-
-        .dot.filled {
-            background: linear-gradient(135deg, var(--itau-orange) 0%, var(--itau-amber) 100%);
-        }
-
-        /* ===== Experience ===== */
-        #experience-container { position: relative; }
-
-        .experience-item {
-            padding: 12px 14px;
+        .skills-section h3 {
+            font-size: 12px;
+            color: var(--primary-color);
             margin-bottom: 10px;
-            border-radius: 16px;
-            background: linear-gradient(150deg, #ffffff, rgba(255, 244, 236, 0.6));
-            border: 1px solid rgba(255, 98, 0, 0.16);
-            border-left: 4px solid var(--itau-orange);
-            page-break-inside: avoid;
-        }
-
-        .job-title {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            font-size: 12.5px;
-            color: var(--itau-terracotta);
-            margin-bottom: 4px;
-        }
-
-        .job-number {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            width: 20px;
-            height: 18px;
-            background: linear-gradient(135deg, var(--itau-orange), var(--itau-amber));
-            color: white;
-            border-radius: var(--stone-radius);
-            font-size: 9.5px;
-            font-weight: 800;
-            flex-shrink: 0;
-        }
-
-        .experience-item .company {
             font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .skill-items {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
+
+        .skill-tag {
+            background: var(--tag-bg);
+            color: var(--primary-color);
+            padding: 4px 10px;
+            border-radius: 12px;
+            font-size: 10.5px;
+            font-weight: 500;
+            border: 1px solid var(--tag-border);
+        }
+
+        /* Cursos Complementares */
+        .courses-section {
+            margin-top: 10px;
+        }
+
+        .course-item {
+            padding: 8px 0;
+            border-bottom: 1px solid var(--border-color);
             font-size: 11px;
-            color: var(--itau-orange);
+        }
+
+        .course-item:last-child {
+            border-bottom: none;
+        }
+
+        .course-name {
+            color: var(--text-color);
+            font-weight: 500;
+            display: block;
             margin-bottom: 2px;
         }
 
-        .experience-item .period {
-            display: inline-block;
-            font-size: 9px;
-            font-weight: 600;
-            color: var(--itau-terracotta);
-            background: rgba(255, 98, 0, 0.08);
-            border: 1px solid rgba(255, 98, 0, 0.16);
-            border-radius: 999px;
-            padding: 1px 9px;
-            margin-bottom: 6px;
-        }
-
-        .job-description {
+        .course-info {
+            color: var(--secondary-color);
             font-size: 10px;
-            line-height: 1.45;
-            margin-bottom: 6px;
+            font-style: italic;
         }
-
-        .achievements-container {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 6px;
+        
+        /* Experience Timeline */
+        .experience-timeline {
+            position: relative;
+            margin-left: 20px;
+            padding-left: 30px;
         }
-
-        .achievement-item {
+        
+        .experience-timeline::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            top: 0;
+            bottom: 0;
+            width: 3px;
+            background: var(--primary-color);
+            border-radius: 3px;
+        }
+        
+        .experience-item {
+            margin-bottom: 25px;
+            position: relative;
+            padding: 18px;
+            border-radius: 14px;
+            background: #fff;
+            border: 1px solid var(--border-color);
+        }
+        
+        .experience-item::before {
+            content: "";
+            position: absolute;
+            left: -36px;
+            top: 25px;
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background: var(--accent-color);
+            border: 3px solid white;
+        }
+        
+        .job-header {
             display: flex;
-            gap: 6px;
-            background: rgba(255, 98, 0, 0.05);
-            border: 1px solid rgba(255, 98, 0, 0.12);
-            border-radius: 10px;
-            padding: 6px 8px;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-bottom: 10px;
         }
 
-        .achievement-icon {
-            color: var(--itau-orange);
-            font-size: 10px;
-            padding-top: 1px;
-            flex-shrink: 0;
+        .job-title {
+            font-family: var(--font-display);
+            font-weight: 600;
+            font-size: 16px;
+            color: var(--primary-color);
+            margin-bottom: 4px;
+        }
+        
+        .company {
+            font-weight: 500;
+            font-size: 13px;
+            color: var(--secondary-color);
+        }
+        
+        .period {
+            font-size: 12px;
+            color: var(--secondary-color);
+            font-weight: 600;
+            text-align: right;
+        }
+        
+        .job-description {
+            font-size: 12px;
+            line-height: 1.6;
+            color: var(--text-color);
+            margin-bottom: 12px;
         }
 
-        .achievement-title {
-            font-weight: 700;
-            font-size: 9.5px;
-            color: var(--itau-terracotta);
-            margin-bottom: 1px;
+        .job-bullets {
+            list-style: none;
+            padding: 0;
         }
 
-        .achievement-description { font-size: 8.8px; line-height: 1.35; }
+        .job-bullets li {
+            position: relative;
+            padding-left: 20px;
+            margin-bottom: 8px;
+            font-size: 12px;
+            line-height: 1.5;
+            color: var(--text-color);
+        }
 
-        .tooltip { display: none !important; }
-
-        /* ===== Education ===== */
-        #education-container {
+        .job-bullets li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+        }
+        
+        /* Education */
+        .education-tech-container {
             display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 10px;
+            grid-template-columns: 1fr 2fr;
+            gap: 25px;
+        }
+        
+        .education-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 20px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
         }
 
         .education-item {
-            padding: 10px 12px;
-            border-radius: 12px;
-            background: linear-gradient(160deg, rgba(255, 244, 236, 0.9), rgba(255, 244, 236, 0.3));
-            border: 1px solid rgba(255, 98, 0, 0.14);
-            border-left: 4px solid var(--itau-amber);
-            page-break-inside: avoid;
+            margin-bottom: 12px;
+            padding-bottom: 12px;
+            border-bottom: 1px solid var(--border-color);
         }
 
-        .degree { font-size: 11.5px; color: var(--itau-terracotta); margin-bottom: 2px; }
-        .university { font-size: 10px; margin-bottom: 2px; }
-        .thesis { font-size: 9.5px; font-style: italic; color: #8a7263; }
-        .cta-button { display: none; }
-
-        /* ===== Projects ===== */
-        #projects-container {
-            display: grid;
-            grid-template-columns: 1fr 1fr 1fr;
-            gap: 10px;
+        .education-item:last-child {
+            margin-bottom: 0;
+            padding-bottom: 0;
+            border-bottom: none;
         }
-
-        .project-item {
-            padding: 10px 12px;
-            border-radius: 14px;
-            background: linear-gradient(150deg, #ffffff, rgba(255, 244, 236, 0.5));
-            border: 1px solid rgba(255, 98, 0, 0.14);
-            page-break-inside: avoid;
-        }
-
-        .project-title { font-size: 10.5px; color: var(--itau-terracotta); margin-bottom: 4px; }
-        .project-description { font-size: 9.5px; line-height: 1.4; margin-bottom: 6px; }
-
-        .tech-tag {
-            display: inline-block;
-            background: rgba(255, 98, 0, 0.08);
-            color: var(--itau-terracotta);
-            border: 1px solid rgba(255, 98, 0, 0.2);
-            border-radius: 999px;
-            padding: 2px 8px;
-            margin: 2px 3px 0 0;
-            font-size: 8px;
+        
+        .degree {
+            font-family: var(--font-display);
             font-weight: 600;
+            font-size: 13px;
+            color: var(--primary-color);
+            margin-bottom: 3px;
+        }
+        
+        .university {
+            font-size: 11px;
+            color: var(--text-color);
+            margin-bottom: 2px;
+        }
+        
+        .edu-period {
+            font-size: 10px;
+            color: var(--secondary-color);
+            font-style: italic;
         }
 
-        /* ===== Print ===== */
+        .tech-skills-container {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 15px;
+        }
+
+        /* Languages */
+        .language-container {
+            display: flex;
+            justify-content: center;
+            gap: 30px;
+        }
+
+        .language-item {
+            text-align: center;
+        }
+
+        .language-name {
+            font-weight: 600;
+            color: var(--primary-color);
+            font-size: 13px;
+            margin-bottom: 2px;
+        }
+
+        .language-level {
+            font-size: 11px;
+            color: var(--text-color);
+        }
+
+        /* Print Styles */
         @media print {
-            * {
+            body {
+                background: white;
+                margin: 0;
+                padding: 0;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
             }
 
-            body { margin: 0; padding: 0; background: white; }
-
             .cv-container {
+                max-width: 100%;
                 margin: 0;
-                max-width: none;
-                border-radius: 0;
                 box-shadow: none;
             }
 
-            .header { border-radius: 0 0 28px 46px; padding: 16px 24px 20px; }
-            .header h1 { font-size: 18px !important; }
-            .header h2 { font-size: 10.5px !important; }
-
-            .section { padding: 10px 24px !important; }
-            .section-title { font-size: 10px !important; padding: 5px 16px !important; margin-bottom: 8px !important; }
-
-            .experience-item, .education-item, .project-item {
-                page-break-inside: avoid;
-                margin-bottom: 8px !important;
+            .header {
+                background: var(--background-gradient) !important;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+                padding: 25px 35px !important;
+                page-break-after: avoid;
             }
 
-            .job-description, .achievement-description { font-size: 9px !important; }
+            .section-title {
+                background: var(--primary-color) !important;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+                color: white !important;
+                page-break-after: avoid;
+            }
+
+            .section {
+                padding: 15px 35px;
+                page-break-inside: avoid;
+            }
+
+            .experience-item {
+                page-break-inside: avoid;
+            }
+
+            /* Hide animations */
+            * {
+                animation: none !important;
+            }
 
             @page {
                 size: A4;
                 margin: 8mm;
             }
         }
+        .contact-info { max-width: calc(100% - 180px); }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <!-- Favicon Meta Tags -->
     <meta name="theme-color" content="#FF6200">
+    <meta name="msapplication-TileColor" content="#FF6200">
+    <meta name="msapplication-config" content="../assets/favicons/browserconfig.xml">
 </head>
 <body>
     <div class="cv-container">
         <header class="header">
-            <div class="header-top">
-                <div class="brand-logo">
-                    <img src="../assets/images/itau.png" alt="Itaú">
+            <div class="header-content">
+                <img src="../assets/images/itau.png" alt="Itaú" class="brand-logo">
+                <h1>PEDRO HENRIQUE MARCONATO</h1>
+                
+                <div class="header-tagline">CRM | ANALYTICS | BUSINESS INTELLIGENCE | LTV | SQL</div>
+                
+                <div class="contact-info">
+                    <div class="contact-item">
+                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 35 anos
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-phone"></i> +55 (55) 98114-7758
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-envelope"></i> pedrohmarconato@gmail.com
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fab fa-linkedin"></i> linkedin.com/in/pedrohmarconato
+                    </div>
                 </div>
-                <div class="header-text">
-                    <div class="tagline"><span class="tagline-dot"></span>feito de futuro</div>
-                    <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
-                    <h2 id="cv-role">Gestão de CRM e Inteligência de Dados</h2>
-                </div>
-            </div>
-            <div class="contact-info">
-                <span class="contact-item"><i class="fas fa-envelope"></i><span id="cv-email">pedrohmarconato@gmail.com</span></span>
-                <span class="contact-item"><i class="fas fa-phone"></i><span id="cv-phone">+55 (55) 981147758</span></span>
-                <span class="contact-item" id="cv-location"><i class="fas fa-map-marker-alt"></i><span>Cachoeira do Sul, RS</span></span>
-                <span class="contact-item"><i class="fab fa-linkedin"></i><a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin" target="_blank">LinkedIn</a></span>
-                <span class="contact-item"><i class="fab fa-github"></i><a href="https://github.com/pedrohmarconato/Pedro-Marconato-CV" id="cv-repository" target="_blank">Repositório</a></span>
             </div>
         </header>
-
-        <section class="section">
-            <h2 class="section-title" id="section-profile">Perfil Profissional</h2>
-            <p id="cv-profile"></p>
+        
+        <section class="section" style="padding-top: 35px;">
+            <h2 class="section-title">RESUMO DE QUALIFICAÇÕES</h2>
+            <ul class="qualifications-list">
+                <li>Mestre em Administração de Empresas, com ênfase na área de Analytics, unindo inteligência de dados, CRM, visualização analítica e automação para gerar valor ao negócio</li>
+                <li>Atuação em empresas de grande porte e alta complexidade, como Grupo RBS, Realize CFI (Grupo Lojas Renner S.A.) e Rede Globo, liderando projetos estratégicos nas frentes de CRM, inteligência comercial e performance de marketing</li>
+                <li>Vivência com dados aplicados a marketing, canais, crédito, controle e operações, conectando áreas e traduzindo necessidades técnicas em soluções analíticas de alto impacto</li>
+                <li>Destaques em projetos de visualização, segmentação e comportamento de consumo, com domínio de ferramentas como Databricks, SQL, Responsys, Power BI, Python, Salesforce, Mailchimp, Tableau, SAS, Mix Agents e Kanbanize</li>
+                <li>Conhecimento em metodologias ágeis (Scrum, Kanban), com atuação na priorização de backlog, estruturação de squads e aceleração de entrega com foco no cliente</li>
+                <li>Experiência com integração de dados de múltiplas fontes, construção de pipelines, análises preditivas e mapeamento de comportamento para suportar decisões estratégicas</li>
+                <li>Diferencial na combinação entre capacidade analítica, pensamento estratégico e conhecimento técnico, com atuação reconhecida como liderança mesmo em estruturas consultivas</li>
+                <li>Gestão de pessoas, liderando times multidisciplinares com foco em desenvolvimento, autonomia e geração de resultados consistentes</li>
+            </ul>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-skills">Habilidades e Ferramentas</h2>
-            <div class="skills-grid">
-                <div id="skills-strategic"></div>
-                <div id="skills-tools"></div>
-                <div id="skills-emerging"></div>
+            <h2 class="section-title">FORMAÇÃO ACADÊMICA & TECNOLOGIA</h2>
+            <div class="education-tech-container">
+                <div class="education-section">
+                    <h3 style="font-size: 12px; color: var(--primary-color); margin-bottom: 12px; font-weight: 600;">FORMAÇÃO</h3>
+                    <div class="education-item">
+                        <div class="degree">Mestrado em Administração de Empresas</div>
+                        <div class="university">Universidade Federal de Santa Maria - UFSM</div>
+                        <div class="edu-period">Conclusão: 2019</div>
+                    </div>
+                    
+                    <div class="education-item">
+                        <div class="degree">Bacharelado em Administração</div>
+                        <div class="university">Universidade Federal de Santa Maria - UFSM</div>
+                        <div class="edu-period">Conclusão: 2015</div>
+                    </div>
+                </div>
+                
+                <div class="tech-skills-container">
+                    <div class="skills-section">
+                        <h3>FERRAMENTAS & PLATAFORMAS</h3>
+                        <div class="skill-items">
+                            <span class="skill-tag">Databricks</span>
+                            <span class="skill-tag">SQL</span>
+                            <span class="skill-tag">Power BI</span>
+                            <span class="skill-tag">Python</span>
+                            <span class="skill-tag">Oracle Responsys</span>
+                            <span class="skill-tag">Kanbanize</span>
+                            <span class="skill-tag">Mailchimp</span>
+                            <span class="skill-tag">Mix Agents</span>
+                            <span class="skill-tag">SAS</span>
+                            <span class="skill-tag">Tableau</span>
+                            <span class="skill-tag">Salesforce CRM</span>
+                        </div>
+                    </div>
+                    
+                    <div class="skills-section">
+                        <h3>CERTIFICAÇÕES & CURSOS</h3>
+                        <div class="courses-section">
+                            <div class="course-item">
+                                <span class="course-name">Statement of Accomplishment - Intermediate R Course</span>
+                                <span class="course-info">Marketing Analytics In Practice - Coursera</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Marketing Analytics em R</span>
+                                <span class="course-info">PPGA - Programa de Pós-Graduação em Administração</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Fundamentos de Solução de Problemas</span>
+                                <span class="course-info">Marketing in a Digital World - Illinois University</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-experience">Experiência Profissional</h2>
-            <div id="experience-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-education">Formação Acadêmica</h2>
-            <div id="education-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-projects">Projetos e Inovação</h2>
-            <div id="projects-container"></div>
+            <h2 class="section-title">EXPERIÊNCIA PROFISSIONAL</h2>
+            
+            <div class="experience-timeline">
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">CADASTRA (Agência de Marketing Digital e Performance)</div>
+                        </div>
+                        <div class="period">2025-Atual</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">Coordenador de Data Analytics</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">Set/2025-Atual</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável pela operação de Data Analytics e AI para clientes de grande porte dos setores de tecnologia, varejo e educação, liderando time multidisciplinar (DataViz, Engenharia de Dados, Web Analytics)</li>
+                        <li>Gestão simultânea de contas estratégicas, com interface direta com stakeholders C-level e áreas de negócio (Performance, E-commerce, Comercial)</li>
+                        <li>Definição de arquitetura de dados e governança para projetos de Business Intelligence, Real-Time Analytics e aplicações de inteligência artificial</li>
+                        <li>Diagnóstico técnico e reestruturação de ambientes de dados legados, incluindo migração de infraestrutura (AWS→GCP) com redução projetada de 40% em custos de processamento</li>
+                        <li>Reestruturação de operações de dados com expansão de time (+67%) e ampliação de escopo para múltiplas unidades de negócio em LATAM</li>
+                        <li>Estabilização de ambientes críticos de dados, alcançando economia de 20% em custos operacionais de processamento (Airflow/DAGs)</li>
+                        <li>Desenvolvimento de automações com n8n e AI Agents (LLMs), incluindo Status Report automatizado com geração de resumos executivos por inteligência artificial</li>
+                        <li>Liderança das primeiras iniciativas de aplicação de IA generativa em operações de clientes, posicionando a área como referência em inovação</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">LOJAS RENNER | REALIZE CFI (Empresa Nacional do segmento Financeiro)</div>
+                        </div>
+                        <div class="period">2020-2025</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">CRM Manager</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2021-2025</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável pela liderança da frente estratégica de CRM, com foco na evolução da área, crescimento da base de clientes e geração de valor ao negócio</li>
+                        <li>Definição e acompanhamento dos OKRs da área, conectando metas do negócio a indicadores de relacionamento</li>
+                        <li>Planejamento, execução e otimização de campanhas de relacionamento multicanal (e-mail, SMS, push, entre outros), aplicando segmentações inteligentes e automações para aumentar frequência de uso e vendas</li>
+                        <li>Construção de jornadas personalizadas com base em comportamento e perfil dos clientes, promovendo a evolução do ciclo de vida e fidelização em produtos financeiros (cartões, empréstimos, seguros e consumo no ecossistema Renner)</li>
+                        <li>Gestão do ritmo de gestão ágil (daily, planning, reviews e retrospectives), utilizando frameworks como Scrum e Kanban para manter ritmo de entrega, visibilidade de prioridades e foco em impacto</li>
+                        <li>Gestão do backlog da área, com mapeamento, priorização e organização das demandas de acordo com o valor incremental e alinhamento com o time comercial</li>
+                        <li>Gestão estratégica de fornecedores e parceiros de tecnologia, incluindo plataformas de CRM, automação e enriquecimento de dados, garantindo qualidade das entregas e alinhamento às diretrizes da área</li>
+                        <li>Interface contínua com áreas-chave (TI, Produtos, Analytics, Marketing, Lojas e Comercial), promovendo alinhamento entre as iniciativas de CRM e os objetivos corporativos</li>
+                        <li>Gestão técnica e operacional de ferramentas como Oracle Responsys, Databricks e Power BI, viabilizando segmentações automatizadas, tratamento de dados e dashboards de performance</li>
+                        <li>Monitoramento e análise de KPIs e indicadores de campanhas, utilizando dados para orientar decisões, validar hipóteses e promover a melhoria contínua</li>
+                        <li>Liderança de projetos e iniciativas estratégicas de expansão da base ativa de clientes e ativação de novos canais de comunicação</li>
+                    </ul>
+                    
+                    <div class="job-title" style="margin-top: 15px; margin-bottom: 8px;">Especialista de Analytics</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2020-2021</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável por criar dashboards e indicadores estratégicos para áreas como Marketing, CRM, Crédito e Canais, entregando uma visão integrada e em tempo real para apoiar decisões de negócio</li>
+                        <li>Desenvolvimento de bases segmentadas e relatórios automatizados voltados ao time de CRM, com foco em ganho de eficiência, agilidade nas análises e geração de receita por meio de ações mais precisas</li>
+                        <li>Organização e integração de dados operacionais, comportamentais e transacionais, consolidando múltiplas fontes em uma base confiável para análises completas do ciclo de vida do cliente</li>
+                        <li>Utilização prática de ferramentas como SQL, BigQuery, Python e Power BI para análises exploratórias, automações de rotinas e desenvolvimento de modelos preditivos aplicados ao negócio</li>
+                        <li>Atuação próxima às áreas de Marketing, Produtos, Riscos e Operações, traduzindo necessidades estratégicas em análises aplicáveis, com foco em direcionamento de ações e tomada de decisão</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Especialista de Analytics</div>
+                            <div class="company">DBC COMPANY (Empresa Nacional do segmento de Consultoria em TI)</div>
+                        </div>
+                        <div class="period">2020-2021</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável por apoiar a reestruturação estratégica da área de CRM no cliente Realize, implementando metodologias ágeis (Kanban) e definindo processos que reduziram o time-to-market das campanhas e aumentaram a eficiência operacional</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Analista de Inteligência Comercial</div>
+                            <div class="company">GRUPO RBS (Empresa Nacional do segmento de Mídia)</div>
+                        </div>
+                        <div class="period">2019 - 2020</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável pela estruturação e análise dados de desempenho comercial, audiência e comportamento de mercado, apoiando a liderança na tomada de decisões estratégicas do cliente Rede Globo</li>
+                        <li>Desenvolvimento de estudos de segmentação e mapeamento de potencial de consumo, utilizando dados para orientar decisões, validar hipóteses e promover ações de vendas e prospecção</li>
+                        <li>Criação de relatórios e dashboards analíticos em tempo real para apoiar decisões do negócio</li>
+                        <li>Interface direta com a liderança, traduzindo dados de mercado em planos de ação e oportunidades de crescimento</li>
+                        <li>Análise de KPIs e indicadores de campanhas, utilizando dados para orientar decisões, validar hipóteses e promover a melhoria contínua</li>
+                    </ul>
+                </div>
+            </div>
         </section>
     </div>
-
-    <script src="../assets/js/cv-texts.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            var lang = 'pt';
-            initializeBasicContent(lang);
-            renderSkills('skills-strategic', 'strategic', lang);
-            renderSkills('skills-tools', 'tools', lang);
-            renderSkills('skills-emerging', 'emerging', lang);
-            renderExperienceTimeline(lang);
-            renderEducation(lang);
-            renderProjects(lang);
-        });
-    </script>
+    <!-- Dynamic Favicon System -->
+    <script src="../assets/js/dynamic-favicon.js"></script>
 </body>
 </html>

--- a/cv_styles/cv_magalu_style_EN.html
+++ b/cv_styles/cv_magalu_style_EN.html
@@ -3,471 +3,669 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pedro Henrique Marconato - CV</title>
+    <title>Pedro Henrique Marconato - CV (Magalu)</title>
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&display=swap');
         @import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap');
-
+        
         :root {
-            /* Magalu Colors (docs/magalu_brandbook.md) */
+            /* Magalu — brand tokens */
             --primary-color: #0086FF;
             --secondary-color: #236FBE;
             --accent-color: #FF3BA8;
-            --light-bg: #E5F2FF;
-            --text-color: #2c3e50;
-            --muted-color: #5a6b7a;
+            --light-accent: #EAF4FF;
+            --text-color: #2C3E50;
             --border-color: rgba(0, 134, 255, 0.18);
             --background-gradient: linear-gradient(135deg, #0086FF 0%, #236FBE 100%);
-            --font-title: 'Baloo 2', 'Trebuchet MS', sans-serif;
+
             --font-body: 'Nunito', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            --font-display: 'Nunito', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+
+            --header-text: #ffffff;
+            --header-text-soft: rgba(255, 255, 255, 0.95);
+            --header-chip-bg: rgba(255, 255, 255, 0.15);
+            --header-chip-border: rgba(255, 255, 255, 0.28);
+
+            --tag-bg: rgba(255, 59, 168, 0.12);
+            --tag-border: rgba(255, 59, 168, 0.28);
         }
-
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-
+        
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
         body {
             font-family: var(--font-body);
             color: var(--text-color);
-            line-height: 1.55;
-            background: linear-gradient(180deg, #eaf4ff 0%, #f8fbff 100%);
-            font-size: 12.5px;
+            line-height: 1.6;
+            background: var(--light-accent);
+            min-height: 100vh;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
         }
 
+        /* Main container */
         .cv-container {
             max-width: 210mm;
-            margin: 20px auto;
-            padding: 0 0 14mm;
-            background: #ffffff;
-            border-radius: 20px;
+            margin: 0 auto;
+            background: rgba(255, 255, 255, 1);
             overflow: hidden;
-            box-shadow: 0 10px 40px rgba(0, 134, 255, 0.14);
+            position: relative;
         }
-
-        /* Header */
+        
+        /* Header Section */
         .header {
             background: var(--background-gradient);
-            padding: 32px 40px 34px;
+            padding: 50px 50px 55px 50px;
             position: relative;
             overflow: hidden;
         }
+        
+        .header-content {
+            position: relative;
+            z-index: 1;
+        }
 
-        .header::before {
-            content: '';
+.brand-logo {
             position: absolute;
-            width: 190px;
-            height: 190px;
-            border-radius: 50%;
-            background: rgba(255, 255, 255, 0.08);
-            top: -80px;
-            right: -50px;
-        }
-
-        .header::after {
-            content: '';
-            position: absolute;
-            width: 130px;
-            height: 130px;
-            border-radius: 50%;
-            background: rgba(255, 59, 168, 0.12);
-            bottom: -60px;
-            left: -35px;
-        }
-
-        .header-content { position: relative; z-index: 1; }
-
-        .brand-logo {
-            width: 150px;
-            height: 42px;
-            margin: 0 auto 14px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .brand-logo img {
-            width: 100%;
-            height: 100%;
-            object-fit: contain;
+            bottom: 20px;
+            right: 40px;
+            width: 140px;
+            height: auto;
+            opacity: 0.95;
             filter: brightness(0) invert(1);
         }
-
+        
         .header h1 {
-            font-family: var(--font-title);
-            font-size: 24px;
-            font-weight: 800;
-            color: #ffffff;
-            text-align: center;
-            letter-spacing: 0.3px;
-        }
-
-        .header h2 {
-            font-family: var(--font-body);
-            font-size: 13.5px;
+            font-family: var(--font-display);
+            font-size: 32px;
             font-weight: 700;
-            color: rgba(255, 255, 255, 0.95);
-            text-align: center;
-            margin-top: 4px;
-            margin-bottom: 16px;
+            color: var(--header-text);
+            margin-bottom: 8px;
+            letter-spacing: -0.5px;
+            text-transform: uppercase;
         }
 
+        .header-tagline {
+            font-size: 17px;
+            font-weight: 400;
+            color: var(--header-text-soft);
+            margin-top: 22px;
+            margin-bottom: 28px;
+            font-style: italic;
+            letter-spacing: 0.5px;
+        }
+        
         .contact-info {
             display: flex;
             flex-wrap: wrap;
-            gap: 8px;
-            justify-content: center;
+            gap: 10px;
+            align-items: center;
+            margin-top: 12px;
         }
-
-        .contact-pill {
+        
+        .contact-item {
             display: inline-flex;
             align-items: center;
-            gap: 6px;
-            background: rgba(255, 255, 255, 0.18);
-            border: 1px solid rgba(255, 255, 255, 0.3);
-            border-radius: 999px;
-            padding: 7px 14px;
-            color: #ffffff;
-            font-size: 11.5px;
-            font-weight: 600;
-            text-decoration: none;
+            background: var(--header-chip-bg);
+            border-radius: 10px;
+            padding: 8px 14px;
+            color: var(--header-text);
+            font-size: 12.5px;
+            font-weight: 500;
+            border: 1px solid var(--header-chip-border);
+        }
+        
+        .contact-item i {
+            margin-right: 6px;
+            font-size: 12px;
+        }
+        
+        /* Section Styles */
+        .section {
+            padding: 25px 50px;
+            border-bottom: 1px solid var(--border-color);
         }
 
-        .contact-pill i { font-size: 11px; color: #ffffff; }
-        .contact-pill span, .contact-pill a { color: #ffffff; text-decoration: none; }
-
-        /* Sections */
-        .section { padding: 22px 40px; position: relative; }
-
-        .section:not(:last-child)::after {
-            content: '';
-            position: absolute;
-            bottom: 0;
-            left: 40px;
-            right: 40px;
-            height: 1px;
-            background: linear-gradient(to right, transparent, var(--border-color), transparent);
+        .section:last-child {
+            border-bottom: none;
         }
 
         .section-title {
-            font-family: var(--font-title);
-            background: var(--background-gradient);
-            color: #ffffff;
-            font-size: 14px;
-            font-weight: 700;
-            padding: 8px 18px;
-            border-radius: 999px;
-            margin-bottom: 16px;
+            font-family: var(--font-display);
+            background: var(--primary-color);
+            color: white;
+            font-size: 15px;
+            font-weight: 600;
+            margin-bottom: 18px;
+            padding: 8px 16px;
+            border-radius: 12px;
+            letter-spacing: 0.3px;
             display: inline-block;
-            letter-spacing: 0.2px;
-            box-shadow: 0 4px 12px rgba(0, 134, 255, 0.22);
+            text-transform: uppercase;
         }
 
-        #cv-profile { font-size: 12.5px; line-height: 1.65; color: var(--text-color); }
+        /* Resumo de Qualificações */
+        .qualifications-list {
+            list-style: none;
+            padding: 0;
+        }
 
-        /* Skills */
-        .skills-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 16px; }
+        .qualifications-list li {
+            position: relative;
+            padding-left: 28px;
+            margin-bottom: 14px;
+            font-size: 13.5px;
+            line-height: 1.7;
+            color: var(--text-color);
+        }
 
-        .skills-card {
-            background: linear-gradient(135deg, var(--light-bg), #ffffff);
+        .qualifications-list li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+            font-size: 20px;
+            top: -2px;
+        }
+        
+        /* Skills & Tools Grid */
+        .skills-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 20px;
+        }
+
+        .skills-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 16px;
+            border-radius: 14px;
             border: 1px solid var(--border-color);
-            border-radius: 16px;
-            padding: 14px 16px;
         }
 
-        .skills-card h3 { font-family: var(--font-title); }
+        .skills-section h3 {
+            font-size: 12px;
+            color: var(--primary-color);
+            margin-bottom: 10px;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
 
-        .tool-item { margin-bottom: 9px; }
-        .tool-item:last-child { margin-bottom: 0; }
+        .skill-items {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
 
-        .tool-name {
+        .skill-tag {
+            background: var(--tag-bg);
+            color: var(--primary-color);
+            padding: 4px 10px;
+            border-radius: 12px;
+            font-size: 10.5px;
+            font-weight: 500;
+            border: 1px solid var(--tag-border);
+        }
+
+        /* Cursos Complementares */
+        .courses-section {
+            margin-top: 10px;
+        }
+
+        .course-item {
+            padding: 8px 0;
+            border-bottom: 1px solid var(--border-color);
+            font-size: 11px;
+        }
+
+        .course-item:last-child {
+            border-bottom: none;
+        }
+
+        .course-name {
+            color: var(--text-color);
+            font-weight: 500;
+            display: block;
+            margin-bottom: 2px;
+        }
+
+        .course-info {
+            color: var(--secondary-color);
+            font-size: 10px;
+            font-style: italic;
+        }
+        
+        /* Experience Timeline */
+        .experience-timeline {
+            position: relative;
+            margin-left: 20px;
+            padding-left: 30px;
+        }
+        
+        .experience-timeline::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            top: 0;
+            bottom: 0;
+            width: 3px;
+            background: var(--primary-color);
+            border-radius: 3px;
+        }
+
+        .experience-item {
+            margin-bottom: 25px;
+            position: relative;
+            padding: 18px;
+            border-radius: 14px;
+            background: #fff;
+            border: 1px solid var(--border-color);
+        }
+        
+        .experience-item::before {
+            content: "";
+            position: absolute;
+            left: -36px;
+            top: 25px;
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background: var(--accent-color);
+            border: 3px solid white;
+        }
+        
+        .job-header {
             display: flex;
             justify-content: space-between;
-            align-items: center;
-            font-weight: 700;
-            font-size: 11.5px;
-            color: var(--text-color);
-            margin-bottom: 4px;
-        }
-
-        .tool-percentage {
-            color: var(--accent-color);
-            font-size: 9.5px;
-            font-weight: 800;
-            background: rgba(255, 59, 168, 0.1);
-            padding: 2px 8px;
-            border-radius: 999px;
-        }
-
-        .dots-container { display: flex; gap: 3px; }
-        .dot { width: 7px; height: 7px; border-radius: 50%; background: rgba(0, 134, 255, 0.15); }
-        .dot.filled { background: var(--primary-color); }
-
-        /* Experience */
-        .experience-item {
-            position: relative;
-            margin-bottom: 16px;
-            padding: 16px 18px 16px 22px;
-            border-radius: 16px;
-            border: 1px solid var(--border-color);
-            border-left: 5px solid var(--primary-color);
-            background: linear-gradient(135deg, #ffffff 0%, rgba(229, 242, 255, 0.5) 100%);
-            box-shadow: 0 3px 14px rgba(0, 134, 255, 0.07);
-            page-break-inside: avoid;
+            align-items: flex-start;
+            margin-bottom: 10px;
         }
 
         .job-title {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            font-family: var(--font-title);
-            font-weight: 700;
-            font-size: 14px;
-            color: var(--secondary-color);
+            font-family: var(--font-display);
+            font-weight: 600;
+            font-size: 16px;
+            color: var(--primary-color);
             margin-bottom: 4px;
         }
-
-        .job-number {
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            width: 20px;
-            height: 20px;
-            flex-shrink: 0;
-            border-radius: 50%;
-            background: var(--background-gradient);
-            color: #ffffff;
-            font-family: var(--font-body);
-            font-size: 10px;
-            font-weight: 800;
+        
+        .company {
+            font-weight: 500;
+            font-size: 13px;
+            color: var(--secondary-color);
+        }
+        
+        .period {
+            font-size: 12px;
+            color: var(--secondary-color);
+            font-weight: 600;
+            text-align: right;
+        }
+        
+        .job-description {
+            font-size: 12px;
+            line-height: 1.6;
+            color: var(--text-color);
+            margin-bottom: 12px;
         }
 
-        .experience-item .company { font-weight: 700; font-size: 12px; color: var(--primary-color); }
-        .experience-item .period { font-size: 11px; color: var(--accent-color); font-weight: 700; margin-bottom: 6px; }
-        .job-description { font-size: 11.5px; line-height: 1.55; margin-bottom: 8px; color: var(--text-color); }
-
-        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
-
-        .achievement-item {
-            display: flex;
-            gap: 8px;
-            align-items: flex-start;
-            background: rgba(255, 255, 255, 0.65);
-            border-radius: 10px;
-            padding: 6px 8px;
+        .job-bullets {
+            list-style: none;
+            padding: 0;
         }
 
-        .achievement-icon {
-            width: 20px;
-            height: 20px;
-            flex-shrink: 0;
-            border-radius: 50%;
-            background: rgba(0, 134, 255, 0.12);
-            color: var(--primary-color);
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 9.5px;
+        .job-bullets li {
+            position: relative;
+            padding-left: 20px;
+            margin-bottom: 8px;
+            font-size: 12px;
+            line-height: 1.5;
+            color: var(--text-color);
         }
 
-        .achievement-title { font-weight: 700; font-size: 10.5px; color: var(--text-color); }
-        .achievement-description { font-size: 10px; color: var(--muted-color); line-height: 1.4; }
-
-        .tooltip { display: none; } /* hover doesn't work on paper */
-
+        .job-bullets li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+        }
+        
         /* Education */
+        .education-tech-container {
+            display: grid;
+            grid-template-columns: 1fr 2fr;
+            gap: 25px;
+        }
+        
+        .education-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 20px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
+        }
+
         .education-item {
-            margin-bottom: 10px;
-            padding: 14px 16px;
-            border-radius: 14px;
-            background: linear-gradient(135deg, var(--light-bg), #ffffff);
-            border: 1px solid var(--border-color);
-            page-break-inside: avoid;
+            margin-bottom: 12px;
+            padding-bottom: 12px;
+            border-bottom: 1px solid var(--border-color);
         }
 
-        .degree { font-family: var(--font-title); font-weight: 700; color: var(--primary-color); font-size: 12.5px; }
-        .university { font-size: 11px; margin-top: 2px; }
-        .thesis { font-size: 10.5px; color: var(--muted-color); font-style: italic; margin-top: 2px; }
-        .cta-button { display: none; }
-
-        /* Projects */
-        .project-item {
-            margin-bottom: 10px;
-            padding: 14px 16px;
-            border-radius: 14px;
-            background: linear-gradient(135deg, #ffffff, rgba(229, 242, 255, 0.5));
-            border: 1px solid var(--border-color);
-            page-break-inside: avoid;
+        .education-item:last-child {
+            margin-bottom: 0;
+            padding-bottom: 0;
+            border-bottom: none;
         }
-
-        .project-title { font-family: var(--font-title); font-weight: 700; color: var(--primary-color); font-size: 12.5px; }
-        .project-description { font-size: 11px; margin-top: 3px; margin-bottom: 6px; }
-
-        .tech-tag {
-            display: inline-block;
-            padding: 3px 10px;
-            margin: 2px 4px 0 0;
-            background: var(--light-bg);
-            border: 1px solid rgba(0, 134, 255, 0.35);
+        
+        .degree {
+            font-family: var(--font-display);
+            font-weight: 600;
+            font-size: 13px;
             color: var(--primary-color);
-            border-radius: 999px;
-            font-size: 9.5px;
-            font-weight: 700;
+            margin-bottom: 3px;
+        }
+        
+        .university {
+            font-size: 11px;
+            color: var(--text-color);
+            margin-bottom: 2px;
+        }
+        
+        .edu-period {
+            font-size: 10px;
+            color: var(--secondary-color);
+            font-style: italic;
         }
 
-        @media print {
-            * { animation: none !important; }
+        .tech-skills-container {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 15px;
+        }
 
+        /* Languages */
+        .language-container {
+            display: flex;
+            justify-content: center;
+            gap: 30px;
+        }
+
+        .language-item {
+            text-align: center;
+        }
+
+        .language-name {
+            font-weight: 600;
+            color: var(--primary-color);
+            font-size: 13px;
+            margin-bottom: 2px;
+        }
+
+        .language-level {
+            font-size: 11px;
+            color: var(--text-color);
+        }
+
+        /* Print Styles */
+        @media print {
             body {
-                background: #ffffff;
+                background: white;
                 margin: 0;
                 padding: 0;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
             }
 
-            .cv-container { margin: 0; max-width: 100%; border-radius: 0; box-shadow: none; padding-bottom: 6mm; }
+            .cv-container {
+                max-width: 100%;
+                margin: 0;
+                box-shadow: none;
+            }
 
             .header {
                 background: var(--background-gradient) !important;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
-                padding: 18px 26px 22px !important;
+                padding: 25px 35px !important;
                 page-break-after: avoid;
             }
 
-            .header h1 { font-size: 19px !important; }
-            .header h2 { font-size: 11px !important; margin-bottom: 10px !important; }
-            .brand-logo { width: 110px !important; height: 32px !important; margin-bottom: 8px !important; }
-
-            .contact-pill {
-                font-size: 8.5px !important;
-                padding: 4px 9px !important;
-                background: rgba(255, 255, 255, 0.22) !important;
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
-            }
-
-            .section { padding: 10px 26px !important; page-break-inside: avoid; }
-            .section:not(:last-child)::after { left: 26px; right: 26px; }
-
             .section-title {
-                background: var(--background-gradient) !important;
+                background: var(--primary-color) !important;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
-                font-size: 11.5px !important;
-                padding: 5px 14px !important;
-                margin-bottom: 9px !important;
-                box-shadow: none !important;
+                color: white !important;
+                page-break-after: avoid;
             }
 
-            #cv-profile { font-size: 10.5px !important; line-height: 1.5 !important; }
-
-            .skills-grid { gap: 10px !important; }
-            .skills-card { padding: 9px 11px !important; border-radius: 12px !important; }
-            .skills-card h3 { font-size: 12px !important; margin-bottom: 8px !important; }
-            .tool-item { margin-bottom: 6px !important; }
-            .tool-name { font-size: 9.5px !important; }
-            .tool-percentage { font-size: 7.5px !important; padding: 1px 6px !important; }
-            .dot { width: 5.5px !important; height: 5.5px !important; }
+            .section {
+                padding: 15px 35px;
+                page-break-inside: avoid;
+            }
 
             .experience-item {
-                padding: 10px 12px 10px 15px !important;
-                margin-bottom: 8px !important;
-                border-radius: 10px !important;
-                box-shadow: none !important;
-                page-break-inside: avoid !important;
+                page-break-inside: avoid;
             }
 
-            .job-title { font-size: 11.5px !important; }
-            .job-number { width: 15px !important; height: 15px !important; font-size: 8px !important; }
-            .experience-item .company { font-size: 10px !important; }
-            .experience-item .period { font-size: 9px !important; margin-bottom: 4px !important; }
-            .job-description { font-size: 9.5px !important; margin-bottom: 5px !important; }
-            .achievements-container { gap: 5px !important; }
-            .achievement-item { padding: 4px 6px !important; gap: 5px !important; }
-            .achievement-icon { width: 15px !important; height: 15px !important; font-size: 7.5px !important; }
-            .achievement-title { font-size: 9px !important; }
-            .achievement-description { font-size: 8.5px !important; }
-
-            .education-item, .project-item {
-                padding: 9px 11px !important;
-                margin-bottom: 6px !important;
-                border-radius: 10px !important;
-                page-break-inside: avoid !important;
+            /* Hide animations */
+            * {
+                animation: none !important;
             }
 
-            .degree, .project-title { font-size: 10.5px !important; }
-            .university { font-size: 9.5px !important; }
-            .thesis { font-size: 9px !important; }
-            .project-description { font-size: 9.5px !important; }
-            .tech-tag { font-size: 8px !important; padding: 2px 8px !important; }
-
-            .tooltip { display: none !important; }
-
-            @page { size: A4; margin: 8mm; }
+            @page {
+                size: A4;
+                margin: 8mm;
+            }
         }
+        .contact-info { max-width: calc(100% - 180px); }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <!-- Favicon Meta Tags -->
+    <meta name="theme-color" content="#0086FF">
+    <meta name="msapplication-TileColor" content="#0086FF">
+    <meta name="msapplication-config" content="../assets/favicons/browserconfig.xml">
 </head>
 <body>
     <div class="cv-container">
         <header class="header">
             <div class="header-content">
-                <div class="brand-logo">
-                    <img src="../assets/images/magalu.svg" alt="Magalu">
-                </div>
-                <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
-                <h2 id="cv-role">CRM Management and Data Intelligence</h2>
+                <img src="../assets/images/magalu.svg" alt="Magalu" class="brand-logo">
+                <h1>PEDRO HENRIQUE MARCONATO</h1>
+                
+                <div class="header-tagline">CRM | ANALYTICS | BUSINESS INTELLIGENCE | LTV | SQL</div>
+                
                 <div class="contact-info">
-                    <span class="contact-pill"><i class="fas fa-envelope"></i><span id="cv-email">pedrohmarconato@gmail.com</span></span>
-                    <span class="contact-pill"><i class="fas fa-phone"></i><span id="cv-phone">+55 (55) 981147758</span></span>
-                    <span class="contact-pill" id="cv-location"><i class="fas fa-map-marker-alt"></i><span>Cachoeira do Sul, RS</span></span>
-                    <a class="contact-pill" href="https://linkedin.com/in/pedrohmarconato" target="_blank"><i class="fab fa-linkedin"></i><span id="cv-linkedin">LinkedIn</span></a>
-                    <a class="contact-pill" href="https://github.com/pedrohmarconato" target="_blank"><i class="fab fa-github"></i><span id="cv-repository">Repository</span></a>
+                    <div class="contact-item">
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-phone"></i> +55 (55) 98114-7758
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-envelope"></i> pedrohmarconato@gmail.com
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fab fa-linkedin"></i> linkedin.com/in/pedrohmarconato
+                    </div>
                 </div>
             </div>
         </header>
-
-        <section class="section">
-            <h2 class="section-title" id="section-profile">Professional Profile</h2>
-            <p id="cv-profile"></p>
+        
+        <section class="section" style="padding-top: 35px;">
+            <h2 class="section-title">PROFESSIONAL SUMMARY</h2>
+            <ul class="qualifications-list">
+                <li>Master's degree in Business Administration, with an Analytics track, combining data intelligence, CRM, analytical visualization, and automation to generate business value</li>
+                <li>Experience in large and highly complex companies, such as Grupo RBS, Realize CFI (Lojas Renner S.A. Group), and Rede Globo, leading strategic projects in CRM, business intelligence, and marketing performance</li>
+                <li>Experience with data applied to marketing, channels, credit, control, and operations, connecting areas and translating technical needs into high-impact analytical solutions</li>
+                <li>Highlights in visualization, segmentation, and consumer behavior projects, with mastery of tools such as Databricks, SQL, Responsys, Power BI, Python, Salesforce, Mailchimp, Tableau, SAS, Mix Agents, and Kanbanize</li>
+                <li>Knowledge in agile methodologies (Scrum, Kanban), working on backlog prioritization, squad structuring, and accelerating delivery with a focus on the customer</li>
+                <li>Experience with data integration from multiple sources, building pipelines, predictive analytics, and behavior mapping to support strategic decisions</li>
+                <li>Differentiator in combining analytical capacity, strategic thinking, and technical knowledge, with recognized performance as leadership even in consultative structures</li>
+                <li>People management, leading multidisciplinary teams with a focus on development, autonomy, and generating consistent results</li>
+            </ul>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-skills">Skills & Tools</h2>
-            <div class="skills-grid">
-                <div id="skills-strategic" class="skills-card"></div>
-                <div id="skills-tools" class="skills-card"></div>
-                <div id="skills-emerging" class="skills-card"></div>
+            <h2 class="section-title">EDUCATION & TECHNOLOGY</h2>
+            <div class="education-tech-container">
+                <div class="education-section">
+                    <h3 style="font-size: 12px; color: var(--primary-color); margin-bottom: 12px; font-weight: 600;">EDUCATION</h3>
+                    <div class="education-item">
+                        <div class="degree">Master's in Business Administration</div>
+                        <div class="university">Federal University of Santa Maria - UFSM</div>
+                        <div class="edu-period">Completed: 2019</div>
+                    </div>
+                    
+                    <div class="education-item">
+                        <div class="degree">Bachelor's in Business Administration</div>
+                        <div class="university">Federal University of Santa Maria - UFSM</div>
+                        <div class="edu-period">Completed: 2015</div>
+                    </div>
+                </div>
+                
+                <div class="tech-skills-container">
+                    <div class="skills-section">
+                        <h3>TOOLS & PLATFORMS</h3>
+                        <div class="skill-items">
+                            <span class="skill-tag">Databricks</span>
+                            <span class="skill-tag">SQL</span>
+                            <span class="skill-tag">Power BI</span>
+                            <span class="skill-tag">Python</span>
+                            <span class="skill-tag">Oracle Responsys</span>
+                            <span class="skill-tag">Kanbanize</span>
+                            <span class="skill-tag">Mailchimp</span>
+                            <span class="skill-tag">Mix Agents</span>
+                            <span class="skill-tag">SAS</span>
+                            <span class="skill-tag">Tableau</span>
+                            <span class="skill-tag">Salesforce CRM</span>
+                        </div>
+                    </div>
+                    
+                    <div class="skills-section">
+                        <h3>CERTIFICATIONS & COURSES</h3>
+                        <div class="courses-section">
+                            <div class="course-item">
+                                <span class="course-name">Statement of Accomplishment - Intermediate R Course</span>
+                                <span class="course-info">Marketing Analytics In Practice - Coursera</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Marketing Analytics in R</span>
+                                <span class="course-info">PPGA - Graduate Program in Business Administration</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Fundamentals of Problem Solving</span>
+                                <span class="course-info">Marketing in a Digital World - Illinois University</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-experience">Professional Experience</h2>
-            <div id="experience-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-education">Education</h2>
-            <div id="education-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-projects">Projects & Innovation</h2>
-            <div id="projects-container"></div>
+            <h2 class="section-title">PROFESSIONAL EXPERIENCE</h2>
+            
+            <div class="experience-timeline">
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">CADASTRA (Digital Marketing and Performance Agency)</div>
+                        </div>
+                        <div class="period">2025-Present</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">Data Analytics Coordinator</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">Sep/2025-Present</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Leading Data Analytics and AI operations for enterprise clients in technology, retail and education sectors, managing multidisciplinary team (DataViz, Data Engineering, Web Analytics)</li>
+                        <li>Simultaneous management of strategic accounts with direct interface to C-level stakeholders and business areas (Performance, E-commerce, Commercial)</li>
+                        <li>Data architecture and governance definition for Business Intelligence, Real-Time Analytics and AI applications projects</li>
+                        <li>Technical diagnosis and restructuring of legacy data environments, including infrastructure migration (AWS→GCP) with projected 40% reduction in processing costs</li>
+                        <li>Data operations restructuring with team expansion (+67%) and scope extension to multiple LATAM business units</li>
+                        <li>Stabilization of critical data environments, achieving 20% savings in operational processing costs (Airflow/DAGs)</li>
+                        <li>Development of automations with n8n and AI Agents (LLMs), including automated Status Report with AI-generated executive summaries</li>
+                        <li>Leadership of first generative AI initiatives in client operations, positioning the area as innovation reference</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">LOJAS RENNER | REALIZE CFI (National Financial Services Company)</div>
+                        </div>
+                        <div class="period">2020-2025</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">CRM Manager</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2021-2025</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for leading the strategic CRM front, focusing on area evolution, customer base growth, and business value generation</li>
+                        <li>Definition and monitoring of area OKRs, connecting business goals to relationship indicators</li>
+                        <li>Planning, execution, and optimization of multichannel relationship campaigns (email, SMS, push, among others), applying intelligent segmentations and automations to increase usage frequency and sales</li>
+                        <li>Building personalized journeys based on customer behavior and profile, promoting lifecycle evolution and loyalty in financial products (cards, loans, insurance, and consumption in the Renner ecosystem)</li>
+                        <li>Management of agile management rhythm (daily, planning, reviews, and retrospectives), using frameworks such as Scrum and Kanban to maintain delivery pace, priority visibility, and impact focus</li>
+                        <li>Area backlog management, with mapping, prioritization, and organization of demands according to incremental value and alignment with the commercial team</li>
+                        <li>Strategic management of suppliers and technology partners, including CRM platforms, automation, and data enrichment, ensuring delivery quality and alignment with area guidelines</li>
+                        <li>Continuous interface with key areas (IT, Products, Analytics, Marketing, Stores, and Commercial), promoting alignment between CRM initiatives and corporate objectives</li>
+                        <li>Technical and operational management of tools such as Oracle Responsys, Databricks, and Power BI, enabling automated segmentations, data processing, and performance dashboards</li>
+                        <li>Monitoring and analysis of KPIs and campaign indicators, using data to guide decisions, validate hypotheses, and promote continuous improvement</li>
+                        <li>Leadership of strategic projects and initiatives to expand the active customer base and activate new communication channels</li>
+                    </ul>
+                    
+                    <div class="job-title" style="margin-top: 15px; margin-bottom: 8px;">Analytics Specialist</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2020-2021</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for creating dashboards and strategic indicators for areas such as Marketing, CRM, Credit, and Channels, delivering an integrated real-time view to support business decisions</li>
+                        <li>Development of segmented databases and automated reports focused on the CRM team, with a focus on efficiency gains, agility in analyses, and revenue generation through more precise actions</li>
+                        <li>Organization and integration of operational, behavioral, and transactional data, consolidating multiple sources into a reliable base for comprehensive customer lifecycle analyses</li>
+                        <li>Practical use of tools such as SQL, BigQuery, Python, and Power BI for exploratory analyses, routine automations, and development of predictive models applied to the business</li>
+                        <li>Close collaboration with Marketing, Products, Risk, and Operations areas, translating strategic needs into applicable analyses, focusing on action direction and decision-making</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Analytics Specialist</div>
+                            <div class="company">DBC COMPANY (National IT Consulting Company)</div>
+                        </div>
+                        <div class="period">2020-2021</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for supporting the strategic restructuring of the CRM area at client Realize, implementing agile methodologies (Kanban) and defining processes that reduced campaign time-to-market and increased operational efficiency</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Business Intelligence Analyst</div>
+                            <div class="company">GRUPO RBS (National Media Company)</div>
+                        </div>
+                        <div class="period">2019 - 2020</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for structuring and analyzing commercial performance, audience, and market behavior data, supporting leadership in strategic decision-making for client Rede Globo</li>
+                        <li>Development of segmentation studies and consumption potential mapping, using data to guide decisions, validate hypotheses, and promote sales and prospecting actions</li>
+                        <li>Creation of real-time analytical reports and dashboards to support business decisions</li>
+                        <li>Direct interface with leadership, translating market data into action plans and growth opportunities</li>
+                        <li>Analysis of KPIs and campaign indicators, using data to guide decisions, validate hypotheses, and promote continuous improvement</li>
+                    </ul>
+                </div>
+            </div>
         </section>
     </div>
-
-    <script src="../assets/js/cv-texts.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            var lang = 'en';
-            initializeBasicContent(lang);
-            renderSkills('skills-strategic', 'strategic', lang);
-            renderSkills('skills-tools', 'tools', lang);
-            renderSkills('skills-emerging', 'emerging', lang);
-            renderExperienceTimeline(lang);
-            renderEducation(lang);
-            renderProjects(lang);
-        });
-    </script>
+    <!-- Dynamic Favicon System -->
+    <script src="../assets/js/dynamic-favicon.js"></script>
 </body>
 </html>

--- a/cv_styles/cv_magalu_style_PT.html
+++ b/cv_styles/cv_magalu_style_PT.html
@@ -3,471 +3,669 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pedro Henrique Marconato - CV</title>
+    <title>Pedro Henrique Marconato - CV (Magalu)</title>
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&display=swap');
         @import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap');
-
+        
         :root {
-            /* Magalu Colors (docs/magalu_brandbook.md) */
+            /* Magalu — brand tokens */
             --primary-color: #0086FF;
             --secondary-color: #236FBE;
             --accent-color: #FF3BA8;
-            --light-bg: #E5F2FF;
-            --text-color: #2c3e50;
-            --muted-color: #5a6b7a;
+            --light-accent: #EAF4FF;
+            --text-color: #2C3E50;
             --border-color: rgba(0, 134, 255, 0.18);
             --background-gradient: linear-gradient(135deg, #0086FF 0%, #236FBE 100%);
-            --font-title: 'Baloo 2', 'Trebuchet MS', sans-serif;
+
             --font-body: 'Nunito', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            --font-display: 'Nunito', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+
+            --header-text: #ffffff;
+            --header-text-soft: rgba(255, 255, 255, 0.95);
+            --header-chip-bg: rgba(255, 255, 255, 0.15);
+            --header-chip-border: rgba(255, 255, 255, 0.28);
+
+            --tag-bg: rgba(255, 59, 168, 0.12);
+            --tag-border: rgba(255, 59, 168, 0.28);
         }
-
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-
+        
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
         body {
             font-family: var(--font-body);
             color: var(--text-color);
-            line-height: 1.55;
-            background: linear-gradient(180deg, #eaf4ff 0%, #f8fbff 100%);
-            font-size: 12.5px;
+            line-height: 1.6;
+            background: var(--light-accent);
+            min-height: 100vh;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
         }
 
+        /* Main container */
         .cv-container {
             max-width: 210mm;
-            margin: 20px auto;
-            padding: 0 0 14mm;
-            background: #ffffff;
-            border-radius: 20px;
+            margin: 0 auto;
+            background: rgba(255, 255, 255, 1);
             overflow: hidden;
-            box-shadow: 0 10px 40px rgba(0, 134, 255, 0.14);
+            position: relative;
         }
-
-        /* Header */
+        
+        /* Header Section */
         .header {
             background: var(--background-gradient);
-            padding: 32px 40px 34px;
+            padding: 50px 50px 55px 50px;
             position: relative;
             overflow: hidden;
         }
+        
+        .header-content {
+            position: relative;
+            z-index: 1;
+        }
 
-        .header::before {
-            content: '';
+.brand-logo {
             position: absolute;
-            width: 190px;
-            height: 190px;
-            border-radius: 50%;
-            background: rgba(255, 255, 255, 0.08);
-            top: -80px;
-            right: -50px;
-        }
-
-        .header::after {
-            content: '';
-            position: absolute;
-            width: 130px;
-            height: 130px;
-            border-radius: 50%;
-            background: rgba(255, 59, 168, 0.12);
-            bottom: -60px;
-            left: -35px;
-        }
-
-        .header-content { position: relative; z-index: 1; }
-
-        .brand-logo {
-            width: 150px;
-            height: 42px;
-            margin: 0 auto 14px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .brand-logo img {
-            width: 100%;
-            height: 100%;
-            object-fit: contain;
+            bottom: 20px;
+            right: 40px;
+            width: 140px;
+            height: auto;
+            opacity: 0.95;
             filter: brightness(0) invert(1);
         }
-
+        
         .header h1 {
-            font-family: var(--font-title);
-            font-size: 24px;
-            font-weight: 800;
-            color: #ffffff;
-            text-align: center;
-            letter-spacing: 0.3px;
-        }
-
-        .header h2 {
-            font-family: var(--font-body);
-            font-size: 13.5px;
+            font-family: var(--font-display);
+            font-size: 32px;
             font-weight: 700;
-            color: rgba(255, 255, 255, 0.95);
-            text-align: center;
-            margin-top: 4px;
-            margin-bottom: 16px;
+            color: var(--header-text);
+            margin-bottom: 8px;
+            letter-spacing: -0.5px;
+            text-transform: uppercase;
         }
 
+        .header-tagline {
+            font-size: 17px;
+            font-weight: 400;
+            color: var(--header-text-soft);
+            margin-top: 22px;
+            margin-bottom: 28px;
+            font-style: italic;
+            letter-spacing: 0.5px;
+        }
+        
         .contact-info {
             display: flex;
             flex-wrap: wrap;
-            gap: 8px;
-            justify-content: center;
+            gap: 10px;
+            align-items: center;
+            margin-top: 12px;
         }
-
-        .contact-pill {
+        
+        .contact-item {
             display: inline-flex;
             align-items: center;
-            gap: 6px;
-            background: rgba(255, 255, 255, 0.18);
-            border: 1px solid rgba(255, 255, 255, 0.3);
-            border-radius: 999px;
-            padding: 7px 14px;
-            color: #ffffff;
-            font-size: 11.5px;
-            font-weight: 600;
-            text-decoration: none;
+            background: var(--header-chip-bg);
+            border-radius: 10px;
+            padding: 8px 14px;
+            color: var(--header-text);
+            font-size: 12.5px;
+            font-weight: 500;
+            border: 1px solid var(--header-chip-border);
+        }
+        
+        .contact-item i {
+            margin-right: 6px;
+            font-size: 12px;
+        }
+        
+        /* Section Styles */
+        .section {
+            padding: 25px 50px;
+            border-bottom: 1px solid var(--border-color);
         }
 
-        .contact-pill i { font-size: 11px; color: #ffffff; }
-        .contact-pill span, .contact-pill a { color: #ffffff; text-decoration: none; }
-
-        /* Sections */
-        .section { padding: 22px 40px; position: relative; }
-
-        .section:not(:last-child)::after {
-            content: '';
-            position: absolute;
-            bottom: 0;
-            left: 40px;
-            right: 40px;
-            height: 1px;
-            background: linear-gradient(to right, transparent, var(--border-color), transparent);
+        .section:last-child {
+            border-bottom: none;
         }
 
         .section-title {
-            font-family: var(--font-title);
-            background: var(--background-gradient);
-            color: #ffffff;
-            font-size: 14px;
-            font-weight: 700;
-            padding: 8px 18px;
-            border-radius: 999px;
-            margin-bottom: 16px;
+            font-family: var(--font-display);
+            background: var(--primary-color);
+            color: white;
+            font-size: 15px;
+            font-weight: 600;
+            margin-bottom: 18px;
+            padding: 8px 16px;
+            border-radius: 12px;
+            letter-spacing: 0.3px;
             display: inline-block;
-            letter-spacing: 0.2px;
-            box-shadow: 0 4px 12px rgba(0, 134, 255, 0.22);
+            text-transform: uppercase;
         }
 
-        #cv-profile { font-size: 12.5px; line-height: 1.65; color: var(--text-color); }
+        /* Resumo de Qualificações */
+        .qualifications-list {
+            list-style: none;
+            padding: 0;
+        }
 
-        /* Skills */
-        .skills-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 16px; }
+        .qualifications-list li {
+            position: relative;
+            padding-left: 28px;
+            margin-bottom: 14px;
+            font-size: 13.5px;
+            line-height: 1.7;
+            color: var(--text-color);
+        }
 
-        .skills-card {
-            background: linear-gradient(135deg, var(--light-bg), #ffffff);
+        .qualifications-list li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+            font-size: 20px;
+            top: -2px;
+        }
+        
+        /* Skills & Tools Grid */
+        .skills-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 20px;
+        }
+
+        .skills-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 16px;
+            border-radius: 14px;
             border: 1px solid var(--border-color);
-            border-radius: 16px;
-            padding: 14px 16px;
         }
 
-        .skills-card h3 { font-family: var(--font-title); }
+        .skills-section h3 {
+            font-size: 12px;
+            color: var(--primary-color);
+            margin-bottom: 10px;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
 
-        .tool-item { margin-bottom: 9px; }
-        .tool-item:last-child { margin-bottom: 0; }
+        .skill-items {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
 
-        .tool-name {
+        .skill-tag {
+            background: var(--tag-bg);
+            color: var(--primary-color);
+            padding: 4px 10px;
+            border-radius: 12px;
+            font-size: 10.5px;
+            font-weight: 500;
+            border: 1px solid var(--tag-border);
+        }
+
+        /* Cursos Complementares */
+        .courses-section {
+            margin-top: 10px;
+        }
+
+        .course-item {
+            padding: 8px 0;
+            border-bottom: 1px solid var(--border-color);
+            font-size: 11px;
+        }
+
+        .course-item:last-child {
+            border-bottom: none;
+        }
+
+        .course-name {
+            color: var(--text-color);
+            font-weight: 500;
+            display: block;
+            margin-bottom: 2px;
+        }
+
+        .course-info {
+            color: var(--secondary-color);
+            font-size: 10px;
+            font-style: italic;
+        }
+        
+        /* Experience Timeline */
+        .experience-timeline {
+            position: relative;
+            margin-left: 20px;
+            padding-left: 30px;
+        }
+        
+        .experience-timeline::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            top: 0;
+            bottom: 0;
+            width: 3px;
+            background: var(--primary-color);
+            border-radius: 3px;
+        }
+        
+        .experience-item {
+            margin-bottom: 25px;
+            position: relative;
+            padding: 18px;
+            border-radius: 14px;
+            background: #fff;
+            border: 1px solid var(--border-color);
+        }
+        
+        .experience-item::before {
+            content: "";
+            position: absolute;
+            left: -36px;
+            top: 25px;
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background: var(--accent-color);
+            border: 3px solid white;
+        }
+        
+        .job-header {
             display: flex;
             justify-content: space-between;
-            align-items: center;
-            font-weight: 700;
-            font-size: 11.5px;
-            color: var(--text-color);
-            margin-bottom: 4px;
-        }
-
-        .tool-percentage {
-            color: var(--accent-color);
-            font-size: 9.5px;
-            font-weight: 800;
-            background: rgba(255, 59, 168, 0.1);
-            padding: 2px 8px;
-            border-radius: 999px;
-        }
-
-        .dots-container { display: flex; gap: 3px; }
-        .dot { width: 7px; height: 7px; border-radius: 50%; background: rgba(0, 134, 255, 0.15); }
-        .dot.filled { background: var(--primary-color); }
-
-        /* Experience */
-        .experience-item {
-            position: relative;
-            margin-bottom: 16px;
-            padding: 16px 18px 16px 22px;
-            border-radius: 16px;
-            border: 1px solid var(--border-color);
-            border-left: 5px solid var(--primary-color);
-            background: linear-gradient(135deg, #ffffff 0%, rgba(229, 242, 255, 0.5) 100%);
-            box-shadow: 0 3px 14px rgba(0, 134, 255, 0.07);
-            page-break-inside: avoid;
+            align-items: flex-start;
+            margin-bottom: 10px;
         }
 
         .job-title {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            font-family: var(--font-title);
-            font-weight: 700;
-            font-size: 14px;
-            color: var(--secondary-color);
+            font-family: var(--font-display);
+            font-weight: 600;
+            font-size: 16px;
+            color: var(--primary-color);
             margin-bottom: 4px;
         }
-
-        .job-number {
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            width: 20px;
-            height: 20px;
-            flex-shrink: 0;
-            border-radius: 50%;
-            background: var(--background-gradient);
-            color: #ffffff;
-            font-family: var(--font-body);
-            font-size: 10px;
-            font-weight: 800;
+        
+        .company {
+            font-weight: 500;
+            font-size: 13px;
+            color: var(--secondary-color);
+        }
+        
+        .period {
+            font-size: 12px;
+            color: var(--secondary-color);
+            font-weight: 600;
+            text-align: right;
+        }
+        
+        .job-description {
+            font-size: 12px;
+            line-height: 1.6;
+            color: var(--text-color);
+            margin-bottom: 12px;
         }
 
-        .experience-item .company { font-weight: 700; font-size: 12px; color: var(--primary-color); }
-        .experience-item .period { font-size: 11px; color: var(--accent-color); font-weight: 700; margin-bottom: 6px; }
-        .job-description { font-size: 11.5px; line-height: 1.55; margin-bottom: 8px; color: var(--text-color); }
-
-        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
-
-        .achievement-item {
-            display: flex;
-            gap: 8px;
-            align-items: flex-start;
-            background: rgba(255, 255, 255, 0.65);
-            border-radius: 10px;
-            padding: 6px 8px;
+        .job-bullets {
+            list-style: none;
+            padding: 0;
         }
 
-        .achievement-icon {
-            width: 20px;
-            height: 20px;
-            flex-shrink: 0;
-            border-radius: 50%;
-            background: rgba(0, 134, 255, 0.12);
-            color: var(--primary-color);
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 9.5px;
+        .job-bullets li {
+            position: relative;
+            padding-left: 20px;
+            margin-bottom: 8px;
+            font-size: 12px;
+            line-height: 1.5;
+            color: var(--text-color);
         }
 
-        .achievement-title { font-weight: 700; font-size: 10.5px; color: var(--text-color); }
-        .achievement-description { font-size: 10px; color: var(--muted-color); line-height: 1.4; }
-
-        .tooltip { display: none; } /* hover não funciona no papel */
-
+        .job-bullets li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+        }
+        
         /* Education */
+        .education-tech-container {
+            display: grid;
+            grid-template-columns: 1fr 2fr;
+            gap: 25px;
+        }
+        
+        .education-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 20px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
+        }
+
         .education-item {
-            margin-bottom: 10px;
-            padding: 14px 16px;
-            border-radius: 14px;
-            background: linear-gradient(135deg, var(--light-bg), #ffffff);
-            border: 1px solid var(--border-color);
-            page-break-inside: avoid;
+            margin-bottom: 12px;
+            padding-bottom: 12px;
+            border-bottom: 1px solid var(--border-color);
         }
 
-        .degree { font-family: var(--font-title); font-weight: 700; color: var(--primary-color); font-size: 12.5px; }
-        .university { font-size: 11px; margin-top: 2px; }
-        .thesis { font-size: 10.5px; color: var(--muted-color); font-style: italic; margin-top: 2px; }
-        .cta-button { display: none; }
-
-        /* Projects */
-        .project-item {
-            margin-bottom: 10px;
-            padding: 14px 16px;
-            border-radius: 14px;
-            background: linear-gradient(135deg, #ffffff, rgba(229, 242, 255, 0.5));
-            border: 1px solid var(--border-color);
-            page-break-inside: avoid;
+        .education-item:last-child {
+            margin-bottom: 0;
+            padding-bottom: 0;
+            border-bottom: none;
         }
-
-        .project-title { font-family: var(--font-title); font-weight: 700; color: var(--primary-color); font-size: 12.5px; }
-        .project-description { font-size: 11px; margin-top: 3px; margin-bottom: 6px; }
-
-        .tech-tag {
-            display: inline-block;
-            padding: 3px 10px;
-            margin: 2px 4px 0 0;
-            background: var(--light-bg);
-            border: 1px solid rgba(0, 134, 255, 0.35);
+        
+        .degree {
+            font-family: var(--font-display);
+            font-weight: 600;
+            font-size: 13px;
             color: var(--primary-color);
-            border-radius: 999px;
-            font-size: 9.5px;
-            font-weight: 700;
+            margin-bottom: 3px;
+        }
+        
+        .university {
+            font-size: 11px;
+            color: var(--text-color);
+            margin-bottom: 2px;
+        }
+        
+        .edu-period {
+            font-size: 10px;
+            color: var(--secondary-color);
+            font-style: italic;
         }
 
-        @media print {
-            * { animation: none !important; }
+        .tech-skills-container {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 15px;
+        }
 
+        /* Languages */
+        .language-container {
+            display: flex;
+            justify-content: center;
+            gap: 30px;
+        }
+
+        .language-item {
+            text-align: center;
+        }
+
+        .language-name {
+            font-weight: 600;
+            color: var(--primary-color);
+            font-size: 13px;
+            margin-bottom: 2px;
+        }
+
+        .language-level {
+            font-size: 11px;
+            color: var(--text-color);
+        }
+
+        /* Print Styles */
+        @media print {
             body {
-                background: #ffffff;
+                background: white;
                 margin: 0;
                 padding: 0;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
             }
 
-            .cv-container { margin: 0; max-width: 100%; border-radius: 0; box-shadow: none; padding-bottom: 6mm; }
+            .cv-container {
+                max-width: 100%;
+                margin: 0;
+                box-shadow: none;
+            }
 
             .header {
                 background: var(--background-gradient) !important;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
-                padding: 18px 26px 22px !important;
+                padding: 25px 35px !important;
                 page-break-after: avoid;
             }
 
-            .header h1 { font-size: 19px !important; }
-            .header h2 { font-size: 11px !important; margin-bottom: 10px !important; }
-            .brand-logo { width: 110px !important; height: 32px !important; margin-bottom: 8px !important; }
-
-            .contact-pill {
-                font-size: 8.5px !important;
-                padding: 4px 9px !important;
-                background: rgba(255, 255, 255, 0.22) !important;
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
-            }
-
-            .section { padding: 10px 26px !important; page-break-inside: avoid; }
-            .section:not(:last-child)::after { left: 26px; right: 26px; }
-
             .section-title {
-                background: var(--background-gradient) !important;
+                background: var(--primary-color) !important;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
-                font-size: 11.5px !important;
-                padding: 5px 14px !important;
-                margin-bottom: 9px !important;
-                box-shadow: none !important;
+                color: white !important;
+                page-break-after: avoid;
             }
 
-            #cv-profile { font-size: 10.5px !important; line-height: 1.5 !important; }
-
-            .skills-grid { gap: 10px !important; }
-            .skills-card { padding: 9px 11px !important; border-radius: 12px !important; }
-            .skills-card h3 { font-size: 12px !important; margin-bottom: 8px !important; }
-            .tool-item { margin-bottom: 6px !important; }
-            .tool-name { font-size: 9.5px !important; }
-            .tool-percentage { font-size: 7.5px !important; padding: 1px 6px !important; }
-            .dot { width: 5.5px !important; height: 5.5px !important; }
+            .section {
+                padding: 15px 35px;
+                page-break-inside: avoid;
+            }
 
             .experience-item {
-                padding: 10px 12px 10px 15px !important;
-                margin-bottom: 8px !important;
-                border-radius: 10px !important;
-                box-shadow: none !important;
-                page-break-inside: avoid !important;
+                page-break-inside: avoid;
             }
 
-            .job-title { font-size: 11.5px !important; }
-            .job-number { width: 15px !important; height: 15px !important; font-size: 8px !important; }
-            .experience-item .company { font-size: 10px !important; }
-            .experience-item .period { font-size: 9px !important; margin-bottom: 4px !important; }
-            .job-description { font-size: 9.5px !important; margin-bottom: 5px !important; }
-            .achievements-container { gap: 5px !important; }
-            .achievement-item { padding: 4px 6px !important; gap: 5px !important; }
-            .achievement-icon { width: 15px !important; height: 15px !important; font-size: 7.5px !important; }
-            .achievement-title { font-size: 9px !important; }
-            .achievement-description { font-size: 8.5px !important; }
-
-            .education-item, .project-item {
-                padding: 9px 11px !important;
-                margin-bottom: 6px !important;
-                border-radius: 10px !important;
-                page-break-inside: avoid !important;
+            /* Hide animations */
+            * {
+                animation: none !important;
             }
 
-            .degree, .project-title { font-size: 10.5px !important; }
-            .university { font-size: 9.5px !important; }
-            .thesis { font-size: 9px !important; }
-            .project-description { font-size: 9.5px !important; }
-            .tech-tag { font-size: 8px !important; padding: 2px 8px !important; }
-
-            .tooltip { display: none !important; }
-
-            @page { size: A4; margin: 8mm; }
+            @page {
+                size: A4;
+                margin: 8mm;
+            }
         }
+        .contact-info { max-width: calc(100% - 180px); }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <!-- Favicon Meta Tags -->
+    <meta name="theme-color" content="#0086FF">
+    <meta name="msapplication-TileColor" content="#0086FF">
+    <meta name="msapplication-config" content="../assets/favicons/browserconfig.xml">
 </head>
 <body>
     <div class="cv-container">
         <header class="header">
             <div class="header-content">
-                <div class="brand-logo">
-                    <img src="../assets/images/magalu.svg" alt="Magalu">
-                </div>
-                <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
-                <h2 id="cv-role">Gestão de CRM e Inteligência de Dados</h2>
+                <img src="../assets/images/magalu.svg" alt="Magalu" class="brand-logo">
+                <h1>PEDRO HENRIQUE MARCONATO</h1>
+                
+                <div class="header-tagline">CRM | ANALYTICS | BUSINESS INTELLIGENCE | LTV | SQL</div>
+                
                 <div class="contact-info">
-                    <span class="contact-pill"><i class="fas fa-envelope"></i><span id="cv-email">pedrohmarconato@gmail.com</span></span>
-                    <span class="contact-pill"><i class="fas fa-phone"></i><span id="cv-phone">+55 (55) 981147758</span></span>
-                    <span class="contact-pill" id="cv-location"><i class="fas fa-map-marker-alt"></i><span>Cachoeira do Sul, RS</span></span>
-                    <a class="contact-pill" href="https://linkedin.com/in/pedrohmarconato" target="_blank"><i class="fab fa-linkedin"></i><span id="cv-linkedin">LinkedIn</span></a>
-                    <a class="contact-pill" href="https://github.com/pedrohmarconato" target="_blank"><i class="fab fa-github"></i><span id="cv-repository">Repositório</span></a>
+                    <div class="contact-item">
+                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 35 anos
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-phone"></i> +55 (55) 98114-7758
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-envelope"></i> pedrohmarconato@gmail.com
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fab fa-linkedin"></i> linkedin.com/in/pedrohmarconato
+                    </div>
                 </div>
             </div>
         </header>
-
-        <section class="section">
-            <h2 class="section-title" id="section-profile">Perfil Profissional</h2>
-            <p id="cv-profile"></p>
+        
+        <section class="section" style="padding-top: 35px;">
+            <h2 class="section-title">RESUMO DE QUALIFICAÇÕES</h2>
+            <ul class="qualifications-list">
+                <li>Mestre em Administração de Empresas, com ênfase na área de Analytics, unindo inteligência de dados, CRM, visualização analítica e automação para gerar valor ao negócio</li>
+                <li>Atuação em empresas de grande porte e alta complexidade, como Grupo RBS, Realize CFI (Grupo Lojas Renner S.A.) e Rede Globo, liderando projetos estratégicos nas frentes de CRM, inteligência comercial e performance de marketing</li>
+                <li>Vivência com dados aplicados a marketing, canais, crédito, controle e operações, conectando áreas e traduzindo necessidades técnicas em soluções analíticas de alto impacto</li>
+                <li>Destaques em projetos de visualização, segmentação e comportamento de consumo, com domínio de ferramentas como Databricks, SQL, Responsys, Power BI, Python, Salesforce, Mailchimp, Tableau, SAS, Mix Agents e Kanbanize</li>
+                <li>Conhecimento em metodologias ágeis (Scrum, Kanban), com atuação na priorização de backlog, estruturação de squads e aceleração de entrega com foco no cliente</li>
+                <li>Experiência com integração de dados de múltiplas fontes, construção de pipelines, análises preditivas e mapeamento de comportamento para suportar decisões estratégicas</li>
+                <li>Diferencial na combinação entre capacidade analítica, pensamento estratégico e conhecimento técnico, com atuação reconhecida como liderança mesmo em estruturas consultivas</li>
+                <li>Gestão de pessoas, liderando times multidisciplinares com foco em desenvolvimento, autonomia e geração de resultados consistentes</li>
+            </ul>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-skills">Habilidades e Ferramentas</h2>
-            <div class="skills-grid">
-                <div id="skills-strategic" class="skills-card"></div>
-                <div id="skills-tools" class="skills-card"></div>
-                <div id="skills-emerging" class="skills-card"></div>
+            <h2 class="section-title">FORMAÇÃO ACADÊMICA & TECNOLOGIA</h2>
+            <div class="education-tech-container">
+                <div class="education-section">
+                    <h3 style="font-size: 12px; color: var(--primary-color); margin-bottom: 12px; font-weight: 600;">FORMAÇÃO</h3>
+                    <div class="education-item">
+                        <div class="degree">Mestrado em Administração de Empresas</div>
+                        <div class="university">Universidade Federal de Santa Maria - UFSM</div>
+                        <div class="edu-period">Conclusão: 2019</div>
+                    </div>
+                    
+                    <div class="education-item">
+                        <div class="degree">Bacharelado em Administração</div>
+                        <div class="university">Universidade Federal de Santa Maria - UFSM</div>
+                        <div class="edu-period">Conclusão: 2015</div>
+                    </div>
+                </div>
+                
+                <div class="tech-skills-container">
+                    <div class="skills-section">
+                        <h3>FERRAMENTAS & PLATAFORMAS</h3>
+                        <div class="skill-items">
+                            <span class="skill-tag">Databricks</span>
+                            <span class="skill-tag">SQL</span>
+                            <span class="skill-tag">Power BI</span>
+                            <span class="skill-tag">Python</span>
+                            <span class="skill-tag">Oracle Responsys</span>
+                            <span class="skill-tag">Kanbanize</span>
+                            <span class="skill-tag">Mailchimp</span>
+                            <span class="skill-tag">Mix Agents</span>
+                            <span class="skill-tag">SAS</span>
+                            <span class="skill-tag">Tableau</span>
+                            <span class="skill-tag">Salesforce CRM</span>
+                        </div>
+                    </div>
+                    
+                    <div class="skills-section">
+                        <h3>CERTIFICAÇÕES & CURSOS</h3>
+                        <div class="courses-section">
+                            <div class="course-item">
+                                <span class="course-name">Statement of Accomplishment - Intermediate R Course</span>
+                                <span class="course-info">Marketing Analytics In Practice - Coursera</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Marketing Analytics em R</span>
+                                <span class="course-info">PPGA - Programa de Pós-Graduação em Administração</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Fundamentos de Solução de Problemas</span>
+                                <span class="course-info">Marketing in a Digital World - Illinois University</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-experience">Experiência Profissional</h2>
-            <div id="experience-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-education">Formação Acadêmica</h2>
-            <div id="education-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-projects">Projetos e Inovação</h2>
-            <div id="projects-container"></div>
+            <h2 class="section-title">EXPERIÊNCIA PROFISSIONAL</h2>
+            
+            <div class="experience-timeline">
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">CADASTRA (Agência de Marketing Digital e Performance)</div>
+                        </div>
+                        <div class="period">2025-Atual</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">Coordenador de Data Analytics</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">Set/2025-Atual</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável pela operação de Data Analytics e AI para clientes de grande porte dos setores de tecnologia, varejo e educação, liderando time multidisciplinar (DataViz, Engenharia de Dados, Web Analytics)</li>
+                        <li>Gestão simultânea de contas estratégicas, com interface direta com stakeholders C-level e áreas de negócio (Performance, E-commerce, Comercial)</li>
+                        <li>Definição de arquitetura de dados e governança para projetos de Business Intelligence, Real-Time Analytics e aplicações de inteligência artificial</li>
+                        <li>Diagnóstico técnico e reestruturação de ambientes de dados legados, incluindo migração de infraestrutura (AWS→GCP) com redução projetada de 40% em custos de processamento</li>
+                        <li>Reestruturação de operações de dados com expansão de time (+67%) e ampliação de escopo para múltiplas unidades de negócio em LATAM</li>
+                        <li>Estabilização de ambientes críticos de dados, alcançando economia de 20% em custos operacionais de processamento (Airflow/DAGs)</li>
+                        <li>Desenvolvimento de automações com n8n e AI Agents (LLMs), incluindo Status Report automatizado com geração de resumos executivos por inteligência artificial</li>
+                        <li>Liderança das primeiras iniciativas de aplicação de IA generativa em operações de clientes, posicionando a área como referência em inovação</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">LOJAS RENNER | REALIZE CFI (Empresa Nacional do segmento Financeiro)</div>
+                        </div>
+                        <div class="period">2020-2025</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">CRM Manager</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2021-2025</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável pela liderança da frente estratégica de CRM, com foco na evolução da área, crescimento da base de clientes e geração de valor ao negócio</li>
+                        <li>Definição e acompanhamento dos OKRs da área, conectando metas do negócio a indicadores de relacionamento</li>
+                        <li>Planejamento, execução e otimização de campanhas de relacionamento multicanal (e-mail, SMS, push, entre outros), aplicando segmentações inteligentes e automações para aumentar frequência de uso e vendas</li>
+                        <li>Construção de jornadas personalizadas com base em comportamento e perfil dos clientes, promovendo a evolução do ciclo de vida e fidelização em produtos financeiros (cartões, empréstimos, seguros e consumo no ecossistema Renner)</li>
+                        <li>Gestão do ritmo de gestão ágil (daily, planning, reviews e retrospectives), utilizando frameworks como Scrum e Kanban para manter ritmo de entrega, visibilidade de prioridades e foco em impacto</li>
+                        <li>Gestão do backlog da área, com mapeamento, priorização e organização das demandas de acordo com o valor incremental e alinhamento com o time comercial</li>
+                        <li>Gestão estratégica de fornecedores e parceiros de tecnologia, incluindo plataformas de CRM, automação e enriquecimento de dados, garantindo qualidade das entregas e alinhamento às diretrizes da área</li>
+                        <li>Interface contínua com áreas-chave (TI, Produtos, Analytics, Marketing, Lojas e Comercial), promovendo alinhamento entre as iniciativas de CRM e os objetivos corporativos</li>
+                        <li>Gestão técnica e operacional de ferramentas como Oracle Responsys, Databricks e Power BI, viabilizando segmentações automatizadas, tratamento de dados e dashboards de performance</li>
+                        <li>Monitoramento e análise de KPIs e indicadores de campanhas, utilizando dados para orientar decisões, validar hipóteses e promover a melhoria contínua</li>
+                        <li>Liderança de projetos e iniciativas estratégicas de expansão da base ativa de clientes e ativação de novos canais de comunicação</li>
+                    </ul>
+                    
+                    <div class="job-title" style="margin-top: 15px; margin-bottom: 8px;">Especialista de Analytics</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2020-2021</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável por criar dashboards e indicadores estratégicos para áreas como Marketing, CRM, Crédito e Canais, entregando uma visão integrada e em tempo real para apoiar decisões de negócio</li>
+                        <li>Desenvolvimento de bases segmentadas e relatórios automatizados voltados ao time de CRM, com foco em ganho de eficiência, agilidade nas análises e geração de receita por meio de ações mais precisas</li>
+                        <li>Organização e integração de dados operacionais, comportamentais e transacionais, consolidando múltiplas fontes em uma base confiável para análises completas do ciclo de vida do cliente</li>
+                        <li>Utilização prática de ferramentas como SQL, BigQuery, Python e Power BI para análises exploratórias, automações de rotinas e desenvolvimento de modelos preditivos aplicados ao negócio</li>
+                        <li>Atuação próxima às áreas de Marketing, Produtos, Riscos e Operações, traduzindo necessidades estratégicas em análises aplicáveis, com foco em direcionamento de ações e tomada de decisão</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Especialista de Analytics</div>
+                            <div class="company">DBC COMPANY (Empresa Nacional do segmento de Consultoria em TI)</div>
+                        </div>
+                        <div class="period">2020-2021</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável por apoiar a reestruturação estratégica da área de CRM no cliente Realize, implementando metodologias ágeis (Kanban) e definindo processos que reduziram o time-to-market das campanhas e aumentaram a eficiência operacional</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Analista de Inteligência Comercial</div>
+                            <div class="company">GRUPO RBS (Empresa Nacional do segmento de Mídia)</div>
+                        </div>
+                        <div class="period">2019 - 2020</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável pela estruturação e análise dados de desempenho comercial, audiência e comportamento de mercado, apoiando a liderança na tomada de decisões estratégicas do cliente Rede Globo</li>
+                        <li>Desenvolvimento de estudos de segmentação e mapeamento de potencial de consumo, utilizando dados para orientar decisões, validar hipóteses e promover ações de vendas e prospecção</li>
+                        <li>Criação de relatórios e dashboards analíticos em tempo real para apoiar decisões do negócio</li>
+                        <li>Interface direta com a liderança, traduzindo dados de mercado em planos de ação e oportunidades de crescimento</li>
+                        <li>Análise de KPIs e indicadores de campanhas, utilizando dados para orientar decisões, validar hipóteses e promover a melhoria contínua</li>
+                    </ul>
+                </div>
+            </div>
         </section>
     </div>
-
-    <script src="../assets/js/cv-texts.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            var lang = 'pt';
-            initializeBasicContent(lang);
-            renderSkills('skills-strategic', 'strategic', lang);
-            renderSkills('skills-tools', 'tools', lang);
-            renderSkills('skills-emerging', 'emerging', lang);
-            renderExperienceTimeline(lang);
-            renderEducation(lang);
-            renderProjects(lang);
-        });
-    </script>
+    <!-- Dynamic Favicon System -->
+    <script src="../assets/js/dynamic-favicon.js"></script>
 </body>
 </html>

--- a/cv_styles/cv_mercado-livre_style_EN.html
+++ b/cv_styles/cv_mercado-livre_style_EN.html
@@ -3,344 +3,668 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pedro Henrique Marconato - CV</title>
-    <meta name="theme-color" content="#FFE600">
+    <title>Pedro Henrique Marconato - CV (Mercado Livre)</title>
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Montserrat:wght@600;700;800&display=swap');
-
+        @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@500;600;700;800&family=Inter:wght@300;400;500;600;700&display=swap');
+        
         :root {
-            /* Mercado Livre Colors — brandbook (docs/mercado-livre_brandbook.md) */
-            --primary-color: #2D3277;   /* Azul Navy — masterbrand na página impressa */
-            --secondary-color: #1B1F55; /* Azul Profundo */
-            --accent-color: #3A3F80;    /* Azul Suave — detalhes/periodo */
-            --yellow-color: #FFE600;    /* Amarelo Mercado Livre — header */
-            --yellow-deep: #FFD100;     /* Amarelo Profundo */
-            --lavender-color: #B8BDE0;  /* Azul Pálido — empty dots */
-            --mist-color: #F4F5FB;      /* Névoa Azulada — alternating section background */
+            /* Mercado Livre — brand tokens */
+            --primary-color: #2D3277;
+            --secondary-color: #1B1F55;
+            --accent-color: #3A3F80;
+            --light-accent: #EEF0F8;
             --text-color: #1B1F55;
             --border-color: rgba(45, 50, 119, 0.15);
-            --gradient: linear-gradient(135deg, #2D3277 0%, #1B1F55 100%);
-            --font-display: 'Montserrat', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            --background-gradient: linear-gradient(135deg, #FFE600 0%, #FFDB00 100%);
+
             --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            --font-display: 'Montserrat', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+
+            --header-text: #2D3277;
+            --header-text-soft: #1B1F55;
+            --header-chip-bg: rgba(45, 50, 119, 0.10);
+            --header-chip-border: rgba(45, 50, 119, 0.28);
+
+            --tag-bg: rgba(45, 50, 119, 0.10);
+            --tag-border: rgba(45, 50, 119, 0.24);
         }
-
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-
+        
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
         body {
             font-family: var(--font-body);
             color: var(--text-color);
-            line-height: 1.55;
-            background: #ffffff;
-            font-size: 12px;
+            line-height: 1.6;
+            background: var(--light-accent);
+            min-height: 100vh;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
         }
 
-        .cv-container { max-width: 210mm; margin: 0 auto; background: #ffffff; }
-
-        /* Header — bright yellow hero, navy ink, natural logo */
+        /* Main container */
+        .cv-container {
+            max-width: 210mm;
+            margin: 0 auto;
+            background: rgba(255, 255, 255, 1);
+            overflow: hidden;
+            position: relative;
+        }
+        
+        /* Header Section */
         .header {
-            background: linear-gradient(135deg, #FFE600 0%, #FFD100 100%);
-            padding: 34px 40px 38px;
-            text-align: center;
+            background: var(--background-gradient);
+            padding: 50px 50px 55px 50px;
+            position: relative;
+            overflow: hidden;
+        }
+        
+        .header-content {
+            position: relative;
+            z-index: 1;
         }
 
-        .brand-logo { width: 108px; height: 58px; margin: 0 auto 14px; }
-        .brand-logo img { width: 100%; height: 100%; object-fit: contain; }
-
+.brand-logo {
+            position: absolute;
+            bottom: 20px;
+            right: 40px;
+            width: 120px;
+            height: auto;
+            opacity: 1;
+        }
+        
         .header h1 {
             font-family: var(--font-display);
-            font-size: 23px;
-            font-weight: 800;
-            color: var(--primary-color);
-            letter-spacing: 0.2px;
-            margin-bottom: 6px;
+            font-size: 32px;
+            font-weight: 700;
+            color: var(--header-text);
+            margin-bottom: 8px;
+            letter-spacing: -0.5px;
+            text-transform: uppercase;
         }
 
-        .header h2 {
-            font-size: 12.5px;
-            font-weight: 500;
-            color: var(--accent-color);
-            margin-bottom: 16px;
+        .header-tagline {
+            font-size: 17px;
+            font-weight: 400;
+            color: var(--header-text-soft);
+            margin-top: 22px;
+            margin-bottom: 28px;
+            font-style: italic;
+            letter-spacing: 0.5px;
         }
-
+        
         .contact-info {
             display: flex;
             flex-wrap: wrap;
-            justify-content: center;
-            gap: 8px;
+            gap: 10px;
+            align-items: center;
+            margin-top: 12px;
         }
-
-        .contact-info > span,
-        .contact-info > a {
-            display: inline-block;
-            background: rgba(255, 255, 255, 0.4);
-            border: 1px solid rgba(45, 50, 119, 0.35);
-            color: var(--primary-color);
-            text-decoration: none;
-            font-size: 10.5px;
-            font-weight: 600;
-            padding: 5px 12px;
-            border-radius: 20px;
+        
+        .contact-item {
+            display: inline-flex;
+            align-items: center;
+            background: var(--header-chip-bg);
+            border-radius: 10px;
+            padding: 8px 14px;
+            color: var(--header-text);
+            font-size: 12.5px;
+            font-weight: 500;
+            border: 1px solid var(--header-chip-border);
         }
-
-        /* Sections — generous whitespace, alternating mist */
-        .section { padding: 24px 40px; }
-        .section:nth-of-type(even) { background: var(--mist-color); }
-
-        .section-title {
-            display: inline-block;
-            font-family: var(--font-display);
-            background: var(--primary-color);
-            color: #ffffff;
+        
+        .contact-item i {
+            margin-right: 6px;
             font-size: 12px;
-            font-weight: 700;
-            letter-spacing: 0.4px;
-            text-transform: uppercase;
-            padding: 6px 14px;
-            border-radius: 8px;
-            margin-bottom: 14px;
         }
-
-        #cv-profile { font-size: 11.5px; line-height: 1.65; }
-
-        /* Skills — navy dot scale */
-        .skills-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; }
-
-        #skills-strategic h3,
-        #skills-tools h3,
-        #skills-emerging h3 {
-            font-family: var(--font-display) !important;
-            font-size: 11.5px !important;
-            font-weight: 700 !important;
-            color: var(--secondary-color) !important;
-            text-transform: uppercase;
-            letter-spacing: 0.3px;
-            padding-bottom: 6px;
-            margin-bottom: 10px !important;
+        
+        /* Section Styles */
+        .section {
+            padding: 25px 50px;
             border-bottom: 1px solid var(--border-color);
         }
 
-        .tool-item { margin-bottom: 8px; }
-        .tool-name { display: flex; justify-content: space-between; align-items: baseline; font-size: 10.8px; font-weight: 500; }
-        .tool-percentage { color: var(--accent-color); font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.2px; }
-        .dots-container { display: flex; gap: 3px; margin-top: 3px; }
-        .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--lavender-color); }
-        .dot.filled { background: var(--primary-color); }
+        .section:last-child {
+            border-bottom: none;
+        }
 
-        /* Experience — clean cards, soft shadow */
-        .experience-item {
-            background: #ffffff;
-            border-left: 3px solid var(--primary-color);
-            border-radius: 0 10px 10px 0;
-            padding: 14px 18px;
+        .section-title {
+            font-family: var(--font-display);
+            background: var(--primary-color);
+            color: white;
+            font-size: 15px;
+            font-weight: 600;
+            margin-bottom: 18px;
+            padding: 8px 16px;
+            border-radius: 12px;
+            letter-spacing: 0.3px;
+            display: inline-block;
+            text-transform: uppercase;
+        }
+
+        /* Resumo de Qualificações */
+        .qualifications-list {
+            list-style: none;
+            padding: 0;
+        }
+
+        .qualifications-list li {
+            position: relative;
+            padding-left: 28px;
             margin-bottom: 14px;
-            box-shadow: 0 2px 10px rgba(45, 50, 119, 0.08);
+            font-size: 13.5px;
+            line-height: 1.7;
+            color: var(--text-color);
+        }
+
+        .qualifications-list li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+            font-size: 20px;
+            top: -2px;
+        }
+        
+        /* Skills & Tools Grid */
+        .skills-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 20px;
+        }
+
+        .skills-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 16px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
+        }
+
+        .skills-section h3 {
+            font-size: 12px;
+            color: var(--primary-color);
+            margin-bottom: 10px;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .skill-items {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
+
+        .skill-tag {
+            background: var(--tag-bg);
+            color: var(--primary-color);
+            padding: 4px 10px;
+            border-radius: 12px;
+            font-size: 10.5px;
+            font-weight: 500;
+            border: 1px solid var(--tag-border);
+        }
+
+        /* Cursos Complementares */
+        .courses-section {
+            margin-top: 10px;
+        }
+
+        .course-item {
+            padding: 8px 0;
+            border-bottom: 1px solid var(--border-color);
+            font-size: 11px;
+        }
+
+        .course-item:last-child {
+            border-bottom: none;
+        }
+
+        .course-name {
+            color: var(--text-color);
+            font-weight: 500;
+            display: block;
+            margin-bottom: 2px;
+        }
+
+        .course-info {
+            color: var(--secondary-color);
+            font-size: 10px;
+            font-style: italic;
+        }
+        
+        /* Experience Timeline */
+        .experience-timeline {
+            position: relative;
+            margin-left: 20px;
+            padding-left: 30px;
+        }
+        
+        .experience-timeline::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            top: 0;
+            bottom: 0;
+            width: 3px;
+            background: var(--primary-color);
+            border-radius: 3px;
+        }
+
+        .experience-item {
+            margin-bottom: 25px;
+            position: relative;
+            padding: 18px;
+            border-radius: 14px;
+            background: #fff;
+            border: 1px solid var(--border-color);
+        }
+        
+        .experience-item::before {
+            content: "";
+            position: absolute;
+            left: -36px;
+            top: 25px;
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background: var(--accent-color);
+            border: 3px solid white;
+        }
+        
+        .job-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-bottom: 10px;
         }
 
         .job-title {
-            display: flex;
-            align-items: center;
-            gap: 8px;
             font-family: var(--font-display);
-            font-size: 13.5px;
-            font-weight: 700;
-            color: var(--secondary-color);
+            font-weight: 600;
+            font-size: 16px;
+            color: var(--primary-color);
             margin-bottom: 4px;
         }
-
-        .job-number {
-            flex-shrink: 0;
-            width: 20px;
-            height: 20px;
-            border-radius: 50%;
-            background: var(--primary-color);
-            color: #ffffff;
-            font-family: var(--font-body);
-            font-size: 10.5px;
-            font-weight: 700;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .company { font-weight: 600; font-size: 11.5px; color: var(--text-color); }
-        .period { font-size: 10.5px; color: var(--accent-color); font-weight: 600; margin-bottom: 6px; }
-        .job-description { font-size: 11px; line-height: 1.55; margin-bottom: 8px; color: var(--text-color); }
-
-        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 8px 16px; }
-        .achievement-item { display: flex; gap: 7px; align-items: flex-start; font-size: 10.3px; }
-        .achievement-icon { flex-shrink: 0; width: 15px; text-align: center; color: var(--primary-color); padding-top: 1px; }
-        .achievement-title { font-weight: 600; color: var(--text-color); }
-        .achievement-description { color: #4a4a4a; line-height: 1.4; }
-        .tooltip { display: none; }
-
-        /* Education */
-        .education-item {
-            background: #ffffff;
-            border-left: 3px solid var(--secondary-color);
-            border-radius: 0 10px 10px 0;
-            padding: 10px 16px;
-            margin-bottom: 10px;
-        }
-        .degree { font-family: var(--font-display); font-weight: 700; font-size: 12px; color: var(--secondary-color); margin-bottom: 2px; }
-        .university { font-size: 11px; margin-bottom: 2px; }
-        .thesis { font-size: 10px; color: #555555; font-style: italic; }
-        .cta-button { display: none; }
-
-        /* Projects */
-        .project-item {
-            background: #ffffff;
-            border-left: 3px solid var(--primary-color);
-            border-radius: 0 10px 10px 0;
-            padding: 12px 16px;
-            margin-bottom: 10px;
-        }
-        .project-title { font-family: var(--font-display); font-weight: 700; font-size: 12px; color: var(--secondary-color); margin-bottom: 4px; }
-        .project-description { font-size: 11px; line-height: 1.5; margin-bottom: 6px; }
-        .tech-tag {
-            display: inline-block;
-            padding: 2px 9px;
-            margin: 3px 4px 0 0;
-            background: var(--mist-color);
-            border: 1px solid var(--border-color);
+        
+        .company {
+            font-weight: 500;
+            font-size: 13px;
             color: var(--secondary-color);
-            border-radius: 10px;
-            font-size: 9px;
+        }
+        
+        .period {
+            font-size: 12px;
+            color: var(--secondary-color);
             font-weight: 600;
+            text-align: right;
+        }
+        
+        .job-description {
+            font-size: 12px;
+            line-height: 1.6;
+            color: var(--text-color);
+            margin-bottom: 12px;
         }
 
-        @media print {
-            body { margin: 0; padding: 0; -webkit-print-color-adjust: exact !important; print-color-adjust: exact !important; }
-            .cv-container { max-width: 100%; margin: 0; }
+        .job-bullets {
+            list-style: none;
+            padding: 0;
+        }
 
-            .header {
-                background: #FFE600 !important;
+        .job-bullets li {
+            position: relative;
+            padding-left: 20px;
+            margin-bottom: 8px;
+            font-size: 12px;
+            line-height: 1.5;
+            color: var(--text-color);
+        }
+
+        .job-bullets li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+        }
+        
+        /* Education */
+        .education-tech-container {
+            display: grid;
+            grid-template-columns: 1fr 2fr;
+            gap: 25px;
+        }
+        
+        .education-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 20px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
+        }
+
+        .education-item {
+            margin-bottom: 12px;
+            padding-bottom: 12px;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .education-item:last-child {
+            margin-bottom: 0;
+            padding-bottom: 0;
+            border-bottom: none;
+        }
+        
+        .degree {
+            font-family: var(--font-display);
+            font-weight: 600;
+            font-size: 13px;
+            color: var(--primary-color);
+            margin-bottom: 3px;
+        }
+        
+        .university {
+            font-size: 11px;
+            color: var(--text-color);
+            margin-bottom: 2px;
+        }
+        
+        .edu-period {
+            font-size: 10px;
+            color: var(--secondary-color);
+            font-style: italic;
+        }
+
+        .tech-skills-container {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 15px;
+        }
+
+        /* Languages */
+        .language-container {
+            display: flex;
+            justify-content: center;
+            gap: 30px;
+        }
+
+        .language-item {
+            text-align: center;
+        }
+
+        .language-name {
+            font-weight: 600;
+            color: var(--primary-color);
+            font-size: 13px;
+            margin-bottom: 2px;
+        }
+
+        .language-level {
+            font-size: 11px;
+            color: var(--text-color);
+        }
+
+        /* Print Styles */
+        @media print {
+            body {
+                background: white;
+                margin: 0;
+                padding: 0;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
-                padding: 22px 30px 26px !important;
-                page-break-after: avoid;
             }
 
-            .brand-logo img {
+            .cv-container {
+                max-width: 100%;
+                margin: 0;
+                box-shadow: none;
+            }
+
+            .header {
+                background: var(--background-gradient) !important;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
+                padding: 25px 35px !important;
+                page-break-after: avoid;
             }
 
             .section-title {
                 background: var(--primary-color) !important;
-                color: #ffffff !important;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
+                color: white !important;
+                page-break-after: avoid;
             }
 
-            .job-number {
-                background: var(--primary-color) !important;
-                color: #ffffff !important;
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
+            .section {
+                padding: 15px 35px;
+                page-break-inside: avoid;
             }
 
-            .dot.filled {
-                background: var(--primary-color) !important;
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
+            .experience-item {
+                page-break-inside: avoid;
             }
 
-            .contact-info > span, .contact-info > a {
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
+            /* Hide animations */
+            * {
+                animation: none !important;
             }
 
-            .section:nth-of-type(even) {
-                background: var(--mist-color) !important;
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
+            @page {
+                size: A4;
+                margin: 8mm;
             }
-
-            .section { padding: 14px 30px !important; page-break-inside: avoid; }
-            .experience-item, .education-item, .project-item { page-break-inside: avoid; }
-
-            .header h1 { font-size: 19px !important; }
-            .header h2 { font-size: 11px !important; }
-            .brand-logo { width: 84px !important; height: 46px !important; margin-bottom: 10px !important; }
-            .contact-info > span, .contact-info > a { font-size: 8.5px !important; padding: 3px 8px !important; }
-            .section-title { font-size: 10.5px !important; padding: 4px 11px !important; margin-bottom: 10px !important; }
-
-            .job-title { font-size: 11.5px !important; }
-            .job-number { width: 16px !important; height: 16px !important; font-size: 9px !important; }
-            .job-description, .achievement-item { font-size: 9px !important; }
-            .company, .period { font-size: 9.5px !important; }
-            .experience-item { padding: 10px 14px !important; margin-bottom: 10px !important; }
-            .education-item, .project-item { padding: 8px 14px !important; margin-bottom: 8px !important; }
-            .degree, .project-title { font-size: 10.5px !important; }
-            .university, .project-description { font-size: 9.5px !important; }
-            .thesis { font-size: 8.5px !important; }
-            .tool-name { font-size: 9.5px !important; }
-            .tool-percentage { font-size: 8px !important; }
-            #skills-strategic h3, #skills-tools h3, #skills-emerging h3 { font-size: 10px !important; }
-
-            @page { size: A4; margin: 8mm; }
         }
+        .contact-info { max-width: calc(100% - 180px); }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <!-- Favicon Meta Tags -->
+    <meta name="theme-color" content="#FFE600">
+    <meta name="msapplication-TileColor" content="#FFE600">
+    <meta name="msapplication-config" content="../assets/favicons/browserconfig.xml">
 </head>
 <body>
     <div class="cv-container">
         <header class="header">
-            <div class="brand-logo">
-                <img src="../assets/images/mercado-livre.png" alt="Mercado Livre">
-            </div>
-            <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
-            <h2 id="cv-role">CRM Management and Data Intelligence</h2>
-            <div class="contact-info">
-                <span id="cv-email">pedrohmarconato@gmail.com</span>
-                <span id="cv-phone">+55 (55) 981147758</span>
-                <span id="cv-location"><span>Cachoeira do Sul, RS</span></span>
-                <a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin">LinkedIn</a>
+            <div class="header-content">
+                <img src="../assets/images/mercado-livre.png" alt="Mercado Livre" class="brand-logo">
+                <h1>PEDRO HENRIQUE MARCONATO</h1>
+                
+                <div class="header-tagline">CRM | ANALYTICS | BUSINESS INTELLIGENCE | LTV | SQL</div>
+                
+                <div class="contact-info">
+                    <div class="contact-item">
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-phone"></i> +55 (55) 98114-7758
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-envelope"></i> pedrohmarconato@gmail.com
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fab fa-linkedin"></i> linkedin.com/in/pedrohmarconato
+                    </div>
+                </div>
             </div>
         </header>
-
-        <section class="section">
-            <h2 class="section-title" id="section-profile">Professional Profile</h2>
-            <p id="cv-profile"></p>
+        
+        <section class="section" style="padding-top: 35px;">
+            <h2 class="section-title">PROFESSIONAL SUMMARY</h2>
+            <ul class="qualifications-list">
+                <li>Master's degree in Business Administration, with an Analytics track, combining data intelligence, CRM, analytical visualization, and automation to generate business value</li>
+                <li>Experience in large and highly complex companies, such as Grupo RBS, Realize CFI (Lojas Renner S.A. Group), and Rede Globo, leading strategic projects in CRM, business intelligence, and marketing performance</li>
+                <li>Experience with data applied to marketing, channels, credit, control, and operations, connecting areas and translating technical needs into high-impact analytical solutions</li>
+                <li>Highlights in visualization, segmentation, and consumer behavior projects, with mastery of tools such as Databricks, SQL, Responsys, Power BI, Python, Salesforce, Mailchimp, Tableau, SAS, Mix Agents, and Kanbanize</li>
+                <li>Knowledge in agile methodologies (Scrum, Kanban), working on backlog prioritization, squad structuring, and accelerating delivery with a focus on the customer</li>
+                <li>Experience with data integration from multiple sources, building pipelines, predictive analytics, and behavior mapping to support strategic decisions</li>
+                <li>Differentiator in combining analytical capacity, strategic thinking, and technical knowledge, with recognized performance as leadership even in consultative structures</li>
+                <li>People management, leading multidisciplinary teams with a focus on development, autonomy, and generating consistent results</li>
+            </ul>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-skills">Skills & Tools</h2>
-            <div class="skills-grid">
-                <div id="skills-strategic"></div>
-                <div id="skills-tools"></div>
-                <div id="skills-emerging"></div>
+            <h2 class="section-title">EDUCATION & TECHNOLOGY</h2>
+            <div class="education-tech-container">
+                <div class="education-section">
+                    <h3 style="font-size: 12px; color: var(--primary-color); margin-bottom: 12px; font-weight: 600;">EDUCATION</h3>
+                    <div class="education-item">
+                        <div class="degree">Master's in Business Administration</div>
+                        <div class="university">Federal University of Santa Maria - UFSM</div>
+                        <div class="edu-period">Completed: 2019</div>
+                    </div>
+                    
+                    <div class="education-item">
+                        <div class="degree">Bachelor's in Business Administration</div>
+                        <div class="university">Federal University of Santa Maria - UFSM</div>
+                        <div class="edu-period">Completed: 2015</div>
+                    </div>
+                </div>
+                
+                <div class="tech-skills-container">
+                    <div class="skills-section">
+                        <h3>TOOLS & PLATFORMS</h3>
+                        <div class="skill-items">
+                            <span class="skill-tag">Databricks</span>
+                            <span class="skill-tag">SQL</span>
+                            <span class="skill-tag">Power BI</span>
+                            <span class="skill-tag">Python</span>
+                            <span class="skill-tag">Oracle Responsys</span>
+                            <span class="skill-tag">Kanbanize</span>
+                            <span class="skill-tag">Mailchimp</span>
+                            <span class="skill-tag">Mix Agents</span>
+                            <span class="skill-tag">SAS</span>
+                            <span class="skill-tag">Tableau</span>
+                            <span class="skill-tag">Salesforce CRM</span>
+                        </div>
+                    </div>
+                    
+                    <div class="skills-section">
+                        <h3>CERTIFICATIONS & COURSES</h3>
+                        <div class="courses-section">
+                            <div class="course-item">
+                                <span class="course-name">Statement of Accomplishment - Intermediate R Course</span>
+                                <span class="course-info">Marketing Analytics In Practice - Coursera</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Marketing Analytics in R</span>
+                                <span class="course-info">PPGA - Graduate Program in Business Administration</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Fundamentals of Problem Solving</span>
+                                <span class="course-info">Marketing in a Digital World - Illinois University</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-experience">Professional Experience</h2>
-            <div id="experience-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-education">Education</h2>
-            <div id="education-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-projects">Projects & Innovation</h2>
-            <div id="projects-container"></div>
+            <h2 class="section-title">PROFESSIONAL EXPERIENCE</h2>
+            
+            <div class="experience-timeline">
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">CADASTRA (Digital Marketing and Performance Agency)</div>
+                        </div>
+                        <div class="period">2025-Present</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">Data Analytics Coordinator</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">Sep/2025-Present</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Leading Data Analytics and AI operations for enterprise clients in technology, retail and education sectors, managing multidisciplinary team (DataViz, Data Engineering, Web Analytics)</li>
+                        <li>Simultaneous management of strategic accounts with direct interface to C-level stakeholders and business areas (Performance, E-commerce, Commercial)</li>
+                        <li>Data architecture and governance definition for Business Intelligence, Real-Time Analytics and AI applications projects</li>
+                        <li>Technical diagnosis and restructuring of legacy data environments, including infrastructure migration (AWS→GCP) with projected 40% reduction in processing costs</li>
+                        <li>Data operations restructuring with team expansion (+67%) and scope extension to multiple LATAM business units</li>
+                        <li>Stabilization of critical data environments, achieving 20% savings in operational processing costs (Airflow/DAGs)</li>
+                        <li>Development of automations with n8n and AI Agents (LLMs), including automated Status Report with AI-generated executive summaries</li>
+                        <li>Leadership of first generative AI initiatives in client operations, positioning the area as innovation reference</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">LOJAS RENNER | REALIZE CFI (National Financial Services Company)</div>
+                        </div>
+                        <div class="period">2020-2025</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">CRM Manager</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2021-2025</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for leading the strategic CRM front, focusing on area evolution, customer base growth, and business value generation</li>
+                        <li>Definition and monitoring of area OKRs, connecting business goals to relationship indicators</li>
+                        <li>Planning, execution, and optimization of multichannel relationship campaigns (email, SMS, push, among others), applying intelligent segmentations and automations to increase usage frequency and sales</li>
+                        <li>Building personalized journeys based on customer behavior and profile, promoting lifecycle evolution and loyalty in financial products (cards, loans, insurance, and consumption in the Renner ecosystem)</li>
+                        <li>Management of agile management rhythm (daily, planning, reviews, and retrospectives), using frameworks such as Scrum and Kanban to maintain delivery pace, priority visibility, and impact focus</li>
+                        <li>Area backlog management, with mapping, prioritization, and organization of demands according to incremental value and alignment with the commercial team</li>
+                        <li>Strategic management of suppliers and technology partners, including CRM platforms, automation, and data enrichment, ensuring delivery quality and alignment with area guidelines</li>
+                        <li>Continuous interface with key areas (IT, Products, Analytics, Marketing, Stores, and Commercial), promoting alignment between CRM initiatives and corporate objectives</li>
+                        <li>Technical and operational management of tools such as Oracle Responsys, Databricks, and Power BI, enabling automated segmentations, data processing, and performance dashboards</li>
+                        <li>Monitoring and analysis of KPIs and campaign indicators, using data to guide decisions, validate hypotheses, and promote continuous improvement</li>
+                        <li>Leadership of strategic projects and initiatives to expand the active customer base and activate new communication channels</li>
+                    </ul>
+                    
+                    <div class="job-title" style="margin-top: 15px; margin-bottom: 8px;">Analytics Specialist</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2020-2021</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for creating dashboards and strategic indicators for areas such as Marketing, CRM, Credit, and Channels, delivering an integrated real-time view to support business decisions</li>
+                        <li>Development of segmented databases and automated reports focused on the CRM team, with a focus on efficiency gains, agility in analyses, and revenue generation through more precise actions</li>
+                        <li>Organization and integration of operational, behavioral, and transactional data, consolidating multiple sources into a reliable base for comprehensive customer lifecycle analyses</li>
+                        <li>Practical use of tools such as SQL, BigQuery, Python, and Power BI for exploratory analyses, routine automations, and development of predictive models applied to the business</li>
+                        <li>Close collaboration with Marketing, Products, Risk, and Operations areas, translating strategic needs into applicable analyses, focusing on action direction and decision-making</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Analytics Specialist</div>
+                            <div class="company">DBC COMPANY (National IT Consulting Company)</div>
+                        </div>
+                        <div class="period">2020-2021</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for supporting the strategic restructuring of the CRM area at client Realize, implementing agile methodologies (Kanban) and defining processes that reduced campaign time-to-market and increased operational efficiency</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Business Intelligence Analyst</div>
+                            <div class="company">GRUPO RBS (National Media Company)</div>
+                        </div>
+                        <div class="period">2019 - 2020</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for structuring and analyzing commercial performance, audience, and market behavior data, supporting leadership in strategic decision-making for client Rede Globo</li>
+                        <li>Development of segmentation studies and consumption potential mapping, using data to guide decisions, validate hypotheses, and promote sales and prospecting actions</li>
+                        <li>Creation of real-time analytical reports and dashboards to support business decisions</li>
+                        <li>Direct interface with leadership, translating market data into action plans and growth opportunities</li>
+                        <li>Analysis of KPIs and campaign indicators, using data to guide decisions, validate hypotheses, and promote continuous improvement</li>
+                    </ul>
+                </div>
+            </div>
         </section>
     </div>
-
-    <script src="../assets/js/cv-texts.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            var lang = 'en';
-            initializeBasicContent(lang);
-            renderSkills('skills-strategic', 'strategic', lang);
-            renderSkills('skills-tools', 'tools', lang);
-            renderSkills('skills-emerging', 'emerging', lang);
-            renderExperienceTimeline(lang);
-            renderEducation(lang);
-            renderProjects(lang);
-        });
-    </script>
+    <!-- Dynamic Favicon System -->
+    <script src="../assets/js/dynamic-favicon.js"></script>
 </body>
 </html>

--- a/cv_styles/cv_mercado-livre_style_PT.html
+++ b/cv_styles/cv_mercado-livre_style_PT.html
@@ -3,344 +3,668 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pedro Henrique Marconato - CV</title>
-    <meta name="theme-color" content="#FFE600">
+    <title>Pedro Henrique Marconato - CV (Mercado Livre)</title>
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Montserrat:wght@600;700;800&display=swap');
-
+        @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@500;600;700;800&family=Inter:wght@300;400;500;600;700&display=swap');
+        
         :root {
-            /* Mercado Livre Colors — brandbook (docs/mercado-livre_brandbook.md) */
-            --primary-color: #2D3277;   /* Azul Navy — masterbrand na página impressa */
-            --secondary-color: #1B1F55; /* Azul Profundo */
-            --accent-color: #3A3F80;    /* Azul Suave — detalhes/periodo */
-            --yellow-color: #FFE600;    /* Amarelo Mercado Livre — header */
-            --yellow-deep: #FFD100;     /* Amarelo Profundo */
-            --lavender-color: #B8BDE0;  /* Azul Pálido — empty dots */
-            --mist-color: #F4F5FB;      /* Névoa Azulada — alternating section background */
+            /* Mercado Livre — brand tokens */
+            --primary-color: #2D3277;
+            --secondary-color: #1B1F55;
+            --accent-color: #3A3F80;
+            --light-accent: #EEF0F8;
             --text-color: #1B1F55;
             --border-color: rgba(45, 50, 119, 0.15);
-            --gradient: linear-gradient(135deg, #2D3277 0%, #1B1F55 100%);
-            --font-display: 'Montserrat', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            --background-gradient: linear-gradient(135deg, #FFE600 0%, #FFDB00 100%);
+
             --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            --font-display: 'Montserrat', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+
+            --header-text: #2D3277;
+            --header-text-soft: #1B1F55;
+            --header-chip-bg: rgba(45, 50, 119, 0.10);
+            --header-chip-border: rgba(45, 50, 119, 0.28);
+
+            --tag-bg: rgba(45, 50, 119, 0.10);
+            --tag-border: rgba(45, 50, 119, 0.24);
         }
-
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-
+        
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
         body {
             font-family: var(--font-body);
             color: var(--text-color);
-            line-height: 1.55;
-            background: #ffffff;
-            font-size: 12px;
+            line-height: 1.6;
+            background: var(--light-accent);
+            min-height: 100vh;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
         }
 
-        .cv-container { max-width: 210mm; margin: 0 auto; background: #ffffff; }
-
-        /* Header — bright yellow hero, navy ink, natural logo */
+        /* Main container */
+        .cv-container {
+            max-width: 210mm;
+            margin: 0 auto;
+            background: rgba(255, 255, 255, 1);
+            overflow: hidden;
+            position: relative;
+        }
+        
+        /* Header Section */
         .header {
-            background: linear-gradient(135deg, #FFE600 0%, #FFD100 100%);
-            padding: 34px 40px 38px;
-            text-align: center;
+            background: var(--background-gradient);
+            padding: 50px 50px 55px 50px;
+            position: relative;
+            overflow: hidden;
+        }
+        
+        .header-content {
+            position: relative;
+            z-index: 1;
         }
 
-        .brand-logo { width: 108px; height: 58px; margin: 0 auto 14px; }
-        .brand-logo img { width: 100%; height: 100%; object-fit: contain; }
-
+.brand-logo {
+            position: absolute;
+            bottom: 20px;
+            right: 40px;
+            width: 120px;
+            height: auto;
+            opacity: 1;
+        }
+        
         .header h1 {
             font-family: var(--font-display);
-            font-size: 23px;
-            font-weight: 800;
-            color: var(--primary-color);
-            letter-spacing: 0.2px;
-            margin-bottom: 6px;
+            font-size: 32px;
+            font-weight: 700;
+            color: var(--header-text);
+            margin-bottom: 8px;
+            letter-spacing: -0.5px;
+            text-transform: uppercase;
         }
 
-        .header h2 {
-            font-size: 12.5px;
-            font-weight: 500;
-            color: var(--accent-color);
-            margin-bottom: 16px;
+        .header-tagline {
+            font-size: 17px;
+            font-weight: 400;
+            color: var(--header-text-soft);
+            margin-top: 22px;
+            margin-bottom: 28px;
+            font-style: italic;
+            letter-spacing: 0.5px;
         }
-
+        
         .contact-info {
             display: flex;
             flex-wrap: wrap;
-            justify-content: center;
-            gap: 8px;
+            gap: 10px;
+            align-items: center;
+            margin-top: 12px;
         }
-
-        .contact-info > span,
-        .contact-info > a {
-            display: inline-block;
-            background: rgba(255, 255, 255, 0.4);
-            border: 1px solid rgba(45, 50, 119, 0.35);
-            color: var(--primary-color);
-            text-decoration: none;
-            font-size: 10.5px;
-            font-weight: 600;
-            padding: 5px 12px;
-            border-radius: 20px;
+        
+        .contact-item {
+            display: inline-flex;
+            align-items: center;
+            background: var(--header-chip-bg);
+            border-radius: 10px;
+            padding: 8px 14px;
+            color: var(--header-text);
+            font-size: 12.5px;
+            font-weight: 500;
+            border: 1px solid var(--header-chip-border);
         }
-
-        /* Sections — generous whitespace, alternating mist */
-        .section { padding: 24px 40px; }
-        .section:nth-of-type(even) { background: var(--mist-color); }
-
-        .section-title {
-            display: inline-block;
-            font-family: var(--font-display);
-            background: var(--primary-color);
-            color: #ffffff;
+        
+        .contact-item i {
+            margin-right: 6px;
             font-size: 12px;
-            font-weight: 700;
-            letter-spacing: 0.4px;
-            text-transform: uppercase;
-            padding: 6px 14px;
-            border-radius: 8px;
-            margin-bottom: 14px;
         }
-
-        #cv-profile { font-size: 11.5px; line-height: 1.65; }
-
-        /* Skills — navy dot scale */
-        .skills-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; }
-
-        #skills-strategic h3,
-        #skills-tools h3,
-        #skills-emerging h3 {
-            font-family: var(--font-display) !important;
-            font-size: 11.5px !important;
-            font-weight: 700 !important;
-            color: var(--secondary-color) !important;
-            text-transform: uppercase;
-            letter-spacing: 0.3px;
-            padding-bottom: 6px;
-            margin-bottom: 10px !important;
+        
+        /* Section Styles */
+        .section {
+            padding: 25px 50px;
             border-bottom: 1px solid var(--border-color);
         }
 
-        .tool-item { margin-bottom: 8px; }
-        .tool-name { display: flex; justify-content: space-between; align-items: baseline; font-size: 10.8px; font-weight: 500; }
-        .tool-percentage { color: var(--accent-color); font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.2px; }
-        .dots-container { display: flex; gap: 3px; margin-top: 3px; }
-        .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--lavender-color); }
-        .dot.filled { background: var(--primary-color); }
+        .section:last-child {
+            border-bottom: none;
+        }
 
-        /* Experience — clean cards, soft shadow */
-        .experience-item {
-            background: #ffffff;
-            border-left: 3px solid var(--primary-color);
-            border-radius: 0 10px 10px 0;
-            padding: 14px 18px;
+        .section-title {
+            font-family: var(--font-display);
+            background: var(--primary-color);
+            color: white;
+            font-size: 15px;
+            font-weight: 600;
+            margin-bottom: 18px;
+            padding: 8px 16px;
+            border-radius: 12px;
+            letter-spacing: 0.3px;
+            display: inline-block;
+            text-transform: uppercase;
+        }
+
+        /* Resumo de Qualificações */
+        .qualifications-list {
+            list-style: none;
+            padding: 0;
+        }
+
+        .qualifications-list li {
+            position: relative;
+            padding-left: 28px;
             margin-bottom: 14px;
-            box-shadow: 0 2px 10px rgba(45, 50, 119, 0.08);
+            font-size: 13.5px;
+            line-height: 1.7;
+            color: var(--text-color);
+        }
+
+        .qualifications-list li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+            font-size: 20px;
+            top: -2px;
+        }
+        
+        /* Skills & Tools Grid */
+        .skills-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 20px;
+        }
+
+        .skills-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 16px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
+        }
+
+        .skills-section h3 {
+            font-size: 12px;
+            color: var(--primary-color);
+            margin-bottom: 10px;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .skill-items {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
+
+        .skill-tag {
+            background: var(--tag-bg);
+            color: var(--primary-color);
+            padding: 4px 10px;
+            border-radius: 12px;
+            font-size: 10.5px;
+            font-weight: 500;
+            border: 1px solid var(--tag-border);
+        }
+
+        /* Cursos Complementares */
+        .courses-section {
+            margin-top: 10px;
+        }
+
+        .course-item {
+            padding: 8px 0;
+            border-bottom: 1px solid var(--border-color);
+            font-size: 11px;
+        }
+
+        .course-item:last-child {
+            border-bottom: none;
+        }
+
+        .course-name {
+            color: var(--text-color);
+            font-weight: 500;
+            display: block;
+            margin-bottom: 2px;
+        }
+
+        .course-info {
+            color: var(--secondary-color);
+            font-size: 10px;
+            font-style: italic;
+        }
+        
+        /* Experience Timeline */
+        .experience-timeline {
+            position: relative;
+            margin-left: 20px;
+            padding-left: 30px;
+        }
+        
+        .experience-timeline::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            top: 0;
+            bottom: 0;
+            width: 3px;
+            background: var(--primary-color);
+            border-radius: 3px;
+        }
+        
+        .experience-item {
+            margin-bottom: 25px;
+            position: relative;
+            padding: 18px;
+            border-radius: 14px;
+            background: #fff;
+            border: 1px solid var(--border-color);
+        }
+        
+        .experience-item::before {
+            content: "";
+            position: absolute;
+            left: -36px;
+            top: 25px;
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background: var(--accent-color);
+            border: 3px solid white;
+        }
+        
+        .job-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-bottom: 10px;
         }
 
         .job-title {
-            display: flex;
-            align-items: center;
-            gap: 8px;
             font-family: var(--font-display);
-            font-size: 13.5px;
-            font-weight: 700;
-            color: var(--secondary-color);
+            font-weight: 600;
+            font-size: 16px;
+            color: var(--primary-color);
             margin-bottom: 4px;
         }
-
-        .job-number {
-            flex-shrink: 0;
-            width: 20px;
-            height: 20px;
-            border-radius: 50%;
-            background: var(--primary-color);
-            color: #ffffff;
-            font-family: var(--font-body);
-            font-size: 10.5px;
-            font-weight: 700;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .company { font-weight: 600; font-size: 11.5px; color: var(--text-color); }
-        .period { font-size: 10.5px; color: var(--accent-color); font-weight: 600; margin-bottom: 6px; }
-        .job-description { font-size: 11px; line-height: 1.55; margin-bottom: 8px; color: var(--text-color); }
-
-        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 8px 16px; }
-        .achievement-item { display: flex; gap: 7px; align-items: flex-start; font-size: 10.3px; }
-        .achievement-icon { flex-shrink: 0; width: 15px; text-align: center; color: var(--primary-color); padding-top: 1px; }
-        .achievement-title { font-weight: 600; color: var(--text-color); }
-        .achievement-description { color: #4a4a4a; line-height: 1.4; }
-        .tooltip { display: none; }
-
-        /* Education */
-        .education-item {
-            background: #ffffff;
-            border-left: 3px solid var(--secondary-color);
-            border-radius: 0 10px 10px 0;
-            padding: 10px 16px;
-            margin-bottom: 10px;
-        }
-        .degree { font-family: var(--font-display); font-weight: 700; font-size: 12px; color: var(--secondary-color); margin-bottom: 2px; }
-        .university { font-size: 11px; margin-bottom: 2px; }
-        .thesis { font-size: 10px; color: #555555; font-style: italic; }
-        .cta-button { display: none; }
-
-        /* Projects */
-        .project-item {
-            background: #ffffff;
-            border-left: 3px solid var(--primary-color);
-            border-radius: 0 10px 10px 0;
-            padding: 12px 16px;
-            margin-bottom: 10px;
-        }
-        .project-title { font-family: var(--font-display); font-weight: 700; font-size: 12px; color: var(--secondary-color); margin-bottom: 4px; }
-        .project-description { font-size: 11px; line-height: 1.5; margin-bottom: 6px; }
-        .tech-tag {
-            display: inline-block;
-            padding: 2px 9px;
-            margin: 3px 4px 0 0;
-            background: var(--mist-color);
-            border: 1px solid var(--border-color);
+        
+        .company {
+            font-weight: 500;
+            font-size: 13px;
             color: var(--secondary-color);
-            border-radius: 10px;
-            font-size: 9px;
+        }
+        
+        .period {
+            font-size: 12px;
+            color: var(--secondary-color);
             font-weight: 600;
+            text-align: right;
+        }
+        
+        .job-description {
+            font-size: 12px;
+            line-height: 1.6;
+            color: var(--text-color);
+            margin-bottom: 12px;
         }
 
-        @media print {
-            body { margin: 0; padding: 0; -webkit-print-color-adjust: exact !important; print-color-adjust: exact !important; }
-            .cv-container { max-width: 100%; margin: 0; }
+        .job-bullets {
+            list-style: none;
+            padding: 0;
+        }
 
-            .header {
-                background: #FFE600 !important;
+        .job-bullets li {
+            position: relative;
+            padding-left: 20px;
+            margin-bottom: 8px;
+            font-size: 12px;
+            line-height: 1.5;
+            color: var(--text-color);
+        }
+
+        .job-bullets li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+        }
+        
+        /* Education */
+        .education-tech-container {
+            display: grid;
+            grid-template-columns: 1fr 2fr;
+            gap: 25px;
+        }
+        
+        .education-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 20px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
+        }
+
+        .education-item {
+            margin-bottom: 12px;
+            padding-bottom: 12px;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .education-item:last-child {
+            margin-bottom: 0;
+            padding-bottom: 0;
+            border-bottom: none;
+        }
+        
+        .degree {
+            font-family: var(--font-display);
+            font-weight: 600;
+            font-size: 13px;
+            color: var(--primary-color);
+            margin-bottom: 3px;
+        }
+        
+        .university {
+            font-size: 11px;
+            color: var(--text-color);
+            margin-bottom: 2px;
+        }
+        
+        .edu-period {
+            font-size: 10px;
+            color: var(--secondary-color);
+            font-style: italic;
+        }
+
+        .tech-skills-container {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 15px;
+        }
+
+        /* Languages */
+        .language-container {
+            display: flex;
+            justify-content: center;
+            gap: 30px;
+        }
+
+        .language-item {
+            text-align: center;
+        }
+
+        .language-name {
+            font-weight: 600;
+            color: var(--primary-color);
+            font-size: 13px;
+            margin-bottom: 2px;
+        }
+
+        .language-level {
+            font-size: 11px;
+            color: var(--text-color);
+        }
+
+        /* Print Styles */
+        @media print {
+            body {
+                background: white;
+                margin: 0;
+                padding: 0;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
-                padding: 22px 30px 26px !important;
-                page-break-after: avoid;
             }
 
-            .brand-logo img {
+            .cv-container {
+                max-width: 100%;
+                margin: 0;
+                box-shadow: none;
+            }
+
+            .header {
+                background: var(--background-gradient) !important;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
+                padding: 25px 35px !important;
+                page-break-after: avoid;
             }
 
             .section-title {
                 background: var(--primary-color) !important;
-                color: #ffffff !important;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
+                color: white !important;
+                page-break-after: avoid;
             }
 
-            .job-number {
-                background: var(--primary-color) !important;
-                color: #ffffff !important;
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
+            .section {
+                padding: 15px 35px;
+                page-break-inside: avoid;
             }
 
-            .dot.filled {
-                background: var(--primary-color) !important;
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
+            .experience-item {
+                page-break-inside: avoid;
             }
 
-            .contact-info > span, .contact-info > a {
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
+            /* Hide animations */
+            * {
+                animation: none !important;
             }
 
-            .section:nth-of-type(even) {
-                background: var(--mist-color) !important;
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
+            @page {
+                size: A4;
+                margin: 8mm;
             }
-
-            .section { padding: 14px 30px !important; page-break-inside: avoid; }
-            .experience-item, .education-item, .project-item { page-break-inside: avoid; }
-
-            .header h1 { font-size: 19px !important; }
-            .header h2 { font-size: 11px !important; }
-            .brand-logo { width: 84px !important; height: 46px !important; margin-bottom: 10px !important; }
-            .contact-info > span, .contact-info > a { font-size: 8.5px !important; padding: 3px 8px !important; }
-            .section-title { font-size: 10.5px !important; padding: 4px 11px !important; margin-bottom: 10px !important; }
-
-            .job-title { font-size: 11.5px !important; }
-            .job-number { width: 16px !important; height: 16px !important; font-size: 9px !important; }
-            .job-description, .achievement-item { font-size: 9px !important; }
-            .company, .period { font-size: 9.5px !important; }
-            .experience-item { padding: 10px 14px !important; margin-bottom: 10px !important; }
-            .education-item, .project-item { padding: 8px 14px !important; margin-bottom: 8px !important; }
-            .degree, .project-title { font-size: 10.5px !important; }
-            .university, .project-description { font-size: 9.5px !important; }
-            .thesis { font-size: 8.5px !important; }
-            .tool-name { font-size: 9.5px !important; }
-            .tool-percentage { font-size: 8px !important; }
-            #skills-strategic h3, #skills-tools h3, #skills-emerging h3 { font-size: 10px !important; }
-
-            @page { size: A4; margin: 8mm; }
         }
+        .contact-info { max-width: calc(100% - 180px); }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <!-- Favicon Meta Tags -->
+    <meta name="theme-color" content="#FFE600">
+    <meta name="msapplication-TileColor" content="#FFE600">
+    <meta name="msapplication-config" content="../assets/favicons/browserconfig.xml">
 </head>
 <body>
     <div class="cv-container">
         <header class="header">
-            <div class="brand-logo">
-                <img src="../assets/images/mercado-livre.png" alt="Mercado Livre">
-            </div>
-            <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
-            <h2 id="cv-role">Gestão de CRM e Inteligência de Dados</h2>
-            <div class="contact-info">
-                <span id="cv-email">pedrohmarconato@gmail.com</span>
-                <span id="cv-phone">+55 (55) 981147758</span>
-                <span id="cv-location"><span>Cachoeira do Sul, RS</span></span>
-                <a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin">LinkedIn</a>
+            <div class="header-content">
+                <img src="../assets/images/mercado-livre.png" alt="Mercado Livre" class="brand-logo">
+                <h1>PEDRO HENRIQUE MARCONATO</h1>
+                
+                <div class="header-tagline">CRM | ANALYTICS | BUSINESS INTELLIGENCE | LTV | SQL</div>
+                
+                <div class="contact-info">
+                    <div class="contact-item">
+                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 35 anos
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-phone"></i> +55 (55) 98114-7758
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-envelope"></i> pedrohmarconato@gmail.com
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fab fa-linkedin"></i> linkedin.com/in/pedrohmarconato
+                    </div>
+                </div>
             </div>
         </header>
-
-        <section class="section">
-            <h2 class="section-title" id="section-profile">Perfil Profissional</h2>
-            <p id="cv-profile"></p>
+        
+        <section class="section" style="padding-top: 35px;">
+            <h2 class="section-title">RESUMO DE QUALIFICAÇÕES</h2>
+            <ul class="qualifications-list">
+                <li>Mestre em Administração de Empresas, com ênfase na área de Analytics, unindo inteligência de dados, CRM, visualização analítica e automação para gerar valor ao negócio</li>
+                <li>Atuação em empresas de grande porte e alta complexidade, como Grupo RBS, Realize CFI (Grupo Lojas Renner S.A.) e Rede Globo, liderando projetos estratégicos nas frentes de CRM, inteligência comercial e performance de marketing</li>
+                <li>Vivência com dados aplicados a marketing, canais, crédito, controle e operações, conectando áreas e traduzindo necessidades técnicas em soluções analíticas de alto impacto</li>
+                <li>Destaques em projetos de visualização, segmentação e comportamento de consumo, com domínio de ferramentas como Databricks, SQL, Responsys, Power BI, Python, Salesforce, Mailchimp, Tableau, SAS, Mix Agents e Kanbanize</li>
+                <li>Conhecimento em metodologias ágeis (Scrum, Kanban), com atuação na priorização de backlog, estruturação de squads e aceleração de entrega com foco no cliente</li>
+                <li>Experiência com integração de dados de múltiplas fontes, construção de pipelines, análises preditivas e mapeamento de comportamento para suportar decisões estratégicas</li>
+                <li>Diferencial na combinação entre capacidade analítica, pensamento estratégico e conhecimento técnico, com atuação reconhecida como liderança mesmo em estruturas consultivas</li>
+                <li>Gestão de pessoas, liderando times multidisciplinares com foco em desenvolvimento, autonomia e geração de resultados consistentes</li>
+            </ul>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-skills">Habilidades & Ferramentas</h2>
-            <div class="skills-grid">
-                <div id="skills-strategic"></div>
-                <div id="skills-tools"></div>
-                <div id="skills-emerging"></div>
+            <h2 class="section-title">FORMAÇÃO ACADÊMICA & TECNOLOGIA</h2>
+            <div class="education-tech-container">
+                <div class="education-section">
+                    <h3 style="font-size: 12px; color: var(--primary-color); margin-bottom: 12px; font-weight: 600;">FORMAÇÃO</h3>
+                    <div class="education-item">
+                        <div class="degree">Mestrado em Administração de Empresas</div>
+                        <div class="university">Universidade Federal de Santa Maria - UFSM</div>
+                        <div class="edu-period">Conclusão: 2019</div>
+                    </div>
+                    
+                    <div class="education-item">
+                        <div class="degree">Bacharelado em Administração</div>
+                        <div class="university">Universidade Federal de Santa Maria - UFSM</div>
+                        <div class="edu-period">Conclusão: 2015</div>
+                    </div>
+                </div>
+                
+                <div class="tech-skills-container">
+                    <div class="skills-section">
+                        <h3>FERRAMENTAS & PLATAFORMAS</h3>
+                        <div class="skill-items">
+                            <span class="skill-tag">Databricks</span>
+                            <span class="skill-tag">SQL</span>
+                            <span class="skill-tag">Power BI</span>
+                            <span class="skill-tag">Python</span>
+                            <span class="skill-tag">Oracle Responsys</span>
+                            <span class="skill-tag">Kanbanize</span>
+                            <span class="skill-tag">Mailchimp</span>
+                            <span class="skill-tag">Mix Agents</span>
+                            <span class="skill-tag">SAS</span>
+                            <span class="skill-tag">Tableau</span>
+                            <span class="skill-tag">Salesforce CRM</span>
+                        </div>
+                    </div>
+                    
+                    <div class="skills-section">
+                        <h3>CERTIFICAÇÕES & CURSOS</h3>
+                        <div class="courses-section">
+                            <div class="course-item">
+                                <span class="course-name">Statement of Accomplishment - Intermediate R Course</span>
+                                <span class="course-info">Marketing Analytics In Practice - Coursera</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Marketing Analytics em R</span>
+                                <span class="course-info">PPGA - Programa de Pós-Graduação em Administração</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Fundamentos de Solução de Problemas</span>
+                                <span class="course-info">Marketing in a Digital World - Illinois University</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-experience">Experiência Profissional</h2>
-            <div id="experience-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-education">Formação</h2>
-            <div id="education-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-projects">Projetos & Inovação</h2>
-            <div id="projects-container"></div>
+            <h2 class="section-title">EXPERIÊNCIA PROFISSIONAL</h2>
+            
+            <div class="experience-timeline">
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">CADASTRA (Agência de Marketing Digital e Performance)</div>
+                        </div>
+                        <div class="period">2025-Atual</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">Coordenador de Data Analytics</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">Set/2025-Atual</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável pela operação de Data Analytics e AI para clientes de grande porte dos setores de tecnologia, varejo e educação, liderando time multidisciplinar (DataViz, Engenharia de Dados, Web Analytics)</li>
+                        <li>Gestão simultânea de contas estratégicas, com interface direta com stakeholders C-level e áreas de negócio (Performance, E-commerce, Comercial)</li>
+                        <li>Definição de arquitetura de dados e governança para projetos de Business Intelligence, Real-Time Analytics e aplicações de inteligência artificial</li>
+                        <li>Diagnóstico técnico e reestruturação de ambientes de dados legados, incluindo migração de infraestrutura (AWS→GCP) com redução projetada de 40% em custos de processamento</li>
+                        <li>Reestruturação de operações de dados com expansão de time (+67%) e ampliação de escopo para múltiplas unidades de negócio em LATAM</li>
+                        <li>Estabilização de ambientes críticos de dados, alcançando economia de 20% em custos operacionais de processamento (Airflow/DAGs)</li>
+                        <li>Desenvolvimento de automações com n8n e AI Agents (LLMs), incluindo Status Report automatizado com geração de resumos executivos por inteligência artificial</li>
+                        <li>Liderança das primeiras iniciativas de aplicação de IA generativa em operações de clientes, posicionando a área como referência em inovação</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">LOJAS RENNER | REALIZE CFI (Empresa Nacional do segmento Financeiro)</div>
+                        </div>
+                        <div class="period">2020-2025</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">CRM Manager</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2021-2025</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável pela liderança da frente estratégica de CRM, com foco na evolução da área, crescimento da base de clientes e geração de valor ao negócio</li>
+                        <li>Definição e acompanhamento dos OKRs da área, conectando metas do negócio a indicadores de relacionamento</li>
+                        <li>Planejamento, execução e otimização de campanhas de relacionamento multicanal (e-mail, SMS, push, entre outros), aplicando segmentações inteligentes e automações para aumentar frequência de uso e vendas</li>
+                        <li>Construção de jornadas personalizadas com base em comportamento e perfil dos clientes, promovendo a evolução do ciclo de vida e fidelização em produtos financeiros (cartões, empréstimos, seguros e consumo no ecossistema Renner)</li>
+                        <li>Gestão do ritmo de gestão ágil (daily, planning, reviews e retrospectives), utilizando frameworks como Scrum e Kanban para manter ritmo de entrega, visibilidade de prioridades e foco em impacto</li>
+                        <li>Gestão do backlog da área, com mapeamento, priorização e organização das demandas de acordo com o valor incremental e alinhamento com o time comercial</li>
+                        <li>Gestão estratégica de fornecedores e parceiros de tecnologia, incluindo plataformas de CRM, automação e enriquecimento de dados, garantindo qualidade das entregas e alinhamento às diretrizes da área</li>
+                        <li>Interface contínua com áreas-chave (TI, Produtos, Analytics, Marketing, Lojas e Comercial), promovendo alinhamento entre as iniciativas de CRM e os objetivos corporativos</li>
+                        <li>Gestão técnica e operacional de ferramentas como Oracle Responsys, Databricks e Power BI, viabilizando segmentações automatizadas, tratamento de dados e dashboards de performance</li>
+                        <li>Monitoramento e análise de KPIs e indicadores de campanhas, utilizando dados para orientar decisões, validar hipóteses e promover a melhoria contínua</li>
+                        <li>Liderança de projetos e iniciativas estratégicas de expansão da base ativa de clientes e ativação de novos canais de comunicação</li>
+                    </ul>
+                    
+                    <div class="job-title" style="margin-top: 15px; margin-bottom: 8px;">Especialista de Analytics</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2020-2021</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável por criar dashboards e indicadores estratégicos para áreas como Marketing, CRM, Crédito e Canais, entregando uma visão integrada e em tempo real para apoiar decisões de negócio</li>
+                        <li>Desenvolvimento de bases segmentadas e relatórios automatizados voltados ao time de CRM, com foco em ganho de eficiência, agilidade nas análises e geração de receita por meio de ações mais precisas</li>
+                        <li>Organização e integração de dados operacionais, comportamentais e transacionais, consolidando múltiplas fontes em uma base confiável para análises completas do ciclo de vida do cliente</li>
+                        <li>Utilização prática de ferramentas como SQL, BigQuery, Python e Power BI para análises exploratórias, automações de rotinas e desenvolvimento de modelos preditivos aplicados ao negócio</li>
+                        <li>Atuação próxima às áreas de Marketing, Produtos, Riscos e Operações, traduzindo necessidades estratégicas em análises aplicáveis, com foco em direcionamento de ações e tomada de decisão</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Especialista de Analytics</div>
+                            <div class="company">DBC COMPANY (Empresa Nacional do segmento de Consultoria em TI)</div>
+                        </div>
+                        <div class="period">2020-2021</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável por apoiar a reestruturação estratégica da área de CRM no cliente Realize, implementando metodologias ágeis (Kanban) e definindo processos que reduziram o time-to-market das campanhas e aumentaram a eficiência operacional</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Analista de Inteligência Comercial</div>
+                            <div class="company">GRUPO RBS (Empresa Nacional do segmento de Mídia)</div>
+                        </div>
+                        <div class="period">2019 - 2020</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável pela estruturação e análise dados de desempenho comercial, audiência e comportamento de mercado, apoiando a liderança na tomada de decisões estratégicas do cliente Rede Globo</li>
+                        <li>Desenvolvimento de estudos de segmentação e mapeamento de potencial de consumo, utilizando dados para orientar decisões, validar hipóteses e promover ações de vendas e prospecção</li>
+                        <li>Criação de relatórios e dashboards analíticos em tempo real para apoiar decisões do negócio</li>
+                        <li>Interface direta com a liderança, traduzindo dados de mercado em planos de ação e oportunidades de crescimento</li>
+                        <li>Análise de KPIs e indicadores de campanhas, utilizando dados para orientar decisões, validar hipóteses e promover a melhoria contínua</li>
+                    </ul>
+                </div>
+            </div>
         </section>
     </div>
-
-    <script src="../assets/js/cv-texts.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            var lang = 'pt';
-            initializeBasicContent(lang);
-            renderSkills('skills-strategic', 'strategic', lang);
-            renderSkills('skills-tools', 'tools', lang);
-            renderSkills('skills-emerging', 'emerging', lang);
-            renderExperienceTimeline(lang);
-            renderEducation(lang);
-            renderProjects(lang);
-        });
-    </script>
+    <!-- Dynamic Favicon System -->
+    <script src="../assets/js/dynamic-favicon.js"></script>
 </body>
 </html>

--- a/cv_styles/cv_nubank_style_EN.html
+++ b/cv_styles/cv_nubank_style_EN.html
@@ -3,314 +3,669 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pedro Henrique Marconato - CV</title>
-    <meta name="theme-color" content="#820AD1">
+    <title>Pedro Henrique Marconato - CV (Nubank)</title>
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Sora:wght@400;600;700;800&display=swap');
-
+        
         :root {
-            /* Nubank Colors — brandbook (docs/nubank_brandbook.md) */
-            --primary-color: #820AD1;   /* Roxo Nu — masterbrand */
-            --secondary-color: #5C08A0; /* Roxo Profundo */
-            --accent-color: #A64CE8;    /* Lilás */
-            --lavender-color: #C89AF2;  /* Lavanda — empty dots */
-            --mist-color: #F3E9FC;      /* Névoa — alternating section background */
+            /* Nubank — brand tokens */
+            --primary-color: #820AD1;
+            --secondary-color: #5C08A0;
+            --accent-color: #A64CE8;
+            --light-accent: #F3E9FC;
             --text-color: #1A1A1A;
             --border-color: rgba(130, 10, 209, 0.15);
-            --gradient: linear-gradient(135deg, #820AD1 0%, #5C08A0 100%);
-            --font-display: 'Sora', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            --background-gradient: linear-gradient(135deg, #820AD1 0%, #5C08A0 100%);
+
             --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            --font-display: 'Sora', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+
+            --header-text: #ffffff;
+            --header-text-soft: rgba(255, 255, 255, 0.95);
+            --header-chip-bg: rgba(255, 255, 255, 0.15);
+            --header-chip-border: rgba(255, 255, 255, 0.28);
+
+            --tag-bg: rgba(166, 76, 232, 0.14);
+            --tag-border: rgba(166, 76, 232, 0.30);
         }
-
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-
+        
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
         body {
             font-family: var(--font-body);
             color: var(--text-color);
-            line-height: 1.55;
-            background: #ffffff;
-            font-size: 12px;
+            line-height: 1.6;
+            background: var(--light-accent);
+            min-height: 100vh;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
         }
 
-        .cv-container { max-width: 210mm; margin: 0 auto; background: #ffffff; }
-
-        /* Header — minimalist purple hero */
+        /* Main container */
+        .cv-container {
+            max-width: 210mm;
+            margin: 0 auto;
+            background: rgba(255, 255, 255, 1);
+            overflow: hidden;
+            position: relative;
+        }
+        
+        /* Header Section */
         .header {
-            background: var(--gradient);
-            padding: 34px 40px 38px;
-            text-align: center;
+            background: var(--background-gradient);
+            padding: 50px 50px 55px 50px;
+            position: relative;
+            overflow: hidden;
+        }
+        
+        .header-content {
+            position: relative;
+            z-index: 1;
         }
 
-        .brand-logo { width: 100px; height: 55px; margin: 0 auto 14px; }
-        .brand-logo img { width: 100%; height: 100%; object-fit: contain; filter: brightness(0) invert(1); }
-
+.brand-logo {
+            position: absolute;
+            bottom: 20px;
+            right: 40px;
+            width: 148px;
+            height: auto;
+            opacity: 0.95;
+            filter: brightness(0) invert(1);
+        }
+        
         .header h1 {
             font-family: var(--font-display);
-            font-size: 23px;
+            font-size: 32px;
             font-weight: 700;
-            color: #ffffff;
-            letter-spacing: 0.2px;
-            margin-bottom: 6px;
+            color: var(--header-text);
+            margin-bottom: 8px;
+            letter-spacing: -0.5px;
+            text-transform: uppercase;
         }
 
-        .header h2 {
-            font-size: 12.5px;
+        .header-tagline {
+            font-size: 17px;
             font-weight: 400;
-            color: rgba(255, 255, 255, 0.92);
-            margin-bottom: 16px;
+            color: var(--header-text-soft);
+            margin-top: 22px;
+            margin-bottom: 28px;
+            font-style: italic;
+            letter-spacing: 0.5px;
         }
-
+        
         .contact-info {
             display: flex;
             flex-wrap: wrap;
-            justify-content: center;
-            gap: 8px;
+            gap: 10px;
+            align-items: center;
+            margin-top: 12px;
         }
-
-        .contact-info > span,
-        .contact-info > a {
-            display: inline-block;
-            background: rgba(255, 255, 255, 0.14);
-            border: 1px solid rgba(255, 255, 255, 0.24);
-            color: #ffffff;
-            text-decoration: none;
-            font-size: 10.5px;
+        
+        .contact-item {
+            display: inline-flex;
+            align-items: center;
+            background: var(--header-chip-bg);
+            border-radius: 10px;
+            padding: 8px 14px;
+            color: var(--header-text);
+            font-size: 12.5px;
             font-weight: 500;
-            padding: 5px 12px;
-            border-radius: 20px;
+            border: 1px solid var(--header-chip-border);
         }
-
-        /* Sections — generous whitespace, alternating mist */
-        .section { padding: 24px 40px; }
-        .section:nth-of-type(even) { background: var(--mist-color); }
-
-        .section-title {
-            display: inline-block;
-            font-family: var(--font-display);
-            background: var(--primary-color);
-            color: #ffffff;
+        
+        .contact-item i {
+            margin-right: 6px;
             font-size: 12px;
-            font-weight: 700;
-            letter-spacing: 0.4px;
-            text-transform: uppercase;
-            padding: 6px 14px;
-            border-radius: 8px;
-            margin-bottom: 14px;
         }
-
-        #cv-profile { font-size: 11.5px; line-height: 1.65; }
-
-        /* Skills — purple dot scale */
-        .skills-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; }
-
-        #skills-strategic h3,
-        #skills-tools h3,
-        #skills-emerging h3 {
-            font-family: var(--font-display) !important;
-            font-size: 11.5px !important;
-            font-weight: 700 !important;
-            color: var(--secondary-color) !important;
-            text-transform: uppercase;
-            letter-spacing: 0.3px;
-            padding-bottom: 6px;
-            margin-bottom: 10px !important;
+        
+        /* Section Styles */
+        .section {
+            padding: 25px 50px;
             border-bottom: 1px solid var(--border-color);
         }
 
-        .tool-item { margin-bottom: 8px; }
-        .tool-name { display: flex; justify-content: space-between; align-items: baseline; font-size: 10.8px; font-weight: 500; }
-        .tool-percentage { color: var(--accent-color); font-size: 9px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.2px; }
-        .dots-container { display: flex; gap: 3px; margin-top: 3px; }
-        .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--lavender-color); }
-        .dot.filled { background: var(--primary-color); }
+        .section:last-child {
+            border-bottom: none;
+        }
 
-        /* Experience — clean cards, soft shadow */
-        .experience-item {
-            background: #ffffff;
-            border-left: 3px solid var(--primary-color);
-            border-radius: 0 10px 10px 0;
-            padding: 14px 18px;
+        .section-title {
+            font-family: var(--font-display);
+            background: var(--primary-color);
+            color: white;
+            font-size: 15px;
+            font-weight: 600;
+            margin-bottom: 18px;
+            padding: 8px 16px;
+            border-radius: 12px;
+            letter-spacing: 0.3px;
+            display: inline-block;
+            text-transform: uppercase;
+        }
+
+        /* Resumo de Qualificações */
+        .qualifications-list {
+            list-style: none;
+            padding: 0;
+        }
+
+        .qualifications-list li {
+            position: relative;
+            padding-left: 28px;
             margin-bottom: 14px;
-            box-shadow: 0 2px 10px rgba(130, 10, 209, 0.07);
+            font-size: 13.5px;
+            line-height: 1.7;
+            color: var(--text-color);
+        }
+
+        .qualifications-list li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+            font-size: 20px;
+            top: -2px;
+        }
+        
+        /* Skills & Tools Grid */
+        .skills-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 20px;
+        }
+
+        .skills-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 16px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
+        }
+
+        .skills-section h3 {
+            font-size: 12px;
+            color: var(--primary-color);
+            margin-bottom: 10px;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .skill-items {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
+
+        .skill-tag {
+            background: var(--tag-bg);
+            color: var(--primary-color);
+            padding: 4px 10px;
+            border-radius: 12px;
+            font-size: 10.5px;
+            font-weight: 500;
+            border: 1px solid var(--tag-border);
+        }
+
+        /* Cursos Complementares */
+        .courses-section {
+            margin-top: 10px;
+        }
+
+        .course-item {
+            padding: 8px 0;
+            border-bottom: 1px solid var(--border-color);
+            font-size: 11px;
+        }
+
+        .course-item:last-child {
+            border-bottom: none;
+        }
+
+        .course-name {
+            color: var(--text-color);
+            font-weight: 500;
+            display: block;
+            margin-bottom: 2px;
+        }
+
+        .course-info {
+            color: var(--secondary-color);
+            font-size: 10px;
+            font-style: italic;
+        }
+        
+        /* Experience Timeline */
+        .experience-timeline {
+            position: relative;
+            margin-left: 20px;
+            padding-left: 30px;
+        }
+        
+        .experience-timeline::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            top: 0;
+            bottom: 0;
+            width: 3px;
+            background: var(--primary-color);
+            border-radius: 3px;
+        }
+
+        .experience-item {
+            margin-bottom: 25px;
+            position: relative;
+            padding: 18px;
+            border-radius: 14px;
+            background: #fff;
+            border: 1px solid var(--border-color);
+        }
+        
+        .experience-item::before {
+            content: "";
+            position: absolute;
+            left: -36px;
+            top: 25px;
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background: var(--accent-color);
+            border: 3px solid white;
+        }
+        
+        .job-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-bottom: 10px;
         }
 
         .job-title {
-            display: flex;
-            align-items: center;
-            gap: 8px;
             font-family: var(--font-display);
-            font-size: 13.5px;
-            font-weight: 700;
-            color: var(--secondary-color);
+            font-weight: 600;
+            font-size: 16px;
+            color: var(--primary-color);
             margin-bottom: 4px;
         }
-
-        .job-number {
-            flex-shrink: 0;
-            width: 20px;
-            height: 20px;
-            border-radius: 50%;
-            background: var(--primary-color);
-            color: #ffffff;
-            font-family: var(--font-body);
-            font-size: 10.5px;
-            font-weight: 700;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .company { font-weight: 600; font-size: 11.5px; color: var(--text-color); }
-        .period { font-size: 10.5px; color: var(--accent-color); font-weight: 600; margin-bottom: 6px; }
-        .job-description { font-size: 11px; line-height: 1.55; margin-bottom: 8px; color: var(--text-color); }
-
-        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 8px 16px; }
-        .achievement-item { display: flex; gap: 7px; align-items: flex-start; font-size: 10.3px; }
-        .achievement-icon { flex-shrink: 0; width: 15px; text-align: center; color: var(--primary-color); padding-top: 1px; }
-        .achievement-title { font-weight: 600; color: var(--text-color); }
-        .achievement-description { color: #4a4a4a; line-height: 1.4; }
-        .tooltip { display: none; }
-
-        /* Education */
-        .education-item {
-            background: #ffffff;
-            border-left: 3px solid var(--secondary-color);
-            border-radius: 0 10px 10px 0;
-            padding: 10px 16px;
-            margin-bottom: 10px;
-        }
-        .degree { font-family: var(--font-display); font-weight: 700; font-size: 12px; color: var(--secondary-color); margin-bottom: 2px; }
-        .university { font-size: 11px; margin-bottom: 2px; }
-        .thesis { font-size: 10px; color: #555555; font-style: italic; }
-        .cta-button { display: none; }
-
-        /* Projects */
-        .project-item {
-            background: #ffffff;
-            border-left: 3px solid var(--primary-color);
-            border-radius: 0 10px 10px 0;
-            padding: 12px 16px;
-            margin-bottom: 10px;
-        }
-        .project-title { font-family: var(--font-display); font-weight: 700; font-size: 12px; color: var(--secondary-color); margin-bottom: 4px; }
-        .project-description { font-size: 11px; line-height: 1.5; margin-bottom: 6px; }
-        .tech-tag {
-            display: inline-block;
-            padding: 2px 9px;
-            margin: 3px 4px 0 0;
-            border: 1px solid var(--accent-color);
-            color: var(--secondary-color);
-            border-radius: 10px;
-            font-size: 9px;
+        
+        .company {
             font-weight: 500;
+            font-size: 13px;
+            color: var(--secondary-color);
+        }
+        
+        .period {
+            font-size: 12px;
+            color: var(--secondary-color);
+            font-weight: 600;
+            text-align: right;
+        }
+        
+        .job-description {
+            font-size: 12px;
+            line-height: 1.6;
+            color: var(--text-color);
+            margin-bottom: 12px;
         }
 
-        @media print {
-            body { margin: 0; padding: 0; -webkit-print-color-adjust: exact !important; print-color-adjust: exact !important; }
-            .cv-container { max-width: 100%; margin: 0; }
+        .job-bullets {
+            list-style: none;
+            padding: 0;
+        }
 
-            .header {
+        .job-bullets li {
+            position: relative;
+            padding-left: 20px;
+            margin-bottom: 8px;
+            font-size: 12px;
+            line-height: 1.5;
+            color: var(--text-color);
+        }
+
+        .job-bullets li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+        }
+        
+        /* Education */
+        .education-tech-container {
+            display: grid;
+            grid-template-columns: 1fr 2fr;
+            gap: 25px;
+        }
+        
+        .education-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 20px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
+        }
+
+        .education-item {
+            margin-bottom: 12px;
+            padding-bottom: 12px;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .education-item:last-child {
+            margin-bottom: 0;
+            padding-bottom: 0;
+            border-bottom: none;
+        }
+        
+        .degree {
+            font-family: var(--font-display);
+            font-weight: 600;
+            font-size: 13px;
+            color: var(--primary-color);
+            margin-bottom: 3px;
+        }
+        
+        .university {
+            font-size: 11px;
+            color: var(--text-color);
+            margin-bottom: 2px;
+        }
+        
+        .edu-period {
+            font-size: 10px;
+            color: var(--secondary-color);
+            font-style: italic;
+        }
+
+        .tech-skills-container {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 15px;
+        }
+
+        /* Languages */
+        .language-container {
+            display: flex;
+            justify-content: center;
+            gap: 30px;
+        }
+
+        .language-item {
+            text-align: center;
+        }
+
+        .language-name {
+            font-weight: 600;
+            color: var(--primary-color);
+            font-size: 13px;
+            margin-bottom: 2px;
+        }
+
+        .language-level {
+            font-size: 11px;
+            color: var(--text-color);
+        }
+
+        /* Print Styles */
+        @media print {
+            body {
+                background: white;
+                margin: 0;
+                padding: 0;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
-                padding: 22px 30px 26px !important;
+            }
+
+            .cv-container {
+                max-width: 100%;
+                margin: 0;
+                box-shadow: none;
+            }
+
+            .header {
+                background: var(--background-gradient) !important;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+                padding: 25px 35px !important;
                 page-break-after: avoid;
             }
 
             .section-title {
+                background: var(--primary-color) !important;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
+                color: white !important;
+                page-break-after: avoid;
             }
 
-            .section:nth-of-type(even) {
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
+            .section {
+                padding: 15px 35px;
+                page-break-inside: avoid;
             }
 
-            .section { padding: 14px 30px !important; page-break-inside: avoid; }
-            .experience-item, .education-item, .project-item { page-break-inside: avoid; }
+            .experience-item {
+                page-break-inside: avoid;
+            }
 
-            .header h1 { font-size: 19px !important; }
-            .header h2 { font-size: 11px !important; }
-            .brand-logo { width: 80px !important; height: 44px !important; margin-bottom: 10px !important; }
-            .contact-info > span, .contact-info > a { font-size: 8.5px !important; padding: 3px 8px !important; }
-            .section-title { font-size: 10.5px !important; padding: 4px 11px !important; margin-bottom: 10px !important; }
+            /* Hide animations */
+            * {
+                animation: none !important;
+            }
 
-            .job-title { font-size: 11.5px !important; }
-            .job-number { width: 16px !important; height: 16px !important; font-size: 9px !important; }
-            .job-description, .achievement-item { font-size: 9px !important; }
-            .company, .period { font-size: 9.5px !important; }
-            .experience-item { padding: 10px 14px !important; margin-bottom: 10px !important; }
-            .education-item, .project-item { padding: 8px 14px !important; margin-bottom: 8px !important; }
-            .degree, .project-title { font-size: 10.5px !important; }
-            .university, .project-description { font-size: 9.5px !important; }
-            .thesis { font-size: 8.5px !important; }
-            .tool-name { font-size: 9.5px !important; }
-            .tool-percentage { font-size: 8px !important; }
-            #skills-strategic h3, #skills-tools h3, #skills-emerging h3 { font-size: 10px !important; }
-
-            @page { size: A4; margin: 8mm; }
+            @page {
+                size: A4;
+                margin: 8mm;
+            }
         }
+        .contact-info { max-width: calc(100% - 180px); }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <!-- Favicon Meta Tags -->
+    <meta name="theme-color" content="#820AD1">
+    <meta name="msapplication-TileColor" content="#820AD1">
+    <meta name="msapplication-config" content="../assets/favicons/browserconfig.xml">
 </head>
 <body>
     <div class="cv-container">
         <header class="header">
-            <div class="brand-logo">
-                <img src="../assets/images/nubank.png" alt="Nubank">
-            </div>
-            <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
-            <h2 id="cv-role">CRM Management and Data Intelligence</h2>
-            <div class="contact-info">
-                <span id="cv-email">pedrohmarconato@gmail.com</span>
-                <span id="cv-phone">+55 (55) 981147758</span>
-                <span id="cv-location"><span>Cachoeira do Sul, RS</span></span>
-                <a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin">LinkedIn</a>
+            <div class="header-content">
+                <img src="../assets/images/nubank.png" alt="Nubank" class="brand-logo">
+                <h1>PEDRO HENRIQUE MARCONATO</h1>
+                
+                <div class="header-tagline">CRM | ANALYTICS | BUSINESS INTELLIGENCE | LTV | SQL</div>
+                
+                <div class="contact-info">
+                    <div class="contact-item">
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-phone"></i> +55 (55) 98114-7758
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-envelope"></i> pedrohmarconato@gmail.com
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fab fa-linkedin"></i> linkedin.com/in/pedrohmarconato
+                    </div>
+                </div>
             </div>
         </header>
-
-        <section class="section">
-            <h2 class="section-title" id="section-profile">Professional Profile</h2>
-            <p id="cv-profile"></p>
+        
+        <section class="section" style="padding-top: 35px;">
+            <h2 class="section-title">PROFESSIONAL SUMMARY</h2>
+            <ul class="qualifications-list">
+                <li>Master's degree in Business Administration, with an Analytics track, combining data intelligence, CRM, analytical visualization, and automation to generate business value</li>
+                <li>Experience in large and highly complex companies, such as Grupo RBS, Realize CFI (Lojas Renner S.A. Group), and Rede Globo, leading strategic projects in CRM, business intelligence, and marketing performance</li>
+                <li>Experience with data applied to marketing, channels, credit, control, and operations, connecting areas and translating technical needs into high-impact analytical solutions</li>
+                <li>Highlights in visualization, segmentation, and consumer behavior projects, with mastery of tools such as Databricks, SQL, Responsys, Power BI, Python, Salesforce, Mailchimp, Tableau, SAS, Mix Agents, and Kanbanize</li>
+                <li>Knowledge in agile methodologies (Scrum, Kanban), working on backlog prioritization, squad structuring, and accelerating delivery with a focus on the customer</li>
+                <li>Experience with data integration from multiple sources, building pipelines, predictive analytics, and behavior mapping to support strategic decisions</li>
+                <li>Differentiator in combining analytical capacity, strategic thinking, and technical knowledge, with recognized performance as leadership even in consultative structures</li>
+                <li>People management, leading multidisciplinary teams with a focus on development, autonomy, and generating consistent results</li>
+            </ul>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-skills">Skills & Tools</h2>
-            <div class="skills-grid">
-                <div id="skills-strategic"></div>
-                <div id="skills-tools"></div>
-                <div id="skills-emerging"></div>
+            <h2 class="section-title">EDUCATION & TECHNOLOGY</h2>
+            <div class="education-tech-container">
+                <div class="education-section">
+                    <h3 style="font-size: 12px; color: var(--primary-color); margin-bottom: 12px; font-weight: 600;">EDUCATION</h3>
+                    <div class="education-item">
+                        <div class="degree">Master's in Business Administration</div>
+                        <div class="university">Federal University of Santa Maria - UFSM</div>
+                        <div class="edu-period">Completed: 2019</div>
+                    </div>
+                    
+                    <div class="education-item">
+                        <div class="degree">Bachelor's in Business Administration</div>
+                        <div class="university">Federal University of Santa Maria - UFSM</div>
+                        <div class="edu-period">Completed: 2015</div>
+                    </div>
+                </div>
+                
+                <div class="tech-skills-container">
+                    <div class="skills-section">
+                        <h3>TOOLS & PLATFORMS</h3>
+                        <div class="skill-items">
+                            <span class="skill-tag">Databricks</span>
+                            <span class="skill-tag">SQL</span>
+                            <span class="skill-tag">Power BI</span>
+                            <span class="skill-tag">Python</span>
+                            <span class="skill-tag">Oracle Responsys</span>
+                            <span class="skill-tag">Kanbanize</span>
+                            <span class="skill-tag">Mailchimp</span>
+                            <span class="skill-tag">Mix Agents</span>
+                            <span class="skill-tag">SAS</span>
+                            <span class="skill-tag">Tableau</span>
+                            <span class="skill-tag">Salesforce CRM</span>
+                        </div>
+                    </div>
+                    
+                    <div class="skills-section">
+                        <h3>CERTIFICATIONS & COURSES</h3>
+                        <div class="courses-section">
+                            <div class="course-item">
+                                <span class="course-name">Statement of Accomplishment - Intermediate R Course</span>
+                                <span class="course-info">Marketing Analytics In Practice - Coursera</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Marketing Analytics in R</span>
+                                <span class="course-info">PPGA - Graduate Program in Business Administration</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Fundamentals of Problem Solving</span>
+                                <span class="course-info">Marketing in a Digital World - Illinois University</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-experience">Professional Experience</h2>
-            <div id="experience-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-education">Education</h2>
-            <div id="education-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-projects">Projects & Innovation</h2>
-            <div id="projects-container"></div>
+            <h2 class="section-title">PROFESSIONAL EXPERIENCE</h2>
+            
+            <div class="experience-timeline">
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">CADASTRA (Digital Marketing and Performance Agency)</div>
+                        </div>
+                        <div class="period">2025-Present</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">Data Analytics Coordinator</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">Sep/2025-Present</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Leading Data Analytics and AI operations for enterprise clients in technology, retail and education sectors, managing multidisciplinary team (DataViz, Data Engineering, Web Analytics)</li>
+                        <li>Simultaneous management of strategic accounts with direct interface to C-level stakeholders and business areas (Performance, E-commerce, Commercial)</li>
+                        <li>Data architecture and governance definition for Business Intelligence, Real-Time Analytics and AI applications projects</li>
+                        <li>Technical diagnosis and restructuring of legacy data environments, including infrastructure migration (AWS→GCP) with projected 40% reduction in processing costs</li>
+                        <li>Data operations restructuring with team expansion (+67%) and scope extension to multiple LATAM business units</li>
+                        <li>Stabilization of critical data environments, achieving 20% savings in operational processing costs (Airflow/DAGs)</li>
+                        <li>Development of automations with n8n and AI Agents (LLMs), including automated Status Report with AI-generated executive summaries</li>
+                        <li>Leadership of first generative AI initiatives in client operations, positioning the area as innovation reference</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">LOJAS RENNER | REALIZE CFI (National Financial Services Company)</div>
+                        </div>
+                        <div class="period">2020-2025</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">CRM Manager</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2021-2025</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for leading the strategic CRM front, focusing on area evolution, customer base growth, and business value generation</li>
+                        <li>Definition and monitoring of area OKRs, connecting business goals to relationship indicators</li>
+                        <li>Planning, execution, and optimization of multichannel relationship campaigns (email, SMS, push, among others), applying intelligent segmentations and automations to increase usage frequency and sales</li>
+                        <li>Building personalized journeys based on customer behavior and profile, promoting lifecycle evolution and loyalty in financial products (cards, loans, insurance, and consumption in the Renner ecosystem)</li>
+                        <li>Management of agile management rhythm (daily, planning, reviews, and retrospectives), using frameworks such as Scrum and Kanban to maintain delivery pace, priority visibility, and impact focus</li>
+                        <li>Area backlog management, with mapping, prioritization, and organization of demands according to incremental value and alignment with the commercial team</li>
+                        <li>Strategic management of suppliers and technology partners, including CRM platforms, automation, and data enrichment, ensuring delivery quality and alignment with area guidelines</li>
+                        <li>Continuous interface with key areas (IT, Products, Analytics, Marketing, Stores, and Commercial), promoting alignment between CRM initiatives and corporate objectives</li>
+                        <li>Technical and operational management of tools such as Oracle Responsys, Databricks, and Power BI, enabling automated segmentations, data processing, and performance dashboards</li>
+                        <li>Monitoring and analysis of KPIs and campaign indicators, using data to guide decisions, validate hypotheses, and promote continuous improvement</li>
+                        <li>Leadership of strategic projects and initiatives to expand the active customer base and activate new communication channels</li>
+                    </ul>
+                    
+                    <div class="job-title" style="margin-top: 15px; margin-bottom: 8px;">Analytics Specialist</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2020-2021</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for creating dashboards and strategic indicators for areas such as Marketing, CRM, Credit, and Channels, delivering an integrated real-time view to support business decisions</li>
+                        <li>Development of segmented databases and automated reports focused on the CRM team, with a focus on efficiency gains, agility in analyses, and revenue generation through more precise actions</li>
+                        <li>Organization and integration of operational, behavioral, and transactional data, consolidating multiple sources into a reliable base for comprehensive customer lifecycle analyses</li>
+                        <li>Practical use of tools such as SQL, BigQuery, Python, and Power BI for exploratory analyses, routine automations, and development of predictive models applied to the business</li>
+                        <li>Close collaboration with Marketing, Products, Risk, and Operations areas, translating strategic needs into applicable analyses, focusing on action direction and decision-making</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Analytics Specialist</div>
+                            <div class="company">DBC COMPANY (National IT Consulting Company)</div>
+                        </div>
+                        <div class="period">2020-2021</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for supporting the strategic restructuring of the CRM area at client Realize, implementing agile methodologies (Kanban) and defining processes that reduced campaign time-to-market and increased operational efficiency</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Business Intelligence Analyst</div>
+                            <div class="company">GRUPO RBS (National Media Company)</div>
+                        </div>
+                        <div class="period">2019 - 2020</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for structuring and analyzing commercial performance, audience, and market behavior data, supporting leadership in strategic decision-making for client Rede Globo</li>
+                        <li>Development of segmentation studies and consumption potential mapping, using data to guide decisions, validate hypotheses, and promote sales and prospecting actions</li>
+                        <li>Creation of real-time analytical reports and dashboards to support business decisions</li>
+                        <li>Direct interface with leadership, translating market data into action plans and growth opportunities</li>
+                        <li>Analysis of KPIs and campaign indicators, using data to guide decisions, validate hypotheses, and promote continuous improvement</li>
+                    </ul>
+                </div>
+            </div>
         </section>
     </div>
-
-    <script src="../assets/js/cv-texts.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            var lang = 'en';
-            initializeBasicContent(lang);
-            renderSkills('skills-strategic', 'strategic', lang);
-            renderSkills('skills-tools', 'tools', lang);
-            renderSkills('skills-emerging', 'emerging', lang);
-            renderExperienceTimeline(lang);
-            renderEducation(lang);
-            renderProjects(lang);
-        });
-    </script>
+    <!-- Dynamic Favicon System -->
+    <script src="../assets/js/dynamic-favicon.js"></script>
 </body>
 </html>

--- a/cv_styles/cv_nubank_style_PT.html
+++ b/cv_styles/cv_nubank_style_PT.html
@@ -3,314 +3,669 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pedro Henrique Marconato - CV</title>
-    <meta name="theme-color" content="#820AD1">
+    <title>Pedro Henrique Marconato - CV (Nubank)</title>
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Sora:wght@400;600;700;800&display=swap');
-
+        
         :root {
-            /* Nubank Colors — brandbook (docs/nubank_brandbook.md) */
-            --primary-color: #820AD1;   /* Roxo Nu — masterbrand */
-            --secondary-color: #5C08A0; /* Roxo Profundo */
-            --accent-color: #A64CE8;    /* Lilás */
-            --lavender-color: #C89AF2;  /* Lavanda — dots vazios */
-            --mist-color: #F3E9FC;      /* Névoa — fundo alternado de seção */
+            /* Nubank — brand tokens */
+            --primary-color: #820AD1;
+            --secondary-color: #5C08A0;
+            --accent-color: #A64CE8;
+            --light-accent: #F3E9FC;
             --text-color: #1A1A1A;
             --border-color: rgba(130, 10, 209, 0.15);
-            --gradient: linear-gradient(135deg, #820AD1 0%, #5C08A0 100%);
-            --font-display: 'Sora', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            --background-gradient: linear-gradient(135deg, #820AD1 0%, #5C08A0 100%);
+
             --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            --font-display: 'Sora', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+
+            --header-text: #ffffff;
+            --header-text-soft: rgba(255, 255, 255, 0.95);
+            --header-chip-bg: rgba(255, 255, 255, 0.15);
+            --header-chip-border: rgba(255, 255, 255, 0.28);
+
+            --tag-bg: rgba(166, 76, 232, 0.14);
+            --tag-border: rgba(166, 76, 232, 0.30);
         }
-
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-
+        
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
         body {
             font-family: var(--font-body);
             color: var(--text-color);
-            line-height: 1.55;
-            background: #ffffff;
-            font-size: 12px;
+            line-height: 1.6;
+            background: var(--light-accent);
+            min-height: 100vh;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
         }
 
-        .cv-container { max-width: 210mm; margin: 0 auto; background: #ffffff; }
-
-        /* Header — hero roxo minimalista */
+        /* Main container */
+        .cv-container {
+            max-width: 210mm;
+            margin: 0 auto;
+            background: rgba(255, 255, 255, 1);
+            overflow: hidden;
+            position: relative;
+        }
+        
+        /* Header Section */
         .header {
-            background: var(--gradient);
-            padding: 34px 40px 38px;
-            text-align: center;
+            background: var(--background-gradient);
+            padding: 50px 50px 55px 50px;
+            position: relative;
+            overflow: hidden;
+        }
+        
+        .header-content {
+            position: relative;
+            z-index: 1;
         }
 
-        .brand-logo { width: 100px; height: 55px; margin: 0 auto 14px; }
-        .brand-logo img { width: 100%; height: 100%; object-fit: contain; filter: brightness(0) invert(1); }
-
+.brand-logo {
+            position: absolute;
+            bottom: 20px;
+            right: 40px;
+            width: 148px;
+            height: auto;
+            opacity: 0.95;
+            filter: brightness(0) invert(1);
+        }
+        
         .header h1 {
             font-family: var(--font-display);
-            font-size: 23px;
+            font-size: 32px;
             font-weight: 700;
-            color: #ffffff;
-            letter-spacing: 0.2px;
-            margin-bottom: 6px;
+            color: var(--header-text);
+            margin-bottom: 8px;
+            letter-spacing: -0.5px;
+            text-transform: uppercase;
         }
 
-        .header h2 {
-            font-size: 12.5px;
+        .header-tagline {
+            font-size: 17px;
             font-weight: 400;
-            color: rgba(255, 255, 255, 0.92);
-            margin-bottom: 16px;
+            color: var(--header-text-soft);
+            margin-top: 22px;
+            margin-bottom: 28px;
+            font-style: italic;
+            letter-spacing: 0.5px;
         }
-
+        
         .contact-info {
             display: flex;
             flex-wrap: wrap;
-            justify-content: center;
-            gap: 8px;
+            gap: 10px;
+            align-items: center;
+            margin-top: 12px;
         }
-
-        .contact-info > span,
-        .contact-info > a {
-            display: inline-block;
-            background: rgba(255, 255, 255, 0.14);
-            border: 1px solid rgba(255, 255, 255, 0.24);
-            color: #ffffff;
-            text-decoration: none;
-            font-size: 10.5px;
+        
+        .contact-item {
+            display: inline-flex;
+            align-items: center;
+            background: var(--header-chip-bg);
+            border-radius: 10px;
+            padding: 8px 14px;
+            color: var(--header-text);
+            font-size: 12.5px;
             font-weight: 500;
-            padding: 5px 12px;
-            border-radius: 20px;
+            border: 1px solid var(--header-chip-border);
         }
-
-        /* Seções — muito espaço em branco, névoa alternada */
-        .section { padding: 24px 40px; }
-        .section:nth-of-type(even) { background: var(--mist-color); }
-
-        .section-title {
-            display: inline-block;
-            font-family: var(--font-display);
-            background: var(--primary-color);
-            color: #ffffff;
+        
+        .contact-item i {
+            margin-right: 6px;
             font-size: 12px;
-            font-weight: 700;
-            letter-spacing: 0.4px;
-            text-transform: uppercase;
-            padding: 6px 14px;
-            border-radius: 8px;
-            margin-bottom: 14px;
         }
-
-        #cv-profile { font-size: 11.5px; line-height: 1.65; }
-
-        /* Skills — dots em escala de roxo */
-        .skills-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; }
-
-        #skills-strategic h3,
-        #skills-tools h3,
-        #skills-emerging h3 {
-            font-family: var(--font-display) !important;
-            font-size: 11.5px !important;
-            font-weight: 700 !important;
-            color: var(--secondary-color) !important;
-            text-transform: uppercase;
-            letter-spacing: 0.3px;
-            padding-bottom: 6px;
-            margin-bottom: 10px !important;
+        
+        /* Section Styles */
+        .section {
+            padding: 25px 50px;
             border-bottom: 1px solid var(--border-color);
         }
 
-        .tool-item { margin-bottom: 8px; }
-        .tool-name { display: flex; justify-content: space-between; align-items: baseline; font-size: 10.8px; font-weight: 500; }
-        .tool-percentage { color: var(--accent-color); font-size: 9px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.2px; }
-        .dots-container { display: flex; gap: 3px; margin-top: 3px; }
-        .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--lavender-color); }
-        .dot.filled { background: var(--primary-color); }
+        .section:last-child {
+            border-bottom: none;
+        }
 
-        /* Experiência — cards limpos, sombra suave */
-        .experience-item {
-            background: #ffffff;
-            border-left: 3px solid var(--primary-color);
-            border-radius: 0 10px 10px 0;
-            padding: 14px 18px;
+        .section-title {
+            font-family: var(--font-display);
+            background: var(--primary-color);
+            color: white;
+            font-size: 15px;
+            font-weight: 600;
+            margin-bottom: 18px;
+            padding: 8px 16px;
+            border-radius: 12px;
+            letter-spacing: 0.3px;
+            display: inline-block;
+            text-transform: uppercase;
+        }
+
+        /* Resumo de Qualificações */
+        .qualifications-list {
+            list-style: none;
+            padding: 0;
+        }
+
+        .qualifications-list li {
+            position: relative;
+            padding-left: 28px;
             margin-bottom: 14px;
-            box-shadow: 0 2px 10px rgba(130, 10, 209, 0.07);
+            font-size: 13.5px;
+            line-height: 1.7;
+            color: var(--text-color);
+        }
+
+        .qualifications-list li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+            font-size: 20px;
+            top: -2px;
+        }
+        
+        /* Skills & Tools Grid */
+        .skills-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 20px;
+        }
+
+        .skills-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 16px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
+        }
+
+        .skills-section h3 {
+            font-size: 12px;
+            color: var(--primary-color);
+            margin-bottom: 10px;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .skill-items {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
+
+        .skill-tag {
+            background: var(--tag-bg);
+            color: var(--primary-color);
+            padding: 4px 10px;
+            border-radius: 12px;
+            font-size: 10.5px;
+            font-weight: 500;
+            border: 1px solid var(--tag-border);
+        }
+
+        /* Cursos Complementares */
+        .courses-section {
+            margin-top: 10px;
+        }
+
+        .course-item {
+            padding: 8px 0;
+            border-bottom: 1px solid var(--border-color);
+            font-size: 11px;
+        }
+
+        .course-item:last-child {
+            border-bottom: none;
+        }
+
+        .course-name {
+            color: var(--text-color);
+            font-weight: 500;
+            display: block;
+            margin-bottom: 2px;
+        }
+
+        .course-info {
+            color: var(--secondary-color);
+            font-size: 10px;
+            font-style: italic;
+        }
+        
+        /* Experience Timeline */
+        .experience-timeline {
+            position: relative;
+            margin-left: 20px;
+            padding-left: 30px;
+        }
+        
+        .experience-timeline::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            top: 0;
+            bottom: 0;
+            width: 3px;
+            background: var(--primary-color);
+            border-radius: 3px;
+        }
+        
+        .experience-item {
+            margin-bottom: 25px;
+            position: relative;
+            padding: 18px;
+            border-radius: 14px;
+            background: #fff;
+            border: 1px solid var(--border-color);
+        }
+        
+        .experience-item::before {
+            content: "";
+            position: absolute;
+            left: -36px;
+            top: 25px;
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background: var(--accent-color);
+            border: 3px solid white;
+        }
+        
+        .job-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-bottom: 10px;
         }
 
         .job-title {
-            display: flex;
-            align-items: center;
-            gap: 8px;
             font-family: var(--font-display);
-            font-size: 13.5px;
-            font-weight: 700;
-            color: var(--secondary-color);
+            font-weight: 600;
+            font-size: 16px;
+            color: var(--primary-color);
             margin-bottom: 4px;
         }
-
-        .job-number {
-            flex-shrink: 0;
-            width: 20px;
-            height: 20px;
-            border-radius: 50%;
-            background: var(--primary-color);
-            color: #ffffff;
-            font-family: var(--font-body);
-            font-size: 10.5px;
-            font-weight: 700;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .company { font-weight: 600; font-size: 11.5px; color: var(--text-color); }
-        .period { font-size: 10.5px; color: var(--accent-color); font-weight: 600; margin-bottom: 6px; }
-        .job-description { font-size: 11px; line-height: 1.55; margin-bottom: 8px; color: var(--text-color); }
-
-        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 8px 16px; }
-        .achievement-item { display: flex; gap: 7px; align-items: flex-start; font-size: 10.3px; }
-        .achievement-icon { flex-shrink: 0; width: 15px; text-align: center; color: var(--primary-color); padding-top: 1px; }
-        .achievement-title { font-weight: 600; color: var(--text-color); }
-        .achievement-description { color: #4a4a4a; line-height: 1.4; }
-        .tooltip { display: none; }
-
-        /* Educação */
-        .education-item {
-            background: #ffffff;
-            border-left: 3px solid var(--secondary-color);
-            border-radius: 0 10px 10px 0;
-            padding: 10px 16px;
-            margin-bottom: 10px;
-        }
-        .degree { font-family: var(--font-display); font-weight: 700; font-size: 12px; color: var(--secondary-color); margin-bottom: 2px; }
-        .university { font-size: 11px; margin-bottom: 2px; }
-        .thesis { font-size: 10px; color: #555555; font-style: italic; }
-        .cta-button { display: none; }
-
-        /* Projetos */
-        .project-item {
-            background: #ffffff;
-            border-left: 3px solid var(--primary-color);
-            border-radius: 0 10px 10px 0;
-            padding: 12px 16px;
-            margin-bottom: 10px;
-        }
-        .project-title { font-family: var(--font-display); font-weight: 700; font-size: 12px; color: var(--secondary-color); margin-bottom: 4px; }
-        .project-description { font-size: 11px; line-height: 1.5; margin-bottom: 6px; }
-        .tech-tag {
-            display: inline-block;
-            padding: 2px 9px;
-            margin: 3px 4px 0 0;
-            border: 1px solid var(--accent-color);
-            color: var(--secondary-color);
-            border-radius: 10px;
-            font-size: 9px;
+        
+        .company {
             font-weight: 500;
+            font-size: 13px;
+            color: var(--secondary-color);
+        }
+        
+        .period {
+            font-size: 12px;
+            color: var(--secondary-color);
+            font-weight: 600;
+            text-align: right;
+        }
+        
+        .job-description {
+            font-size: 12px;
+            line-height: 1.6;
+            color: var(--text-color);
+            margin-bottom: 12px;
         }
 
-        @media print {
-            body { margin: 0; padding: 0; -webkit-print-color-adjust: exact !important; print-color-adjust: exact !important; }
-            .cv-container { max-width: 100%; margin: 0; }
+        .job-bullets {
+            list-style: none;
+            padding: 0;
+        }
 
-            .header {
+        .job-bullets li {
+            position: relative;
+            padding-left: 20px;
+            margin-bottom: 8px;
+            font-size: 12px;
+            line-height: 1.5;
+            color: var(--text-color);
+        }
+
+        .job-bullets li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+        }
+        
+        /* Education */
+        .education-tech-container {
+            display: grid;
+            grid-template-columns: 1fr 2fr;
+            gap: 25px;
+        }
+        
+        .education-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 20px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
+        }
+
+        .education-item {
+            margin-bottom: 12px;
+            padding-bottom: 12px;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .education-item:last-child {
+            margin-bottom: 0;
+            padding-bottom: 0;
+            border-bottom: none;
+        }
+        
+        .degree {
+            font-family: var(--font-display);
+            font-weight: 600;
+            font-size: 13px;
+            color: var(--primary-color);
+            margin-bottom: 3px;
+        }
+        
+        .university {
+            font-size: 11px;
+            color: var(--text-color);
+            margin-bottom: 2px;
+        }
+        
+        .edu-period {
+            font-size: 10px;
+            color: var(--secondary-color);
+            font-style: italic;
+        }
+
+        .tech-skills-container {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 15px;
+        }
+
+        /* Languages */
+        .language-container {
+            display: flex;
+            justify-content: center;
+            gap: 30px;
+        }
+
+        .language-item {
+            text-align: center;
+        }
+
+        .language-name {
+            font-weight: 600;
+            color: var(--primary-color);
+            font-size: 13px;
+            margin-bottom: 2px;
+        }
+
+        .language-level {
+            font-size: 11px;
+            color: var(--text-color);
+        }
+
+        /* Print Styles */
+        @media print {
+            body {
+                background: white;
+                margin: 0;
+                padding: 0;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
-                padding: 22px 30px 26px !important;
+            }
+
+            .cv-container {
+                max-width: 100%;
+                margin: 0;
+                box-shadow: none;
+            }
+
+            .header {
+                background: var(--background-gradient) !important;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+                padding: 25px 35px !important;
                 page-break-after: avoid;
             }
 
             .section-title {
+                background: var(--primary-color) !important;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
+                color: white !important;
+                page-break-after: avoid;
             }
 
-            .section:nth-of-type(even) {
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
+            .section {
+                padding: 15px 35px;
+                page-break-inside: avoid;
             }
 
-            .section { padding: 14px 30px !important; page-break-inside: avoid; }
-            .experience-item, .education-item, .project-item { page-break-inside: avoid; }
+            .experience-item {
+                page-break-inside: avoid;
+            }
 
-            .header h1 { font-size: 19px !important; }
-            .header h2 { font-size: 11px !important; }
-            .brand-logo { width: 80px !important; height: 44px !important; margin-bottom: 10px !important; }
-            .contact-info > span, .contact-info > a { font-size: 8.5px !important; padding: 3px 8px !important; }
-            .section-title { font-size: 10.5px !important; padding: 4px 11px !important; margin-bottom: 10px !important; }
+            /* Hide animations */
+            * {
+                animation: none !important;
+            }
 
-            .job-title { font-size: 11.5px !important; }
-            .job-number { width: 16px !important; height: 16px !important; font-size: 9px !important; }
-            .job-description, .achievement-item { font-size: 9px !important; }
-            .company, .period { font-size: 9.5px !important; }
-            .experience-item { padding: 10px 14px !important; margin-bottom: 10px !important; }
-            .education-item, .project-item { padding: 8px 14px !important; margin-bottom: 8px !important; }
-            .degree, .project-title { font-size: 10.5px !important; }
-            .university, .project-description { font-size: 9.5px !important; }
-            .thesis { font-size: 8.5px !important; }
-            .tool-name { font-size: 9.5px !important; }
-            .tool-percentage { font-size: 8px !important; }
-            #skills-strategic h3, #skills-tools h3, #skills-emerging h3 { font-size: 10px !important; }
-
-            @page { size: A4; margin: 8mm; }
+            @page {
+                size: A4;
+                margin: 8mm;
+            }
         }
+        .contact-info { max-width: calc(100% - 180px); }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <!-- Favicon Meta Tags -->
+    <meta name="theme-color" content="#820AD1">
+    <meta name="msapplication-TileColor" content="#820AD1">
+    <meta name="msapplication-config" content="../assets/favicons/browserconfig.xml">
 </head>
 <body>
     <div class="cv-container">
         <header class="header">
-            <div class="brand-logo">
-                <img src="../assets/images/nubank.png" alt="Nubank">
-            </div>
-            <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
-            <h2 id="cv-role">Gestão de CRM e Inteligência de Dados</h2>
-            <div class="contact-info">
-                <span id="cv-email">pedrohmarconato@gmail.com</span>
-                <span id="cv-phone">+55 (55) 981147758</span>
-                <span id="cv-location"><span>Cachoeira do Sul, RS</span></span>
-                <a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin">LinkedIn</a>
+            <div class="header-content">
+                <img src="../assets/images/nubank.png" alt="Nubank" class="brand-logo">
+                <h1>PEDRO HENRIQUE MARCONATO</h1>
+                
+                <div class="header-tagline">CRM | ANALYTICS | BUSINESS INTELLIGENCE | LTV | SQL</div>
+                
+                <div class="contact-info">
+                    <div class="contact-item">
+                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 35 anos
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-phone"></i> +55 (55) 98114-7758
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-envelope"></i> pedrohmarconato@gmail.com
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fab fa-linkedin"></i> linkedin.com/in/pedrohmarconato
+                    </div>
+                </div>
             </div>
         </header>
-
-        <section class="section">
-            <h2 class="section-title" id="section-profile">Perfil Profissional</h2>
-            <p id="cv-profile"></p>
+        
+        <section class="section" style="padding-top: 35px;">
+            <h2 class="section-title">RESUMO DE QUALIFICAÇÕES</h2>
+            <ul class="qualifications-list">
+                <li>Mestre em Administração de Empresas, com ênfase na área de Analytics, unindo inteligência de dados, CRM, visualização analítica e automação para gerar valor ao negócio</li>
+                <li>Atuação em empresas de grande porte e alta complexidade, como Grupo RBS, Realize CFI (Grupo Lojas Renner S.A.) e Rede Globo, liderando projetos estratégicos nas frentes de CRM, inteligência comercial e performance de marketing</li>
+                <li>Vivência com dados aplicados a marketing, canais, crédito, controle e operações, conectando áreas e traduzindo necessidades técnicas em soluções analíticas de alto impacto</li>
+                <li>Destaques em projetos de visualização, segmentação e comportamento de consumo, com domínio de ferramentas como Databricks, SQL, Responsys, Power BI, Python, Salesforce, Mailchimp, Tableau, SAS, Mix Agents e Kanbanize</li>
+                <li>Conhecimento em metodologias ágeis (Scrum, Kanban), com atuação na priorização de backlog, estruturação de squads e aceleração de entrega com foco no cliente</li>
+                <li>Experiência com integração de dados de múltiplas fontes, construção de pipelines, análises preditivas e mapeamento de comportamento para suportar decisões estratégicas</li>
+                <li>Diferencial na combinação entre capacidade analítica, pensamento estratégico e conhecimento técnico, com atuação reconhecida como liderança mesmo em estruturas consultivas</li>
+                <li>Gestão de pessoas, liderando times multidisciplinares com foco em desenvolvimento, autonomia e geração de resultados consistentes</li>
+            </ul>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-skills">Habilidades e Ferramentas</h2>
-            <div class="skills-grid">
-                <div id="skills-strategic"></div>
-                <div id="skills-tools"></div>
-                <div id="skills-emerging"></div>
+            <h2 class="section-title">FORMAÇÃO ACADÊMICA & TECNOLOGIA</h2>
+            <div class="education-tech-container">
+                <div class="education-section">
+                    <h3 style="font-size: 12px; color: var(--primary-color); margin-bottom: 12px; font-weight: 600;">FORMAÇÃO</h3>
+                    <div class="education-item">
+                        <div class="degree">Mestrado em Administração de Empresas</div>
+                        <div class="university">Universidade Federal de Santa Maria - UFSM</div>
+                        <div class="edu-period">Conclusão: 2019</div>
+                    </div>
+                    
+                    <div class="education-item">
+                        <div class="degree">Bacharelado em Administração</div>
+                        <div class="university">Universidade Federal de Santa Maria - UFSM</div>
+                        <div class="edu-period">Conclusão: 2015</div>
+                    </div>
+                </div>
+                
+                <div class="tech-skills-container">
+                    <div class="skills-section">
+                        <h3>FERRAMENTAS & PLATAFORMAS</h3>
+                        <div class="skill-items">
+                            <span class="skill-tag">Databricks</span>
+                            <span class="skill-tag">SQL</span>
+                            <span class="skill-tag">Power BI</span>
+                            <span class="skill-tag">Python</span>
+                            <span class="skill-tag">Oracle Responsys</span>
+                            <span class="skill-tag">Kanbanize</span>
+                            <span class="skill-tag">Mailchimp</span>
+                            <span class="skill-tag">Mix Agents</span>
+                            <span class="skill-tag">SAS</span>
+                            <span class="skill-tag">Tableau</span>
+                            <span class="skill-tag">Salesforce CRM</span>
+                        </div>
+                    </div>
+                    
+                    <div class="skills-section">
+                        <h3>CERTIFICAÇÕES & CURSOS</h3>
+                        <div class="courses-section">
+                            <div class="course-item">
+                                <span class="course-name">Statement of Accomplishment - Intermediate R Course</span>
+                                <span class="course-info">Marketing Analytics In Practice - Coursera</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Marketing Analytics em R</span>
+                                <span class="course-info">PPGA - Programa de Pós-Graduação em Administração</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Fundamentos de Solução de Problemas</span>
+                                <span class="course-info">Marketing in a Digital World - Illinois University</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-experience">Experiência Profissional</h2>
-            <div id="experience-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-education">Formação Acadêmica</h2>
-            <div id="education-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-projects">Projetos e Inovação</h2>
-            <div id="projects-container"></div>
+            <h2 class="section-title">EXPERIÊNCIA PROFISSIONAL</h2>
+            
+            <div class="experience-timeline">
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">CADASTRA (Agência de Marketing Digital e Performance)</div>
+                        </div>
+                        <div class="period">2025-Atual</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">Coordenador de Data Analytics</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">Set/2025-Atual</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável pela operação de Data Analytics e AI para clientes de grande porte dos setores de tecnologia, varejo e educação, liderando time multidisciplinar (DataViz, Engenharia de Dados, Web Analytics)</li>
+                        <li>Gestão simultânea de contas estratégicas, com interface direta com stakeholders C-level e áreas de negócio (Performance, E-commerce, Comercial)</li>
+                        <li>Definição de arquitetura de dados e governança para projetos de Business Intelligence, Real-Time Analytics e aplicações de inteligência artificial</li>
+                        <li>Diagnóstico técnico e reestruturação de ambientes de dados legados, incluindo migração de infraestrutura (AWS→GCP) com redução projetada de 40% em custos de processamento</li>
+                        <li>Reestruturação de operações de dados com expansão de time (+67%) e ampliação de escopo para múltiplas unidades de negócio em LATAM</li>
+                        <li>Estabilização de ambientes críticos de dados, alcançando economia de 20% em custos operacionais de processamento (Airflow/DAGs)</li>
+                        <li>Desenvolvimento de automações com n8n e AI Agents (LLMs), incluindo Status Report automatizado com geração de resumos executivos por inteligência artificial</li>
+                        <li>Liderança das primeiras iniciativas de aplicação de IA generativa em operações de clientes, posicionando a área como referência em inovação</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">LOJAS RENNER | REALIZE CFI (Empresa Nacional do segmento Financeiro)</div>
+                        </div>
+                        <div class="period">2020-2025</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">CRM Manager</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2021-2025</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável pela liderança da frente estratégica de CRM, com foco na evolução da área, crescimento da base de clientes e geração de valor ao negócio</li>
+                        <li>Definição e acompanhamento dos OKRs da área, conectando metas do negócio a indicadores de relacionamento</li>
+                        <li>Planejamento, execução e otimização de campanhas de relacionamento multicanal (e-mail, SMS, push, entre outros), aplicando segmentações inteligentes e automações para aumentar frequência de uso e vendas</li>
+                        <li>Construção de jornadas personalizadas com base em comportamento e perfil dos clientes, promovendo a evolução do ciclo de vida e fidelização em produtos financeiros (cartões, empréstimos, seguros e consumo no ecossistema Renner)</li>
+                        <li>Gestão do ritmo de gestão ágil (daily, planning, reviews e retrospectives), utilizando frameworks como Scrum e Kanban para manter ritmo de entrega, visibilidade de prioridades e foco em impacto</li>
+                        <li>Gestão do backlog da área, com mapeamento, priorização e organização das demandas de acordo com o valor incremental e alinhamento com o time comercial</li>
+                        <li>Gestão estratégica de fornecedores e parceiros de tecnologia, incluindo plataformas de CRM, automação e enriquecimento de dados, garantindo qualidade das entregas e alinhamento às diretrizes da área</li>
+                        <li>Interface contínua com áreas-chave (TI, Produtos, Analytics, Marketing, Lojas e Comercial), promovendo alinhamento entre as iniciativas de CRM e os objetivos corporativos</li>
+                        <li>Gestão técnica e operacional de ferramentas como Oracle Responsys, Databricks e Power BI, viabilizando segmentações automatizadas, tratamento de dados e dashboards de performance</li>
+                        <li>Monitoramento e análise de KPIs e indicadores de campanhas, utilizando dados para orientar decisões, validar hipóteses e promover a melhoria contínua</li>
+                        <li>Liderança de projetos e iniciativas estratégicas de expansão da base ativa de clientes e ativação de novos canais de comunicação</li>
+                    </ul>
+                    
+                    <div class="job-title" style="margin-top: 15px; margin-bottom: 8px;">Especialista de Analytics</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2020-2021</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável por criar dashboards e indicadores estratégicos para áreas como Marketing, CRM, Crédito e Canais, entregando uma visão integrada e em tempo real para apoiar decisões de negócio</li>
+                        <li>Desenvolvimento de bases segmentadas e relatórios automatizados voltados ao time de CRM, com foco em ganho de eficiência, agilidade nas análises e geração de receita por meio de ações mais precisas</li>
+                        <li>Organização e integração de dados operacionais, comportamentais e transacionais, consolidando múltiplas fontes em uma base confiável para análises completas do ciclo de vida do cliente</li>
+                        <li>Utilização prática de ferramentas como SQL, BigQuery, Python e Power BI para análises exploratórias, automações de rotinas e desenvolvimento de modelos preditivos aplicados ao negócio</li>
+                        <li>Atuação próxima às áreas de Marketing, Produtos, Riscos e Operações, traduzindo necessidades estratégicas em análises aplicáveis, com foco em direcionamento de ações e tomada de decisão</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Especialista de Analytics</div>
+                            <div class="company">DBC COMPANY (Empresa Nacional do segmento de Consultoria em TI)</div>
+                        </div>
+                        <div class="period">2020-2021</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável por apoiar a reestruturação estratégica da área de CRM no cliente Realize, implementando metodologias ágeis (Kanban) e definindo processos que reduziram o time-to-market das campanhas e aumentaram a eficiência operacional</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Analista de Inteligência Comercial</div>
+                            <div class="company">GRUPO RBS (Empresa Nacional do segmento de Mídia)</div>
+                        </div>
+                        <div class="period">2019 - 2020</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável pela estruturação e análise dados de desempenho comercial, audiência e comportamento de mercado, apoiando a liderança na tomada de decisões estratégicas do cliente Rede Globo</li>
+                        <li>Desenvolvimento de estudos de segmentação e mapeamento de potencial de consumo, utilizando dados para orientar decisões, validar hipóteses e promover ações de vendas e prospecção</li>
+                        <li>Criação de relatórios e dashboards analíticos em tempo real para apoiar decisões do negócio</li>
+                        <li>Interface direta com a liderança, traduzindo dados de mercado em planos de ação e oportunidades de crescimento</li>
+                        <li>Análise de KPIs e indicadores de campanhas, utilizando dados para orientar decisões, validar hipóteses e promover a melhoria contínua</li>
+                    </ul>
+                </div>
+            </div>
         </section>
     </div>
-
-    <script src="../assets/js/cv-texts.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            var lang = 'pt';
-            initializeBasicContent(lang);
-            renderSkills('skills-strategic', 'strategic', lang);
-            renderSkills('skills-tools', 'tools', lang);
-            renderSkills('skills-emerging', 'emerging', lang);
-            renderExperienceTimeline(lang);
-            renderEducation(lang);
-            renderProjects(lang);
-        });
-    </script>
+    <!-- Dynamic Favicon System -->
+    <script src="../assets/js/dynamic-favicon.js"></script>
 </body>
 </html>

--- a/cv_styles/cv_vivo_style_EN.html
+++ b/cv_styles/cv_vivo_style_EN.html
@@ -4,337 +4,668 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pedro Henrique Marconato - CV (Vivo)</title>
-    <meta name="theme-color" content="#660099">
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Sora:wght@400;600;700;800&display=swap');
-
+        
         :root {
-            /* Vivo Colors — brandbook (docs/vivo_brandbook.md) */
-            --primary-color: #660099;   /* Roxo Vivo — masterbrand */
-            --secondary-color: #44006B; /* Roxo Profundo */
-            --accent-color: #ED0080;    /* Magenta Vivo */
-            --cyan-color: #00B0D6;      /* Ciano — brilho do espectro */
-            --lavender-color: #B98FE0;  /* Lilás — empty dots */
-            --mist-color: #F4ECFA;      /* Névoa lilás — alternating section background */
+            /* Vivo — brand tokens */
+            --primary-color: #660099;
+            --secondary-color: #44006B;
+            --accent-color: #ED0080;
+            --light-accent: #F3E9FB;
             --text-color: #1E1230;
             --border-color: rgba(102, 0, 153, 0.15);
-            --gradient: linear-gradient(135deg, #660099 0%, #44006B 100%);
-            --spectrum: linear-gradient(90deg, #ED0080, #660099);
-            --font-display: 'Sora', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            --background-gradient: linear-gradient(135deg, #660099 0%, #44006B 100%);
+
             --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            --font-display: 'Sora', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+
+            --header-text: #ffffff;
+            --header-text-soft: rgba(255, 255, 255, 0.95);
+            --header-chip-bg: rgba(255, 255, 255, 0.15);
+            --header-chip-border: rgba(255, 255, 255, 0.28);
+
+            --tag-bg: rgba(237, 0, 128, 0.12);
+            --tag-border: rgba(237, 0, 128, 0.28);
         }
-
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-
+        
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
         body {
             font-family: var(--font-body);
             color: var(--text-color);
-            line-height: 1.55;
-            background: #ffffff;
-            font-size: 12px;
+            line-height: 1.6;
+            background: var(--light-accent);
+            min-height: 100vh;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
         }
 
-        .cv-container { max-width: 210mm; margin: 0 auto; background: #ffffff; }
-
-        /* Header — deep purple hero with spectrum accent */
+        /* Main container */
+        .cv-container {
+            max-width: 210mm;
+            margin: 0 auto;
+            background: rgba(255, 255, 255, 1);
+            overflow: hidden;
+            position: relative;
+        }
+        
+        /* Header Section */
         .header {
-            background: linear-gradient(135deg, #660099 0%, #4B0072 55%, #33004F 100%);
-            padding: 34px 40px 38px;
-            text-align: center;
+            background: var(--background-gradient);
+            padding: 50px 50px 55px 50px;
             position: relative;
             overflow: hidden;
         }
-
-        /* Spectrum accent bar — magenta → cyan */
-        .header::after {
-            content: "";
-            position: absolute;
-            left: 0; right: 0; bottom: 0;
-            height: 5px;
-            background: linear-gradient(90deg, #ED0080 0%, #660099 50%, #00B0D6 100%);
+        
+        .header-content {
+            position: relative;
+            z-index: 1;
         }
 
-        .brand-logo { width: 108px; height: 55px; margin: 0 auto 14px; position: relative; z-index: 2; }
-        .brand-logo img { width: 100%; height: 100%; object-fit: contain; filter: brightness(0) invert(1); }
-
+.brand-logo {
+            position: absolute;
+            bottom: 20px;
+            right: 40px;
+            width: 120px;
+            height: auto;
+            opacity: 0.95;
+            filter: brightness(0) invert(1);
+        }
+        
         .header h1 {
             font-family: var(--font-display);
-            font-size: 23px;
+            font-size: 32px;
             font-weight: 700;
-            color: #ffffff;
-            letter-spacing: 0.2px;
-            margin-bottom: 6px;
-            position: relative;
-            z-index: 2;
+            color: var(--header-text);
+            margin-bottom: 8px;
+            letter-spacing: -0.5px;
+            text-transform: uppercase;
         }
 
-        .header h2 {
-            font-size: 12.5px;
+        .header-tagline {
+            font-size: 17px;
             font-weight: 400;
-            color: rgba(255, 255, 255, 0.92);
-            margin-bottom: 16px;
-            position: relative;
-            z-index: 2;
+            color: var(--header-text-soft);
+            margin-top: 22px;
+            margin-bottom: 28px;
+            font-style: italic;
+            letter-spacing: 0.5px;
         }
-
+        
         .contact-info {
             display: flex;
             flex-wrap: wrap;
-            justify-content: center;
-            gap: 8px;
-            position: relative;
-            z-index: 2;
+            gap: 10px;
+            align-items: center;
+            margin-top: 12px;
         }
-
-        .contact-info > span,
-        .contact-info > a {
-            display: inline-block;
-            background: rgba(255, 255, 255, 0.14);
-            border: 1px solid rgba(255, 255, 255, 0.24);
-            color: #ffffff;
-            text-decoration: none;
-            font-size: 10.5px;
+        
+        .contact-item {
+            display: inline-flex;
+            align-items: center;
+            background: var(--header-chip-bg);
+            border-radius: 10px;
+            padding: 8px 14px;
+            color: var(--header-text);
+            font-size: 12.5px;
             font-weight: 500;
-            padding: 5px 12px;
-            border-radius: 20px;
+            border: 1px solid var(--header-chip-border);
         }
-
-        /* Sections — generous whitespace, alternating mist */
-        .section { padding: 24px 40px; }
-        .section:nth-of-type(even) { background: var(--mist-color); }
-
-        .section-title {
-            display: inline-block;
-            font-family: var(--font-display);
-            background: var(--spectrum);
-            color: #ffffff;
+        
+        .contact-item i {
+            margin-right: 6px;
             font-size: 12px;
-            font-weight: 700;
-            letter-spacing: 0.4px;
-            text-transform: uppercase;
-            padding: 6px 14px;
-            border-radius: 8px;
-            margin-bottom: 14px;
         }
-
-        #cv-profile { font-size: 11.5px; line-height: 1.65; }
-
-        /* Skills — purple dot scale */
-        .skills-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; }
-
-        #skills-strategic h3,
-        #skills-tools h3,
-        #skills-emerging h3 {
-            font-family: var(--font-display) !important;
-            font-size: 11.5px !important;
-            font-weight: 700 !important;
-            color: var(--secondary-color) !important;
-            text-transform: uppercase;
-            letter-spacing: 0.3px;
-            padding-bottom: 6px;
-            margin-bottom: 10px !important;
+        
+        /* Section Styles */
+        .section {
+            padding: 25px 50px;
             border-bottom: 1px solid var(--border-color);
         }
 
-        .tool-item { margin-bottom: 8px; }
-        .tool-name { display: flex; justify-content: space-between; align-items: baseline; font-size: 10.8px; font-weight: 500; }
-        .tool-percentage { color: var(--accent-color); font-size: 9px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.2px; }
-        .dots-container { display: flex; gap: 3px; margin-top: 3px; }
-        .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--lavender-color); }
-        .dot.filled { background: var(--primary-color); }
+        .section:last-child {
+            border-bottom: none;
+        }
 
-        /* Experience — clean cards, soft shadow */
-        .experience-item {
-            background: #ffffff;
-            border-left: 3px solid var(--accent-color);
-            border-radius: 0 10px 10px 0;
-            padding: 14px 18px;
+        .section-title {
+            font-family: var(--font-display);
+            background: var(--primary-color);
+            color: white;
+            font-size: 15px;
+            font-weight: 600;
+            margin-bottom: 18px;
+            padding: 8px 16px;
+            border-radius: 12px;
+            letter-spacing: 0.3px;
+            display: inline-block;
+            text-transform: uppercase;
+        }
+
+        /* Resumo de Qualificações */
+        .qualifications-list {
+            list-style: none;
+            padding: 0;
+        }
+
+        .qualifications-list li {
+            position: relative;
+            padding-left: 28px;
             margin-bottom: 14px;
-            box-shadow: 0 2px 10px rgba(102, 0, 153, 0.07);
+            font-size: 13.5px;
+            line-height: 1.7;
+            color: var(--text-color);
+        }
+
+        .qualifications-list li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+            font-size: 20px;
+            top: -2px;
+        }
+        
+        /* Skills & Tools Grid */
+        .skills-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 20px;
+        }
+
+        .skills-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 16px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
+        }
+
+        .skills-section h3 {
+            font-size: 12px;
+            color: var(--primary-color);
+            margin-bottom: 10px;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .skill-items {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
+
+        .skill-tag {
+            background: var(--tag-bg);
+            color: var(--primary-color);
+            padding: 4px 10px;
+            border-radius: 12px;
+            font-size: 10.5px;
+            font-weight: 500;
+            border: 1px solid var(--tag-border);
+        }
+
+        /* Cursos Complementares */
+        .courses-section {
+            margin-top: 10px;
+        }
+
+        .course-item {
+            padding: 8px 0;
+            border-bottom: 1px solid var(--border-color);
+            font-size: 11px;
+        }
+
+        .course-item:last-child {
+            border-bottom: none;
+        }
+
+        .course-name {
+            color: var(--text-color);
+            font-weight: 500;
+            display: block;
+            margin-bottom: 2px;
+        }
+
+        .course-info {
+            color: var(--secondary-color);
+            font-size: 10px;
+            font-style: italic;
+        }
+        
+        /* Experience Timeline */
+        .experience-timeline {
+            position: relative;
+            margin-left: 20px;
+            padding-left: 30px;
+        }
+        
+        .experience-timeline::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            top: 0;
+            bottom: 0;
+            width: 3px;
+            background: var(--primary-color);
+            border-radius: 3px;
+        }
+
+        .experience-item {
+            margin-bottom: 25px;
+            position: relative;
+            padding: 18px;
+            border-radius: 14px;
+            background: #fff;
+            border: 1px solid var(--border-color);
+        }
+        
+        .experience-item::before {
+            content: "";
+            position: absolute;
+            left: -36px;
+            top: 25px;
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background: var(--accent-color);
+            border: 3px solid white;
+        }
+        
+        .job-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-bottom: 10px;
         }
 
         .job-title {
-            display: flex;
-            align-items: center;
-            gap: 8px;
             font-family: var(--font-display);
-            font-size: 13.5px;
-            font-weight: 700;
-            color: var(--secondary-color);
+            font-weight: 600;
+            font-size: 16px;
+            color: var(--primary-color);
             margin-bottom: 4px;
         }
-
-        .job-number {
-            flex-shrink: 0;
-            width: 20px;
-            height: 20px;
-            border-radius: 50%;
-            background: var(--primary-color);
-            color: #ffffff;
-            font-family: var(--font-body);
-            font-size: 10.5px;
-            font-weight: 700;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .company { font-weight: 600; font-size: 11.5px; color: var(--text-color); }
-        .period { font-size: 10.5px; color: var(--accent-color); font-weight: 600; margin-bottom: 6px; }
-        .job-description { font-size: 11px; line-height: 1.55; margin-bottom: 8px; color: var(--text-color); }
-
-        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 8px 16px; }
-        .achievement-item { display: flex; gap: 7px; align-items: flex-start; font-size: 10.3px; }
-        .achievement-icon { flex-shrink: 0; width: 15px; text-align: center; color: var(--accent-color); padding-top: 1px; }
-        .achievement-title { font-weight: 600; color: var(--text-color); }
-        .achievement-description { color: #4a4a4a; line-height: 1.4; }
-        .tooltip { display: none; }
-
-        /* Education */
-        .education-item {
-            background: #ffffff;
-            border-left: 3px solid var(--secondary-color);
-            border-radius: 0 10px 10px 0;
-            padding: 10px 16px;
-            margin-bottom: 10px;
-        }
-        .degree { font-family: var(--font-display); font-weight: 700; font-size: 12px; color: var(--secondary-color); margin-bottom: 2px; }
-        .university { font-size: 11px; margin-bottom: 2px; }
-        .thesis { font-size: 10px; color: #555555; font-style: italic; }
-        .cta-button { display: none; }
-
-        /* Projects */
-        .project-item {
-            background: #ffffff;
-            border-left: 3px solid var(--accent-color);
-            border-radius: 0 10px 10px 0;
-            padding: 12px 16px;
-            margin-bottom: 10px;
-        }
-        .project-title { font-family: var(--font-display); font-weight: 700; font-size: 12px; color: var(--secondary-color); margin-bottom: 4px; }
-        .project-description { font-size: 11px; line-height: 1.5; margin-bottom: 6px; }
-        .tech-tag {
-            display: inline-block;
-            padding: 2px 9px;
-            margin: 3px 4px 0 0;
-            border: 1px solid var(--accent-color);
-            color: var(--secondary-color);
-            border-radius: 10px;
-            font-size: 9px;
+        
+        .company {
             font-weight: 500;
+            font-size: 13px;
+            color: var(--secondary-color);
+        }
+        
+        .period {
+            font-size: 12px;
+            color: var(--secondary-color);
+            font-weight: 600;
+            text-align: right;
+        }
+        
+        .job-description {
+            font-size: 12px;
+            line-height: 1.6;
+            color: var(--text-color);
+            margin-bottom: 12px;
         }
 
-        @media print {
-            body { margin: 0; padding: 0; -webkit-print-color-adjust: exact !important; print-color-adjust: exact !important; }
-            .cv-container { max-width: 100%; margin: 0; }
+        .job-bullets {
+            list-style: none;
+            padding: 0;
+        }
 
-            .header {
+        .job-bullets li {
+            position: relative;
+            padding-left: 20px;
+            margin-bottom: 8px;
+            font-size: 12px;
+            line-height: 1.5;
+            color: var(--text-color);
+        }
+
+        .job-bullets li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+        }
+        
+        /* Education */
+        .education-tech-container {
+            display: grid;
+            grid-template-columns: 1fr 2fr;
+            gap: 25px;
+        }
+        
+        .education-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 20px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
+        }
+
+        .education-item {
+            margin-bottom: 12px;
+            padding-bottom: 12px;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .education-item:last-child {
+            margin-bottom: 0;
+            padding-bottom: 0;
+            border-bottom: none;
+        }
+        
+        .degree {
+            font-family: var(--font-display);
+            font-weight: 600;
+            font-size: 13px;
+            color: var(--primary-color);
+            margin-bottom: 3px;
+        }
+        
+        .university {
+            font-size: 11px;
+            color: var(--text-color);
+            margin-bottom: 2px;
+        }
+        
+        .edu-period {
+            font-size: 10px;
+            color: var(--secondary-color);
+            font-style: italic;
+        }
+
+        .tech-skills-container {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 15px;
+        }
+
+        /* Languages */
+        .language-container {
+            display: flex;
+            justify-content: center;
+            gap: 30px;
+        }
+
+        .language-item {
+            text-align: center;
+        }
+
+        .language-name {
+            font-weight: 600;
+            color: var(--primary-color);
+            font-size: 13px;
+            margin-bottom: 2px;
+        }
+
+        .language-level {
+            font-size: 11px;
+            color: var(--text-color);
+        }
+
+        /* Print Styles */
+        @media print {
+            body {
+                background: white;
+                margin: 0;
+                padding: 0;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
-                padding: 22px 30px 26px !important;
+            }
+
+            .cv-container {
+                max-width: 100%;
+                margin: 0;
+                box-shadow: none;
+            }
+
+            .header {
+                background: var(--background-gradient) !important;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+                padding: 25px 35px !important;
                 page-break-after: avoid;
             }
 
-            .header::after {
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
-            }
-
             .section-title {
+                background: var(--primary-color) !important;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
+                color: white !important;
+                page-break-after: avoid;
             }
 
-            .section:nth-of-type(even) {
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
+            .section {
+                padding: 15px 35px;
+                page-break-inside: avoid;
             }
 
-            .section { padding: 14px 30px !important; page-break-inside: avoid; }
-            .experience-item, .education-item, .project-item { page-break-inside: avoid; }
+            .experience-item {
+                page-break-inside: avoid;
+            }
 
-            .header h1 { font-size: 19px !important; }
-            .header h2 { font-size: 11px !important; }
-            .brand-logo { width: 80px !important; height: 44px !important; margin-bottom: 10px !important; }
-            .contact-info > span, .contact-info > a { font-size: 8.5px !important; padding: 3px 8px !important; }
-            .section-title { font-size: 10.5px !important; padding: 4px 11px !important; margin-bottom: 10px !important; }
+            /* Hide animations */
+            * {
+                animation: none !important;
+            }
 
-            .job-title { font-size: 11.5px !important; }
-            .job-number { width: 16px !important; height: 16px !important; font-size: 9px !important; }
-            .job-description, .achievement-item { font-size: 9px !important; }
-            .company, .period { font-size: 9.5px !important; }
-            .experience-item { padding: 10px 14px !important; margin-bottom: 10px !important; }
-            .education-item, .project-item { padding: 8px 14px !important; margin-bottom: 8px !important; }
-            .degree, .project-title { font-size: 10.5px !important; }
-            .university, .project-description { font-size: 9.5px !important; }
-            .thesis { font-size: 8.5px !important; }
-            .tool-name { font-size: 9.5px !important; }
-            .tool-percentage { font-size: 8px !important; }
-            #skills-strategic h3, #skills-tools h3, #skills-emerging h3 { font-size: 10px !important; }
-
-            @page { size: A4; margin: 8mm; }
+            @page {
+                size: A4;
+                margin: 8mm;
+            }
         }
+        .contact-info { max-width: calc(100% - 180px); }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <!-- Favicon Meta Tags -->
+    <meta name="theme-color" content="#660099">
+    <meta name="msapplication-TileColor" content="#660099">
+    <meta name="msapplication-config" content="../assets/favicons/browserconfig.xml">
 </head>
 <body>
     <div class="cv-container">
         <header class="header">
-            <div class="brand-logo">
-                <img src="../assets/images/vivo.webp" alt="Vivo">
-            </div>
-            <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
-            <h2 id="cv-role">CRM Management and Data Intelligence</h2>
-            <div class="contact-info">
-                <span id="cv-email">pedrohmarconato@gmail.com</span>
-                <span id="cv-phone">+55 (55) 981147758</span>
-                <span id="cv-location"><span>Cachoeira do Sul, RS</span></span>
-                <a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin">LinkedIn</a>
+            <div class="header-content">
+                <img src="../assets/images/vivo.webp" alt="Vivo" class="brand-logo">
+                <h1>PEDRO HENRIQUE MARCONATO</h1>
+                
+                <div class="header-tagline">CRM | ANALYTICS | BUSINESS INTELLIGENCE | LTV | SQL</div>
+                
+                <div class="contact-info">
+                    <div class="contact-item">
+                        <i class="fas fa-map-marker-alt"></i> Brazilian, Married, 35 years old
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-phone"></i> +55 (55) 98114-7758
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-envelope"></i> pedrohmarconato@gmail.com
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fab fa-linkedin"></i> linkedin.com/in/pedrohmarconato
+                    </div>
+                </div>
             </div>
         </header>
-
-        <section class="section">
-            <h2 class="section-title" id="section-profile">Professional Profile</h2>
-            <p id="cv-profile"></p>
+        
+        <section class="section" style="padding-top: 35px;">
+            <h2 class="section-title">PROFESSIONAL SUMMARY</h2>
+            <ul class="qualifications-list">
+                <li>Master's degree in Business Administration, with an Analytics track, combining data intelligence, CRM, analytical visualization, and automation to generate business value</li>
+                <li>Experience in large and highly complex companies, such as Grupo RBS, Realize CFI (Lojas Renner S.A. Group), and Rede Globo, leading strategic projects in CRM, business intelligence, and marketing performance</li>
+                <li>Experience with data applied to marketing, channels, credit, control, and operations, connecting areas and translating technical needs into high-impact analytical solutions</li>
+                <li>Highlights in visualization, segmentation, and consumer behavior projects, with mastery of tools such as Databricks, SQL, Responsys, Power BI, Python, Salesforce, Mailchimp, Tableau, SAS, Mix Agents, and Kanbanize</li>
+                <li>Knowledge in agile methodologies (Scrum, Kanban), working on backlog prioritization, squad structuring, and accelerating delivery with a focus on the customer</li>
+                <li>Experience with data integration from multiple sources, building pipelines, predictive analytics, and behavior mapping to support strategic decisions</li>
+                <li>Differentiator in combining analytical capacity, strategic thinking, and technical knowledge, with recognized performance as leadership even in consultative structures</li>
+                <li>People management, leading multidisciplinary teams with a focus on development, autonomy, and generating consistent results</li>
+            </ul>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-skills">Skills & Tools</h2>
-            <div class="skills-grid">
-                <div id="skills-strategic"></div>
-                <div id="skills-tools"></div>
-                <div id="skills-emerging"></div>
+            <h2 class="section-title">EDUCATION & TECHNOLOGY</h2>
+            <div class="education-tech-container">
+                <div class="education-section">
+                    <h3 style="font-size: 12px; color: var(--primary-color); margin-bottom: 12px; font-weight: 600;">EDUCATION</h3>
+                    <div class="education-item">
+                        <div class="degree">Master's in Business Administration</div>
+                        <div class="university">Federal University of Santa Maria - UFSM</div>
+                        <div class="edu-period">Completed: 2019</div>
+                    </div>
+                    
+                    <div class="education-item">
+                        <div class="degree">Bachelor's in Business Administration</div>
+                        <div class="university">Federal University of Santa Maria - UFSM</div>
+                        <div class="edu-period">Completed: 2015</div>
+                    </div>
+                </div>
+                
+                <div class="tech-skills-container">
+                    <div class="skills-section">
+                        <h3>TOOLS & PLATFORMS</h3>
+                        <div class="skill-items">
+                            <span class="skill-tag">Databricks</span>
+                            <span class="skill-tag">SQL</span>
+                            <span class="skill-tag">Power BI</span>
+                            <span class="skill-tag">Python</span>
+                            <span class="skill-tag">Oracle Responsys</span>
+                            <span class="skill-tag">Kanbanize</span>
+                            <span class="skill-tag">Mailchimp</span>
+                            <span class="skill-tag">Mix Agents</span>
+                            <span class="skill-tag">SAS</span>
+                            <span class="skill-tag">Tableau</span>
+                            <span class="skill-tag">Salesforce CRM</span>
+                        </div>
+                    </div>
+                    
+                    <div class="skills-section">
+                        <h3>CERTIFICATIONS & COURSES</h3>
+                        <div class="courses-section">
+                            <div class="course-item">
+                                <span class="course-name">Statement of Accomplishment - Intermediate R Course</span>
+                                <span class="course-info">Marketing Analytics In Practice - Coursera</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Marketing Analytics in R</span>
+                                <span class="course-info">PPGA - Graduate Program in Business Administration</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Fundamentals of Problem Solving</span>
+                                <span class="course-info">Marketing in a Digital World - Illinois University</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-experience">Professional Experience</h2>
-            <div id="experience-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-education">Education</h2>
-            <div id="education-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-projects">Projects & Innovation</h2>
-            <div id="projects-container"></div>
+            <h2 class="section-title">PROFESSIONAL EXPERIENCE</h2>
+            
+            <div class="experience-timeline">
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">CADASTRA (Digital Marketing and Performance Agency)</div>
+                        </div>
+                        <div class="period">2025-Present</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">Data Analytics Coordinator</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">Sep/2025-Present</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Leading Data Analytics and AI operations for enterprise clients in technology, retail and education sectors, managing multidisciplinary team (DataViz, Data Engineering, Web Analytics)</li>
+                        <li>Simultaneous management of strategic accounts with direct interface to C-level stakeholders and business areas (Performance, E-commerce, Commercial)</li>
+                        <li>Data architecture and governance definition for Business Intelligence, Real-Time Analytics and AI applications projects</li>
+                        <li>Technical diagnosis and restructuring of legacy data environments, including infrastructure migration (AWS→GCP) with projected 40% reduction in processing costs</li>
+                        <li>Data operations restructuring with team expansion (+67%) and scope extension to multiple LATAM business units</li>
+                        <li>Stabilization of critical data environments, achieving 20% savings in operational processing costs (Airflow/DAGs)</li>
+                        <li>Development of automations with n8n and AI Agents (LLMs), including automated Status Report with AI-generated executive summaries</li>
+                        <li>Leadership of first generative AI initiatives in client operations, positioning the area as innovation reference</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">LOJAS RENNER | REALIZE CFI (National Financial Services Company)</div>
+                        </div>
+                        <div class="period">2020-2025</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">CRM Manager</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2021-2025</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for leading the strategic CRM front, focusing on area evolution, customer base growth, and business value generation</li>
+                        <li>Definition and monitoring of area OKRs, connecting business goals to relationship indicators</li>
+                        <li>Planning, execution, and optimization of multichannel relationship campaigns (email, SMS, push, among others), applying intelligent segmentations and automations to increase usage frequency and sales</li>
+                        <li>Building personalized journeys based on customer behavior and profile, promoting lifecycle evolution and loyalty in financial products (cards, loans, insurance, and consumption in the Renner ecosystem)</li>
+                        <li>Management of agile management rhythm (daily, planning, reviews, and retrospectives), using frameworks such as Scrum and Kanban to maintain delivery pace, priority visibility, and impact focus</li>
+                        <li>Area backlog management, with mapping, prioritization, and organization of demands according to incremental value and alignment with the commercial team</li>
+                        <li>Strategic management of suppliers and technology partners, including CRM platforms, automation, and data enrichment, ensuring delivery quality and alignment with area guidelines</li>
+                        <li>Continuous interface with key areas (IT, Products, Analytics, Marketing, Stores, and Commercial), promoting alignment between CRM initiatives and corporate objectives</li>
+                        <li>Technical and operational management of tools such as Oracle Responsys, Databricks, and Power BI, enabling automated segmentations, data processing, and performance dashboards</li>
+                        <li>Monitoring and analysis of KPIs and campaign indicators, using data to guide decisions, validate hypotheses, and promote continuous improvement</li>
+                        <li>Leadership of strategic projects and initiatives to expand the active customer base and activate new communication channels</li>
+                    </ul>
+                    
+                    <div class="job-title" style="margin-top: 15px; margin-bottom: 8px;">Analytics Specialist</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2020-2021</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for creating dashboards and strategic indicators for areas such as Marketing, CRM, Credit, and Channels, delivering an integrated real-time view to support business decisions</li>
+                        <li>Development of segmented databases and automated reports focused on the CRM team, with a focus on efficiency gains, agility in analyses, and revenue generation through more precise actions</li>
+                        <li>Organization and integration of operational, behavioral, and transactional data, consolidating multiple sources into a reliable base for comprehensive customer lifecycle analyses</li>
+                        <li>Practical use of tools such as SQL, BigQuery, Python, and Power BI for exploratory analyses, routine automations, and development of predictive models applied to the business</li>
+                        <li>Close collaboration with Marketing, Products, Risk, and Operations areas, translating strategic needs into applicable analyses, focusing on action direction and decision-making</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Analytics Specialist</div>
+                            <div class="company">DBC COMPANY (National IT Consulting Company)</div>
+                        </div>
+                        <div class="period">2020-2021</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for supporting the strategic restructuring of the CRM area at client Realize, implementing agile methodologies (Kanban) and defining processes that reduced campaign time-to-market and increased operational efficiency</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Business Intelligence Analyst</div>
+                            <div class="company">GRUPO RBS (National Media Company)</div>
+                        </div>
+                        <div class="period">2019 - 2020</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsible for structuring and analyzing commercial performance, audience, and market behavior data, supporting leadership in strategic decision-making for client Rede Globo</li>
+                        <li>Development of segmentation studies and consumption potential mapping, using data to guide decisions, validate hypotheses, and promote sales and prospecting actions</li>
+                        <li>Creation of real-time analytical reports and dashboards to support business decisions</li>
+                        <li>Direct interface with leadership, translating market data into action plans and growth opportunities</li>
+                        <li>Analysis of KPIs and campaign indicators, using data to guide decisions, validate hypotheses, and promote continuous improvement</li>
+                    </ul>
+                </div>
+            </div>
         </section>
     </div>
-
-    <script src="../assets/js/cv-texts.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            var lang = 'en';
-            initializeBasicContent(lang);
-            renderSkills('skills-strategic', 'strategic', lang);
-            renderSkills('skills-tools', 'tools', lang);
-            renderSkills('skills-emerging', 'emerging', lang);
-            renderExperienceTimeline(lang);
-            renderEducation(lang);
-            renderProjects(lang);
-        });
-    </script>
+    <!-- Dynamic Favicon System -->
+    <script src="../assets/js/dynamic-favicon.js"></script>
 </body>
 </html>

--- a/cv_styles/cv_vivo_style_PT.html
+++ b/cv_styles/cv_vivo_style_PT.html
@@ -4,337 +4,668 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pedro Henrique Marconato - CV (Vivo)</title>
-    <meta name="theme-color" content="#660099">
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Sora:wght@400;600;700;800&display=swap');
-
+        
         :root {
-            /* Vivo Colors — brandbook (docs/vivo_brandbook.md) */
-            --primary-color: #660099;   /* Roxo Vivo — masterbrand */
-            --secondary-color: #44006B; /* Roxo Profundo */
-            --accent-color: #ED0080;    /* Magenta Vivo */
-            --cyan-color: #00B0D6;      /* Ciano — brilho do espectro */
-            --lavender-color: #B98FE0;  /* Lilás — empty dots */
-            --mist-color: #F4ECFA;      /* Névoa lilás — alternating section background */
+            /* Vivo — brand tokens */
+            --primary-color: #660099;
+            --secondary-color: #44006B;
+            --accent-color: #ED0080;
+            --light-accent: #F3E9FB;
             --text-color: #1E1230;
             --border-color: rgba(102, 0, 153, 0.15);
-            --gradient: linear-gradient(135deg, #660099 0%, #44006B 100%);
-            --spectrum: linear-gradient(90deg, #ED0080, #660099);
-            --font-display: 'Sora', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            --background-gradient: linear-gradient(135deg, #660099 0%, #44006B 100%);
+
             --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            --font-display: 'Sora', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+
+            --header-text: #ffffff;
+            --header-text-soft: rgba(255, 255, 255, 0.95);
+            --header-chip-bg: rgba(255, 255, 255, 0.15);
+            --header-chip-border: rgba(255, 255, 255, 0.28);
+
+            --tag-bg: rgba(237, 0, 128, 0.12);
+            --tag-border: rgba(237, 0, 128, 0.28);
         }
-
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-
+        
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
         body {
             font-family: var(--font-body);
             color: var(--text-color);
-            line-height: 1.55;
-            background: #ffffff;
-            font-size: 12px;
+            line-height: 1.6;
+            background: var(--light-accent);
+            min-height: 100vh;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
         }
 
-        .cv-container { max-width: 210mm; margin: 0 auto; background: #ffffff; }
-
-        /* Header — deep purple hero with spectrum accent */
+        /* Main container */
+        .cv-container {
+            max-width: 210mm;
+            margin: 0 auto;
+            background: rgba(255, 255, 255, 1);
+            overflow: hidden;
+            position: relative;
+        }
+        
+        /* Header Section */
         .header {
-            background: linear-gradient(135deg, #660099 0%, #4B0072 55%, #33004F 100%);
-            padding: 34px 40px 38px;
-            text-align: center;
+            background: var(--background-gradient);
+            padding: 50px 50px 55px 50px;
             position: relative;
             overflow: hidden;
         }
-
-        /* Spectrum accent bar — magenta → cyan */
-        .header::after {
-            content: "";
-            position: absolute;
-            left: 0; right: 0; bottom: 0;
-            height: 5px;
-            background: linear-gradient(90deg, #ED0080 0%, #660099 50%, #00B0D6 100%);
+        
+        .header-content {
+            position: relative;
+            z-index: 1;
         }
 
-        .brand-logo { width: 108px; height: 55px; margin: 0 auto 14px; position: relative; z-index: 2; }
-        .brand-logo img { width: 100%; height: 100%; object-fit: contain; filter: brightness(0) invert(1); }
-
+.brand-logo {
+            position: absolute;
+            bottom: 20px;
+            right: 40px;
+            width: 120px;
+            height: auto;
+            opacity: 0.95;
+            filter: brightness(0) invert(1);
+        }
+        
         .header h1 {
             font-family: var(--font-display);
-            font-size: 23px;
+            font-size: 32px;
             font-weight: 700;
-            color: #ffffff;
-            letter-spacing: 0.2px;
-            margin-bottom: 6px;
-            position: relative;
-            z-index: 2;
+            color: var(--header-text);
+            margin-bottom: 8px;
+            letter-spacing: -0.5px;
+            text-transform: uppercase;
         }
 
-        .header h2 {
-            font-size: 12.5px;
+        .header-tagline {
+            font-size: 17px;
             font-weight: 400;
-            color: rgba(255, 255, 255, 0.92);
-            margin-bottom: 16px;
-            position: relative;
-            z-index: 2;
+            color: var(--header-text-soft);
+            margin-top: 22px;
+            margin-bottom: 28px;
+            font-style: italic;
+            letter-spacing: 0.5px;
         }
-
+        
         .contact-info {
             display: flex;
             flex-wrap: wrap;
-            justify-content: center;
-            gap: 8px;
-            position: relative;
-            z-index: 2;
+            gap: 10px;
+            align-items: center;
+            margin-top: 12px;
         }
-
-        .contact-info > span,
-        .contact-info > a {
-            display: inline-block;
-            background: rgba(255, 255, 255, 0.14);
-            border: 1px solid rgba(255, 255, 255, 0.24);
-            color: #ffffff;
-            text-decoration: none;
-            font-size: 10.5px;
+        
+        .contact-item {
+            display: inline-flex;
+            align-items: center;
+            background: var(--header-chip-bg);
+            border-radius: 10px;
+            padding: 8px 14px;
+            color: var(--header-text);
+            font-size: 12.5px;
             font-weight: 500;
-            padding: 5px 12px;
-            border-radius: 20px;
+            border: 1px solid var(--header-chip-border);
         }
-
-        /* Sections — generous whitespace, alternating mist */
-        .section { padding: 24px 40px; }
-        .section:nth-of-type(even) { background: var(--mist-color); }
-
-        .section-title {
-            display: inline-block;
-            font-family: var(--font-display);
-            background: var(--spectrum);
-            color: #ffffff;
+        
+        .contact-item i {
+            margin-right: 6px;
             font-size: 12px;
-            font-weight: 700;
-            letter-spacing: 0.4px;
-            text-transform: uppercase;
-            padding: 6px 14px;
-            border-radius: 8px;
-            margin-bottom: 14px;
         }
-
-        #cv-profile { font-size: 11.5px; line-height: 1.65; }
-
-        /* Skills — purple dot scale */
-        .skills-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; }
-
-        #skills-strategic h3,
-        #skills-tools h3,
-        #skills-emerging h3 {
-            font-family: var(--font-display) !important;
-            font-size: 11.5px !important;
-            font-weight: 700 !important;
-            color: var(--secondary-color) !important;
-            text-transform: uppercase;
-            letter-spacing: 0.3px;
-            padding-bottom: 6px;
-            margin-bottom: 10px !important;
+        
+        /* Section Styles */
+        .section {
+            padding: 25px 50px;
             border-bottom: 1px solid var(--border-color);
         }
 
-        .tool-item { margin-bottom: 8px; }
-        .tool-name { display: flex; justify-content: space-between; align-items: baseline; font-size: 10.8px; font-weight: 500; }
-        .tool-percentage { color: var(--accent-color); font-size: 9px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.2px; }
-        .dots-container { display: flex; gap: 3px; margin-top: 3px; }
-        .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--lavender-color); }
-        .dot.filled { background: var(--primary-color); }
+        .section:last-child {
+            border-bottom: none;
+        }
 
-        /* Experience — clean cards, soft shadow */
-        .experience-item {
-            background: #ffffff;
-            border-left: 3px solid var(--accent-color);
-            border-radius: 0 10px 10px 0;
-            padding: 14px 18px;
+        .section-title {
+            font-family: var(--font-display);
+            background: var(--primary-color);
+            color: white;
+            font-size: 15px;
+            font-weight: 600;
+            margin-bottom: 18px;
+            padding: 8px 16px;
+            border-radius: 12px;
+            letter-spacing: 0.3px;
+            display: inline-block;
+            text-transform: uppercase;
+        }
+
+        /* Resumo de Qualificações */
+        .qualifications-list {
+            list-style: none;
+            padding: 0;
+        }
+
+        .qualifications-list li {
+            position: relative;
+            padding-left: 28px;
             margin-bottom: 14px;
-            box-shadow: 0 2px 10px rgba(102, 0, 153, 0.07);
+            font-size: 13.5px;
+            line-height: 1.7;
+            color: var(--text-color);
+        }
+
+        .qualifications-list li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+            font-size: 20px;
+            top: -2px;
+        }
+        
+        /* Skills & Tools Grid */
+        .skills-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 20px;
+        }
+
+        .skills-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 16px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
+        }
+
+        .skills-section h3 {
+            font-size: 12px;
+            color: var(--primary-color);
+            margin-bottom: 10px;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .skill-items {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
+
+        .skill-tag {
+            background: var(--tag-bg);
+            color: var(--primary-color);
+            padding: 4px 10px;
+            border-radius: 12px;
+            font-size: 10.5px;
+            font-weight: 500;
+            border: 1px solid var(--tag-border);
+        }
+
+        /* Cursos Complementares */
+        .courses-section {
+            margin-top: 10px;
+        }
+
+        .course-item {
+            padding: 8px 0;
+            border-bottom: 1px solid var(--border-color);
+            font-size: 11px;
+        }
+
+        .course-item:last-child {
+            border-bottom: none;
+        }
+
+        .course-name {
+            color: var(--text-color);
+            font-weight: 500;
+            display: block;
+            margin-bottom: 2px;
+        }
+
+        .course-info {
+            color: var(--secondary-color);
+            font-size: 10px;
+            font-style: italic;
+        }
+        
+        /* Experience Timeline */
+        .experience-timeline {
+            position: relative;
+            margin-left: 20px;
+            padding-left: 30px;
+        }
+        
+        .experience-timeline::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            top: 0;
+            bottom: 0;
+            width: 3px;
+            background: var(--primary-color);
+            border-radius: 3px;
+        }
+        
+        .experience-item {
+            margin-bottom: 25px;
+            position: relative;
+            padding: 18px;
+            border-radius: 14px;
+            background: #fff;
+            border: 1px solid var(--border-color);
+        }
+        
+        .experience-item::before {
+            content: "";
+            position: absolute;
+            left: -36px;
+            top: 25px;
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background: var(--accent-color);
+            border: 3px solid white;
+        }
+        
+        .job-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-bottom: 10px;
         }
 
         .job-title {
-            display: flex;
-            align-items: center;
-            gap: 8px;
             font-family: var(--font-display);
-            font-size: 13.5px;
-            font-weight: 700;
-            color: var(--secondary-color);
+            font-weight: 600;
+            font-size: 16px;
+            color: var(--primary-color);
             margin-bottom: 4px;
         }
-
-        .job-number {
-            flex-shrink: 0;
-            width: 20px;
-            height: 20px;
-            border-radius: 50%;
-            background: var(--primary-color);
-            color: #ffffff;
-            font-family: var(--font-body);
-            font-size: 10.5px;
-            font-weight: 700;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .company { font-weight: 600; font-size: 11.5px; color: var(--text-color); }
-        .period { font-size: 10.5px; color: var(--accent-color); font-weight: 600; margin-bottom: 6px; }
-        .job-description { font-size: 11px; line-height: 1.55; margin-bottom: 8px; color: var(--text-color); }
-
-        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 8px 16px; }
-        .achievement-item { display: flex; gap: 7px; align-items: flex-start; font-size: 10.3px; }
-        .achievement-icon { flex-shrink: 0; width: 15px; text-align: center; color: var(--accent-color); padding-top: 1px; }
-        .achievement-title { font-weight: 600; color: var(--text-color); }
-        .achievement-description { color: #4a4a4a; line-height: 1.4; }
-        .tooltip { display: none; }
-
-        /* Education */
-        .education-item {
-            background: #ffffff;
-            border-left: 3px solid var(--secondary-color);
-            border-radius: 0 10px 10px 0;
-            padding: 10px 16px;
-            margin-bottom: 10px;
-        }
-        .degree { font-family: var(--font-display); font-weight: 700; font-size: 12px; color: var(--secondary-color); margin-bottom: 2px; }
-        .university { font-size: 11px; margin-bottom: 2px; }
-        .thesis { font-size: 10px; color: #555555; font-style: italic; }
-        .cta-button { display: none; }
-
-        /* Projects */
-        .project-item {
-            background: #ffffff;
-            border-left: 3px solid var(--accent-color);
-            border-radius: 0 10px 10px 0;
-            padding: 12px 16px;
-            margin-bottom: 10px;
-        }
-        .project-title { font-family: var(--font-display); font-weight: 700; font-size: 12px; color: var(--secondary-color); margin-bottom: 4px; }
-        .project-description { font-size: 11px; line-height: 1.5; margin-bottom: 6px; }
-        .tech-tag {
-            display: inline-block;
-            padding: 2px 9px;
-            margin: 3px 4px 0 0;
-            border: 1px solid var(--accent-color);
-            color: var(--secondary-color);
-            border-radius: 10px;
-            font-size: 9px;
+        
+        .company {
             font-weight: 500;
+            font-size: 13px;
+            color: var(--secondary-color);
+        }
+        
+        .period {
+            font-size: 12px;
+            color: var(--secondary-color);
+            font-weight: 600;
+            text-align: right;
+        }
+        
+        .job-description {
+            font-size: 12px;
+            line-height: 1.6;
+            color: var(--text-color);
+            margin-bottom: 12px;
         }
 
-        @media print {
-            body { margin: 0; padding: 0; -webkit-print-color-adjust: exact !important; print-color-adjust: exact !important; }
-            .cv-container { max-width: 100%; margin: 0; }
+        .job-bullets {
+            list-style: none;
+            padding: 0;
+        }
 
-            .header {
+        .job-bullets li {
+            position: relative;
+            padding-left: 20px;
+            margin-bottom: 8px;
+            font-size: 12px;
+            line-height: 1.5;
+            color: var(--text-color);
+        }
+
+        .job-bullets li::before {
+            content: '"';
+            position: absolute;
+            left: 0;
+            color: var(--accent-color);
+            font-weight: bold;
+        }
+        
+        /* Education */
+        .education-tech-container {
+            display: grid;
+            grid-template-columns: 1fr 2fr;
+            gap: 25px;
+        }
+        
+        .education-section {
+            background: rgba(245, 241, 235, 0.7);
+            padding: 20px;
+            border-radius: 14px;
+            border: 1px solid var(--border-color);
+        }
+
+        .education-item {
+            margin-bottom: 12px;
+            padding-bottom: 12px;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .education-item:last-child {
+            margin-bottom: 0;
+            padding-bottom: 0;
+            border-bottom: none;
+        }
+        
+        .degree {
+            font-family: var(--font-display);
+            font-weight: 600;
+            font-size: 13px;
+            color: var(--primary-color);
+            margin-bottom: 3px;
+        }
+        
+        .university {
+            font-size: 11px;
+            color: var(--text-color);
+            margin-bottom: 2px;
+        }
+        
+        .edu-period {
+            font-size: 10px;
+            color: var(--secondary-color);
+            font-style: italic;
+        }
+
+        .tech-skills-container {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 15px;
+        }
+
+        /* Languages */
+        .language-container {
+            display: flex;
+            justify-content: center;
+            gap: 30px;
+        }
+
+        .language-item {
+            text-align: center;
+        }
+
+        .language-name {
+            font-weight: 600;
+            color: var(--primary-color);
+            font-size: 13px;
+            margin-bottom: 2px;
+        }
+
+        .language-level {
+            font-size: 11px;
+            color: var(--text-color);
+        }
+
+        /* Print Styles */
+        @media print {
+            body {
+                background: white;
+                margin: 0;
+                padding: 0;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
-                padding: 22px 30px 26px !important;
+            }
+
+            .cv-container {
+                max-width: 100%;
+                margin: 0;
+                box-shadow: none;
+            }
+
+            .header {
+                background: var(--background-gradient) !important;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+                padding: 25px 35px !important;
                 page-break-after: avoid;
             }
 
-            .header::after {
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
-            }
-
             .section-title {
+                background: var(--primary-color) !important;
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
+                color: white !important;
+                page-break-after: avoid;
             }
 
-            .section:nth-of-type(even) {
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
+            .section {
+                padding: 15px 35px;
+                page-break-inside: avoid;
             }
 
-            .section { padding: 14px 30px !important; page-break-inside: avoid; }
-            .experience-item, .education-item, .project-item { page-break-inside: avoid; }
+            .experience-item {
+                page-break-inside: avoid;
+            }
 
-            .header h1 { font-size: 19px !important; }
-            .header h2 { font-size: 11px !important; }
-            .brand-logo { width: 80px !important; height: 44px !important; margin-bottom: 10px !important; }
-            .contact-info > span, .contact-info > a { font-size: 8.5px !important; padding: 3px 8px !important; }
-            .section-title { font-size: 10.5px !important; padding: 4px 11px !important; margin-bottom: 10px !important; }
+            /* Hide animations */
+            * {
+                animation: none !important;
+            }
 
-            .job-title { font-size: 11.5px !important; }
-            .job-number { width: 16px !important; height: 16px !important; font-size: 9px !important; }
-            .job-description, .achievement-item { font-size: 9px !important; }
-            .company, .period { font-size: 9.5px !important; }
-            .experience-item { padding: 10px 14px !important; margin-bottom: 10px !important; }
-            .education-item, .project-item { padding: 8px 14px !important; margin-bottom: 8px !important; }
-            .degree, .project-title { font-size: 10.5px !important; }
-            .university, .project-description { font-size: 9.5px !important; }
-            .thesis { font-size: 8.5px !important; }
-            .tool-name { font-size: 9.5px !important; }
-            .tool-percentage { font-size: 8px !important; }
-            #skills-strategic h3, #skills-tools h3, #skills-emerging h3 { font-size: 10px !important; }
-
-            @page { size: A4; margin: 8mm; }
+            @page {
+                size: A4;
+                margin: 8mm;
+            }
         }
+        .contact-info { max-width: calc(100% - 180px); }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <!-- Favicon Meta Tags -->
+    <meta name="theme-color" content="#660099">
+    <meta name="msapplication-TileColor" content="#660099">
+    <meta name="msapplication-config" content="../assets/favicons/browserconfig.xml">
 </head>
 <body>
     <div class="cv-container">
         <header class="header">
-            <div class="brand-logo">
-                <img src="../assets/images/vivo.webp" alt="Vivo">
-            </div>
-            <h1 id="cv-name">PEDRO HENRIQUE LIMA MARCONATO</h1>
-            <h2 id="cv-role">Gestão de CRM e Inteligência de Dados</h2>
-            <div class="contact-info">
-                <span id="cv-email">pedrohmarconato@gmail.com</span>
-                <span id="cv-phone">+55 (55) 981147758</span>
-                <span id="cv-location"><span>Cachoeira do Sul, RS</span></span>
-                <a href="https://linkedin.com/in/pedrohmarconato" id="cv-linkedin">LinkedIn</a>
+            <div class="header-content">
+                <img src="../assets/images/vivo.webp" alt="Vivo" class="brand-logo">
+                <h1>PEDRO HENRIQUE MARCONATO</h1>
+                
+                <div class="header-tagline">CRM | ANALYTICS | BUSINESS INTELLIGENCE | LTV | SQL</div>
+                
+                <div class="contact-info">
+                    <div class="contact-item">
+                        <i class="fas fa-map-marker-alt"></i> Brasileiro, Casado, 35 anos
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-phone"></i> +55 (55) 98114-7758
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fas fa-envelope"></i> pedrohmarconato@gmail.com
+                    </div>
+                    
+                    <div class="contact-item">
+                        <i class="fab fa-linkedin"></i> linkedin.com/in/pedrohmarconato
+                    </div>
+                </div>
             </div>
         </header>
-
-        <section class="section">
-            <h2 class="section-title" id="section-profile">Perfil Profissional</h2>
-            <p id="cv-profile"></p>
+        
+        <section class="section" style="padding-top: 35px;">
+            <h2 class="section-title">RESUMO DE QUALIFICAÇÕES</h2>
+            <ul class="qualifications-list">
+                <li>Mestre em Administração de Empresas, com ênfase na área de Analytics, unindo inteligência de dados, CRM, visualização analítica e automação para gerar valor ao negócio</li>
+                <li>Atuação em empresas de grande porte e alta complexidade, como Grupo RBS, Realize CFI (Grupo Lojas Renner S.A.) e Rede Globo, liderando projetos estratégicos nas frentes de CRM, inteligência comercial e performance de marketing</li>
+                <li>Vivência com dados aplicados a marketing, canais, crédito, controle e operações, conectando áreas e traduzindo necessidades técnicas em soluções analíticas de alto impacto</li>
+                <li>Destaques em projetos de visualização, segmentação e comportamento de consumo, com domínio de ferramentas como Databricks, SQL, Responsys, Power BI, Python, Salesforce, Mailchimp, Tableau, SAS, Mix Agents e Kanbanize</li>
+                <li>Conhecimento em metodologias ágeis (Scrum, Kanban), com atuação na priorização de backlog, estruturação de squads e aceleração de entrega com foco no cliente</li>
+                <li>Experiência com integração de dados de múltiplas fontes, construção de pipelines, análises preditivas e mapeamento de comportamento para suportar decisões estratégicas</li>
+                <li>Diferencial na combinação entre capacidade analítica, pensamento estratégico e conhecimento técnico, com atuação reconhecida como liderança mesmo em estruturas consultivas</li>
+                <li>Gestão de pessoas, liderando times multidisciplinares com foco em desenvolvimento, autonomia e geração de resultados consistentes</li>
+            </ul>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-skills">Habilidades & Ferramentas</h2>
-            <div class="skills-grid">
-                <div id="skills-strategic"></div>
-                <div id="skills-tools"></div>
-                <div id="skills-emerging"></div>
+            <h2 class="section-title">FORMAÇÃO ACADÊMICA & TECNOLOGIA</h2>
+            <div class="education-tech-container">
+                <div class="education-section">
+                    <h3 style="font-size: 12px; color: var(--primary-color); margin-bottom: 12px; font-weight: 600;">FORMAÇÃO</h3>
+                    <div class="education-item">
+                        <div class="degree">Mestrado em Administração de Empresas</div>
+                        <div class="university">Universidade Federal de Santa Maria - UFSM</div>
+                        <div class="edu-period">Conclusão: 2019</div>
+                    </div>
+                    
+                    <div class="education-item">
+                        <div class="degree">Bacharelado em Administração</div>
+                        <div class="university">Universidade Federal de Santa Maria - UFSM</div>
+                        <div class="edu-period">Conclusão: 2015</div>
+                    </div>
+                </div>
+                
+                <div class="tech-skills-container">
+                    <div class="skills-section">
+                        <h3>FERRAMENTAS & PLATAFORMAS</h3>
+                        <div class="skill-items">
+                            <span class="skill-tag">Databricks</span>
+                            <span class="skill-tag">SQL</span>
+                            <span class="skill-tag">Power BI</span>
+                            <span class="skill-tag">Python</span>
+                            <span class="skill-tag">Oracle Responsys</span>
+                            <span class="skill-tag">Kanbanize</span>
+                            <span class="skill-tag">Mailchimp</span>
+                            <span class="skill-tag">Mix Agents</span>
+                            <span class="skill-tag">SAS</span>
+                            <span class="skill-tag">Tableau</span>
+                            <span class="skill-tag">Salesforce CRM</span>
+                        </div>
+                    </div>
+                    
+                    <div class="skills-section">
+                        <h3>CERTIFICAÇÕES & CURSOS</h3>
+                        <div class="courses-section">
+                            <div class="course-item">
+                                <span class="course-name">Statement of Accomplishment - Intermediate R Course</span>
+                                <span class="course-info">Marketing Analytics In Practice - Coursera</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Marketing Analytics em R</span>
+                                <span class="course-info">PPGA - Programa de Pós-Graduação em Administração</span>
+                            </div>
+                            <div class="course-item">
+                                <span class="course-name">Fundamentos de Solução de Problemas</span>
+                                <span class="course-info">Marketing in a Digital World - Illinois University</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </section>
-
+        
         <section class="section">
-            <h2 class="section-title" id="section-experience">Experiência Profissional</h2>
-            <div id="experience-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-education">Formação Acadêmica</h2>
-            <div id="education-container"></div>
-        </section>
-
-        <section class="section">
-            <h2 class="section-title" id="section-projects">Projetos & Inovação</h2>
-            <div id="projects-container"></div>
+            <h2 class="section-title">EXPERIÊNCIA PROFISSIONAL</h2>
+            
+            <div class="experience-timeline">
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">CADASTRA (Agência de Marketing Digital e Performance)</div>
+                        </div>
+                        <div class="period">2025-Atual</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">Coordenador de Data Analytics</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">Set/2025-Atual</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável pela operação de Data Analytics e AI para clientes de grande porte dos setores de tecnologia, varejo e educação, liderando time multidisciplinar (DataViz, Engenharia de Dados, Web Analytics)</li>
+                        <li>Gestão simultânea de contas estratégicas, com interface direta com stakeholders C-level e áreas de negócio (Performance, E-commerce, Comercial)</li>
+                        <li>Definição de arquitetura de dados e governança para projetos de Business Intelligence, Real-Time Analytics e aplicações de inteligência artificial</li>
+                        <li>Diagnóstico técnico e reestruturação de ambientes de dados legados, incluindo migração de infraestrutura (AWS→GCP) com redução projetada de 40% em custos de processamento</li>
+                        <li>Reestruturação de operações de dados com expansão de time (+67%) e ampliação de escopo para múltiplas unidades de negócio em LATAM</li>
+                        <li>Estabilização de ambientes críticos de dados, alcançando economia de 20% em custos operacionais de processamento (Airflow/DAGs)</li>
+                        <li>Desenvolvimento de automações com n8n e AI Agents (LLMs), incluindo Status Report automatizado com geração de resumos executivos por inteligência artificial</li>
+                        <li>Liderança das primeiras iniciativas de aplicação de IA generativa em operações de clientes, posicionando a área como referência em inovação</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="company">LOJAS RENNER | REALIZE CFI (Empresa Nacional do segmento Financeiro)</div>
+                        </div>
+                        <div class="period">2020-2025</div>
+                    </div>
+                    
+                    <div class="job-title" style="margin-top: 10px; margin-bottom: 8px;">CRM Manager</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2021-2025</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável pela liderança da frente estratégica de CRM, com foco na evolução da área, crescimento da base de clientes e geração de valor ao negócio</li>
+                        <li>Definição e acompanhamento dos OKRs da área, conectando metas do negócio a indicadores de relacionamento</li>
+                        <li>Planejamento, execução e otimização de campanhas de relacionamento multicanal (e-mail, SMS, push, entre outros), aplicando segmentações inteligentes e automações para aumentar frequência de uso e vendas</li>
+                        <li>Construção de jornadas personalizadas com base em comportamento e perfil dos clientes, promovendo a evolução do ciclo de vida e fidelização em produtos financeiros (cartões, empréstimos, seguros e consumo no ecossistema Renner)</li>
+                        <li>Gestão do ritmo de gestão ágil (daily, planning, reviews e retrospectives), utilizando frameworks como Scrum e Kanban para manter ritmo de entrega, visibilidade de prioridades e foco em impacto</li>
+                        <li>Gestão do backlog da área, com mapeamento, priorização e organização das demandas de acordo com o valor incremental e alinhamento com o time comercial</li>
+                        <li>Gestão estratégica de fornecedores e parceiros de tecnologia, incluindo plataformas de CRM, automação e enriquecimento de dados, garantindo qualidade das entregas e alinhamento às diretrizes da área</li>
+                        <li>Interface contínua com áreas-chave (TI, Produtos, Analytics, Marketing, Lojas e Comercial), promovendo alinhamento entre as iniciativas de CRM e os objetivos corporativos</li>
+                        <li>Gestão técnica e operacional de ferramentas como Oracle Responsys, Databricks e Power BI, viabilizando segmentações automatizadas, tratamento de dados e dashboards de performance</li>
+                        <li>Monitoramento e análise de KPIs e indicadores de campanhas, utilizando dados para orientar decisões, validar hipóteses e promover a melhoria contínua</li>
+                        <li>Liderança de projetos e iniciativas estratégicas de expansão da base ativa de clientes e ativação de novos canais de comunicação</li>
+                    </ul>
+                    
+                    <div class="job-title" style="margin-top: 15px; margin-bottom: 8px;">Especialista de Analytics</div>
+                    <div class="period" style="font-size: 11px; color: var(--secondary-color); margin-bottom: 10px;">2020-2021</div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável por criar dashboards e indicadores estratégicos para áreas como Marketing, CRM, Crédito e Canais, entregando uma visão integrada e em tempo real para apoiar decisões de negócio</li>
+                        <li>Desenvolvimento de bases segmentadas e relatórios automatizados voltados ao time de CRM, com foco em ganho de eficiência, agilidade nas análises e geração de receita por meio de ações mais precisas</li>
+                        <li>Organização e integração de dados operacionais, comportamentais e transacionais, consolidando múltiplas fontes em uma base confiável para análises completas do ciclo de vida do cliente</li>
+                        <li>Utilização prática de ferramentas como SQL, BigQuery, Python e Power BI para análises exploratórias, automações de rotinas e desenvolvimento de modelos preditivos aplicados ao negócio</li>
+                        <li>Atuação próxima às áreas de Marketing, Produtos, Riscos e Operações, traduzindo necessidades estratégicas em análises aplicáveis, com foco em direcionamento de ações e tomada de decisão</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Especialista de Analytics</div>
+                            <div class="company">DBC COMPANY (Empresa Nacional do segmento de Consultoria em TI)</div>
+                        </div>
+                        <div class="period">2020-2021</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável por apoiar a reestruturação estratégica da área de CRM no cliente Realize, implementando metodologias ágeis (Kanban) e definindo processos que reduziram o time-to-market das campanhas e aumentaram a eficiência operacional</li>
+                    </ul>
+                </div>
+                
+                <div class="experience-item">
+                    <div class="job-header">
+                        <div>
+                            <div class="job-title">Analista de Inteligência Comercial</div>
+                            <div class="company">GRUPO RBS (Empresa Nacional do segmento de Mídia)</div>
+                        </div>
+                        <div class="period">2019 - 2020</div>
+                    </div>
+                    
+                    <ul class="job-bullets">
+                        <li>Responsável pela estruturação e análise dados de desempenho comercial, audiência e comportamento de mercado, apoiando a liderança na tomada de decisões estratégicas do cliente Rede Globo</li>
+                        <li>Desenvolvimento de estudos de segmentação e mapeamento de potencial de consumo, utilizando dados para orientar decisões, validar hipóteses e promover ações de vendas e prospecção</li>
+                        <li>Criação de relatórios e dashboards analíticos em tempo real para apoiar decisões do negócio</li>
+                        <li>Interface direta com a liderança, traduzindo dados de mercado em planos de ação e oportunidades de crescimento</li>
+                        <li>Análise de KPIs e indicadores de campanhas, utilizando dados para orientar decisões, validar hipóteses e promover a melhoria contínua</li>
+                    </ul>
+                </div>
+            </div>
         </section>
     </div>
-
-    <script src="../assets/js/cv-texts.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            var lang = 'pt';
-            initializeBasicContent(lang);
-            renderSkills('skills-strategic', 'strategic', lang);
-            renderSkills('skills-tools', 'tools', lang);
-            renderSkills('skills-emerging', 'emerging', lang);
-            renderExperienceTimeline(lang);
-            renderEducation(lang);
-            renderProjects(lang);
-        });
-    </script>
+    <!-- Dynamic Favicon System -->
+    <script src="../assets/js/dynamic-favicon.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Problema
Nas 8 marcas mais novas (**accenture, google, grupo-rbs, itau, magalu, mercado-livre, nubank, vivo**), o botão de PDF abria um documento que **espelhava a página** (impressão dinâmica via `cv-texts.js`). O correto é **página ≠ PDF**:

- **Página** = versão web rica/dinâmica (do `cv-texts.js`).
- **PDF** = currículo clássico **estático** de 1 página (RESUMO DE QUALIFICAÇÕES → FORMAÇÃO → EXPERIÊNCIA), branded por empresa — como o do **Boticário** (referência).

As outras 33 empresas já estavam corretas (estáticas); só as 8 últimas ficaram erradas ao serem criadas.

## Correção
- **16 arquivos `cv_styles/`** reconstruídos a partir da base canônica Boticário e **re-brandados** por marca (título, `@import` fontes, `:root` cores/gradiente, `font-family`, logo + tratamento, `theme-color`, chips do header). Conteúdo do currículo idêntico à referência; só a camada de marca muda.
  - **Mercado Livre**: header amarelo (cor icônica) + texto navy → logo natural com alto contraste.
  - **Google**: hero claro / texto escuro / logo 4-cores natural + borda inferior azul.
  - Nubank/Accenture/Vivo/Magalu/Grupo RBS: header escuro + logo em branco (invert); Grupo RBS com nome em serif (Source Serif 4); Itaú com logo em pastilha branca.
- **`create-new-template.py`**: passa a gerar a impressão **estática** (rebranda a base canônica Boticário com defaults: header escuro + cores da marca; logo/fontes especiais entram na *elevação*) em vez da dinâmica — assim **as próximas empresas já saem certas por padrão**.
- **Docs** (`CLAUDE.md`, `REGRAS_PROJETO.md`, `TEMPLATE_PADRAO.md`) alinhados ao modelo **página ≠ PDF**.

## Validação
- `validate-project.py`: **0 erros / 0 avisos**.
- Render headless (Chrome) dos 16: cada um mostra "RESUMO DE QUALIFICAÇÕES"/"PROFESSIONAL SUMMARY", cor e logo corretos, **sem** marcadores dinâmicos.
- QA visual por screenshot de nubank/google/itau/grupo-rbs/mercado-livre/accenture/vivo/magalu.
- Gerador testado end-to-end (empresa descartável) → produz PDF estático branded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)