### PR TITLE
feat: redesign editorial premium do PDF do Lojas Renner (+ correção de conteúdo)

### DIFF
--- a/cv_styles/cv_renner_style_EN.html
+++ b/cv_styles/cv_renner_style_EN.html
@@ -3,758 +3,546 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pedro Marconato - CV</title>
+    <title>Pedro Henrique Marconato — Resume (Lojas Renner)</title>
+    <meta name="theme-color" content="#D2001F">
+    <meta name="msapplication-TileColor" content="#D2001F">
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap');
-        
-        /* Renner Professional CV Styles */
+        @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,500;0,600;0,700;0,800;1,500;1,600&family=Inter:wght@300;400;500;600;700&display=swap');
+
         :root {
-            --renner-red: #D2001F;
-            --renner-dark-red: #B30020;
-            --renner-light-red: #E85A70;
-            --pure-white: #FFFFFF;
-            --light-gray: #F8F8F8;
-            --dark-gray: #333333;
-            --text-color: #333333;
+            --ink: #1A1712;
+            --ink-soft: #4A453D;
+            --gray: #8A8479;
+            --paper: #FBFAF7;
+            --panel: #F4F1EA;
+            --line: #E3DED3;
+            --line-strong: #C9C2B4;
+            --red: #D2001F;
+            --red-deep: #A80019;
+            --font-serif: 'Playfair Display', Georgia, 'Times New Roman', serif;
+            --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
         }
-        
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-        
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
         body {
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            color: var(--text-color);
-            line-height: 1.5;
-            background: white;
-            font-size: 14px;
+            font-family: var(--font-sans);
+            color: var(--ink-soft);
+            background: #EDEAE2;
+            line-height: 1.55;
+            font-size: 12px;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
         }
-        
-        .cv-container {
-            max-width: 800px;
-            margin: 0 auto;
-            background: white;
-            box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
-        }
-        
-        /* Header with Renner branding */
-        .header {
-            background: linear-gradient(135deg, var(--renner-red) 0%, var(--renner-dark-red) 100%);
-            color: white;
-            padding: 40px;
-            text-align: center;
+
+        .sheet {
+            max-width: 210mm;
+            margin: 20px auto;
+            background: var(--paper);
             position: relative;
+            box-shadow: 0 10px 40px rgba(26, 23, 18, 0.14);
         }
-        
-        .header::after {
-            content: '';
+
+        .sheet::before {
+            content: "";
             position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
+            top: 0; left: 0; right: 0;
             height: 4px;
-            background: linear-gradient(90deg, var(--renner-light-red) 0%, var(--renner-red) 50%, var(--renner-dark-red) 100%);
+            background: var(--red);
         }
-        
-        .logo-container {
-            margin-bottom: 20px;
+
+        .pad { padding: 46px 52px 40px; }
+
+        /* ===================== MASTHEAD ===================== */
+        .masthead {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            gap: 28px;
         }
-        
-        .renner-logo {
-            width: 120px;
-            height: auto;
-            filter: brightness(0) invert(1);
-        }
-        
-        .header h1 {
-            font-size: 32px;
+
+        .name {
+            font-family: var(--font-serif);
             font-weight: 800;
-            margin-bottom: 8px;
+            font-size: 39px;
+            line-height: 0.98;
             letter-spacing: -0.5px;
+            color: var(--ink);
         }
-        
+
         .role {
-            font-size: 18px;
-            font-weight: 500;
-            opacity: 0.9;
+            margin-top: 13px;
+            font-size: 10.5px;
+            font-weight: 600;
+            letter-spacing: 3.4px;
             text-transform: uppercase;
-            letter-spacing: 1px;
+            color: var(--gray);
         }
-        
-        .tagline {
-            font-size: 14px;
-            opacity: 0.8;
-            margin-top: 10px;
-            font-style: italic;
-        }
-        
-        /* Contact Information */
-        .contact-info {
-            background: var(--light-gray);
-            padding: 20px 40px;
-            display: flex;
-            justify-content: space-around;
-            flex-wrap: wrap;
-            gap: 20px;
-            border-bottom: 2px solid var(--renner-red);
-        }
-        
-        .contact-item {
-            display: flex;
-            align-items: center;
-            font-size: 13px;
-            color: var(--dark-gray);
-        }
-        
-        .contact-item i {
-            color: var(--renner-red);
-            margin-right: 8px;
-            width: 16px;
-            text-align: center;
-        }
-        
-        /* Sections */
-        .section {
-            padding: 30px 40px;
-            border-bottom: 1px solid #eee;
-        }
-        
-        .section:last-child {
-            border-bottom: none;
-        }
-        
-        .section-title {
-            font-size: 20px;
-            font-weight: 700;
-            color: var(--renner-dark-red);
-            margin-bottom: 20px;
-            padding-bottom: 8px;
-            border-bottom: 3px solid var(--renner-red);
-            position: relative;
-        }
-        
-        .section-title::after {
-            content: '';
-            position: absolute;
-            bottom: -3px;
-            right: 0;
-            width: 30px;
-            height: 3px;
-            background: var(--renner-light-red);
-        }
-        
-        /* Profile Section */
-        .profile-text {
-            font-size: 15px;
-            line-height: 1.7;
-            text-align: justify;
-            color: var(--dark-gray);
-        }
-        
-        /* Skills Section */
-        .skills-grid {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 30px;
-            margin-top: 20px;
-        }
-        
-        .skills-category {
-            background: linear-gradient(135deg, rgba(210, 0, 31, 0.05), rgba(0, 0, 0, 0.02));
-            padding: 20px;
-            border-radius: 8px;
-            border-left: 4px solid var(--renner-red);
-        }
-        
-        .skills-category h3 {
-            font-size: 16px;
-            font-weight: 600;
-            color: var(--renner-dark-red);
-            margin-bottom: 15px;
-        }
-        
-        .skill-item {
-            display: flex;
-            align-items: center;
-            margin-bottom: 10px;
-            font-size: 14px;
-        }
-        
-        .skill-item i {
-            color: var(--renner-red);
-            margin-right: 10px;
-            width: 16px;
-            font-size: 14px;
-        }
-        
-        /* Tool proficiency with progress bars */
-        .tool-item {
-            margin-bottom: 15px;
-        }
-        
-        .tool-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 5px;
-        }
-        
-        .tool-name {
-            font-weight: 500;
-            font-size: 14px;
-        }
-        
-        .tool-percentage {
-            font-size: 12px;
-            color: var(--renner-red);
-            font-weight: 600;
-        }
-        
-        .progress-bar {
-            height: 6px;
-            background: #e0e0e0;
-            border-radius: 3px;
+
+        .brandmark {
+            flex-shrink: 0;
+            width: 208px;
+            height: 34px;
             overflow: hidden;
+            margin-top: 4px;
         }
-        
-        .progress {
-            height: 100%;
-            background: linear-gradient(90deg, var(--renner-dark-red), var(--renner-red));
-            border-radius: 3px;
-            transition: width 0.3s ease;
+        .brandmark img {
+            width: 208px;
+            height: auto;
+            display: block;
         }
-        
-        /* Experience Section */
-        .experience-timeline {
-            position: relative;
-            padding-left: 30px;
+
+        .rule {
+            height: 1px;
+            background: var(--line-strong);
+            margin: 22px 0 0;
         }
-        
-        .experience-timeline::before {
-            content: '';
-            position: absolute;
-            left: 15px;
-            top: 0;
-            bottom: 0;
-            width: 2px;
-            background: var(--renner-red);
-        }
-        
-        .experience-item {
-            position: relative;
-            margin-bottom: 30px;
-            background: white;
-            border: 1px solid #eee;
-            border-radius: 8px;
-            padding: 20px;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
-        }
-        
-        .experience-item::before {
-            content: '';
-            position: absolute;
-            left: -38px;
-            top: 25px;
-            width: 10px;
-            height: 10px;
-            background: var(--renner-red);
-            border: 3px solid white;
-            border-radius: 50%;
-            box-shadow: 0 0 0 2px var(--renner-red);
-        }
-        
-        .job-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: flex-start;
-            margin-bottom: 10px;
-        }
-        
-        .job-title {
-            font-size: 18px;
-            font-weight: 600;
-            color: var(--renner-dark-red);
-            margin-bottom: 5px;
-        }
-        
-        .company {
-            font-size: 16px;
-            color: var(--renner-red);
-            font-weight: 500;
-        }
-        
-        .job-period {
-            background: var(--renner-light-red);
-            color: white;
-            padding: 4px 10px;
-            border-radius: 4px;
-            font-size: 12px;
-            font-weight: 500;
-        }
-        
-        .job-description {
-            font-size: 14px;
-            line-height: 1.6;
-            margin-bottom: 15px;
-            color: var(--dark-gray);
-        }
-        
-        .achievements {
-            display: grid;
-            grid-template-columns: repeat(2, 1fr);
-            gap: 15px;
-        }
-        
-        .achievement {
-            display: flex;
-            align-items: flex-start;
-            gap: 10px;
-            padding: 12px;
-            background: rgba(210, 0, 31, 0.05);
-            border-radius: 6px;
-            border-left: 3px solid var(--renner-red);
-        }
-        
-        .achievement-icon {
-            color: var(--renner-red);
-            margin-top: 2px;
-            font-size: 16px;
-        }
-        
-        .achievement-text {
-            font-size: 13px;
-            line-height: 1.5;
-        }
-        
-        .achievement-title {
-            font-weight: 600;
-            margin-bottom: 3px;
-        }
-        
-        /* Education Section */
-        .education-grid {
-            display: grid;
-            grid-template-columns: repeat(2, 1fr);
-            gap: 20px;
-        }
-        
-        .education-item {
-            background: linear-gradient(135deg, rgba(210, 0, 31, 0.05), rgba(0, 0, 0, 0.02));
-            padding: 20px;
-            border-radius: 8px;
-            border-top: 3px solid var(--renner-red);
-        }
-        
-        .degree {
-            font-size: 16px;
-            font-weight: 600;
-            color: var(--renner-dark-red);
-            margin-bottom: 8px;
-        }
-        
-        .university {
-            font-size: 14px;
-            color: var(--renner-red);
-            font-weight: 500;
-            margin-bottom: 8px;
-        }
-        
-        .thesis {
-            font-size: 13px;
-            color: var(--dark-gray);
-            font-style: italic;
-            line-height: 1.4;
-        }
-        
-        /* Projects Section */
-        .projects-grid {
-            display: grid;
-            grid-template-columns: repeat(2, 1fr);
-            gap: 20px;
-        }
-        
-        .project-item {
-            background: white;
-            border: 1px solid #eee;
-            border-radius: 8px;
-            padding: 20px;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
-            position: relative;
-        }
-        
-        .project-item::before {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            height: 3px;
-            background: linear-gradient(90deg, var(--renner-dark-red), var(--renner-red));
-        }
-        
-        .project-title {
-            font-size: 16px;
-            font-weight: 600;
-            color: var(--renner-dark-red);
-            margin-bottom: 10px;
-        }
-        
-        .project-description {
-            font-size: 14px;
-            line-height: 1.6;
-            color: var(--dark-gray);
-            margin-bottom: 15px;
-        }
-        
-        .tech-tags {
+
+        .contact {
+            margin-top: 12px;
             display: flex;
             flex-wrap: wrap;
-            gap: 6px;
+            gap: 7px 0;
+            font-size: 10.5px;
+            letter-spacing: 0.2px;
+            color: var(--ink-soft);
         }
-        
-        .tech-tag {
-            background: rgba(210, 0, 31, 0.1);
-            color: var(--renner-red);
-            padding: 4px 8px;
-            border-radius: 12px;
-            font-size: 11px;
-            font-weight: 500;
-            border: 1px solid rgba(210, 0, 31, 0.2);
+        .contact span { display: inline-flex; align-items: center; }
+        .contact span::after {
+            content: "";
+            width: 4px; height: 4px;
+            border-radius: 50%;
+            background: var(--red);
+            margin: 0 13px;
         }
-        
-        /* Footer */
-        .footer {
-            background: var(--renner-dark-red);
-            color: white;
-            text-align: center;
-            padding: 20px;
+        .contact span:last-child::after { display: none; }
+        .contact a { color: inherit; text-decoration: none; }
+
+        /* ===================== BODY 2 COLUMNS ===================== */
+        .grid {
+            display: grid;
+            grid-template-columns: 33% 1fr;
+            gap: 0 40px;
+            margin-top: 30px;
+        }
+
+        .rail { position: relative; }
+        .rail::after {
+            content: "";
+            position: absolute;
+            top: 4px; bottom: 4px; right: -20px;
+            width: 1px;
+            background: var(--line);
+        }
+
+        .block { margin-bottom: 26px; }
+        .block:last-child { margin-bottom: 0; }
+
+        .label {
+            display: flex;
+            align-items: center;
+            gap: 11px;
+            font-size: 10px;
+            font-weight: 700;
+            letter-spacing: 2.6px;
+            text-transform: uppercase;
+            color: var(--ink);
+            margin-bottom: 14px;
+        }
+        .label::before {
+            content: "";
+            width: 15px; height: 2px;
+            background: var(--red);
+            flex-shrink: 0;
+        }
+
+        .profile {
             font-size: 12px;
+            line-height: 1.72;
+            color: var(--ink-soft);
         }
-        
-        .footer::before {
-            content: '';
+        .profile strong { color: var(--ink); font-weight: 600; }
+
+        .skill-group { margin-bottom: 15px; }
+        .skill-group:last-child { margin-bottom: 0; }
+        .skill-group h4 {
+            font-size: 9.5px;
+            font-weight: 600;
+            letter-spacing: 1.6px;
+            text-transform: uppercase;
+            color: var(--gray);
+            margin-bottom: 8px;
+        }
+        .chips { display: flex; flex-wrap: wrap; gap: 5px; }
+        .chip {
+            font-size: 9.5px;
+            font-weight: 500;
+            letter-spacing: 0.3px;
+            color: var(--ink);
+            border: 1px solid var(--line-strong);
+            border-radius: 2px;
+            padding: 3px 8px;
+            background: var(--paper);
+        }
+        .chip.key { border-color: var(--red); color: var(--red-deep); }
+
+        /* ---- Highlights (metrics) ---- */
+        .stat { display: flex; align-items: baseline; gap: 12px; padding: 8px 0; border-bottom: 1px solid var(--line); }
+        .stat:first-of-type { padding-top: 0; }
+        .stat:last-child { border-bottom: none; padding-bottom: 0; }
+        .stat .n { font-family: var(--font-serif); font-size: 20px; font-weight: 700; color: var(--red); line-height: 1; min-width: 56px; }
+        .stat .d { font-size: 10px; color: var(--ink-soft); line-height: 1.4; }
+
+        .item { margin-bottom: 12px; }
+        .item:last-child { margin-bottom: 0; }
+        .item .t {
+            font-family: var(--font-serif);
+            font-size: 12.5px;
+            font-weight: 600;
+            color: var(--ink);
+            line-height: 1.25;
+        }
+        .item .s { font-size: 10.5px; color: var(--ink-soft); margin-top: 2px; }
+        .item .m { font-size: 9.5px; color: var(--gray); font-style: italic; letter-spacing: 0.3px; margin-top: 2px; }
+
+        .cert { padding: 9px 0; border-bottom: 1px solid var(--line); }
+        .cert:first-of-type { padding-top: 0; }
+        .cert:last-child { border-bottom: none; padding-bottom: 0; }
+        .cert .t { font-family: var(--font-sans); font-size: 10.5px; font-weight: 600; color: var(--ink); line-height: 1.3; }
+        .cert .s { font-size: 9.5px; color: var(--gray); font-style: italic; margin-top: 2px; }
+
+        .lang-row { display: flex; justify-content: space-between; font-size: 10.5px; padding: 5px 0; border-bottom: 1px solid var(--line); }
+        .lang-row:last-child { border-bottom: none; }
+        .lang-row .l { color: var(--ink); font-weight: 500; }
+        .lang-row .v { color: var(--gray); letter-spacing: 0.4px; }
+
+        /* ===================== EXPERIENCE ===================== */
+        .exp { position: relative; padding-left: 22px; }
+        .exp::before {
+            content: "";
+            position: absolute;
+            left: 3px; top: 6px; bottom: 6px;
+            width: 1.5px;
+            background: var(--line-strong);
+        }
+
+        .job { position: relative; margin-bottom: 22px; }
+        .job:last-child { margin-bottom: 0; }
+        .job::before {
+            content: "";
+            position: absolute;
+            left: -22px; top: 4px;
+            width: 9px; height: 9px;
+            border-radius: 50%;
+            background: var(--paper);
+            border: 2px solid var(--red);
+        }
+
+        .job-top {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            gap: 12px;
+        }
+        .company {
+            font-family: var(--font-serif);
+            font-size: 15.5px;
+            font-weight: 700;
+            color: var(--ink);
+            line-height: 1.15;
+        }
+        .company small {
             display: block;
-            height: 4px;
-            background: linear-gradient(90deg, var(--renner-light-red) 0%, var(--renner-red) 50%, var(--renner-dark-red) 100%);
-            margin-bottom: 15px;
+            font-family: var(--font-sans);
+            font-size: 9.5px;
+            font-weight: 400;
+            color: var(--gray);
+            letter-spacing: 0.2px;
+            margin-top: 1px;
         }
-        
-        /* Print Styles */
+        .dates {
+            flex-shrink: 0;
+            font-size: 9.5px;
+            font-weight: 500;
+            letter-spacing: 0.8px;
+            color: var(--gray);
+            text-transform: uppercase;
+            white-space: nowrap;
+            padding-top: 2px;
+        }
+
+        .stint { margin-top: 9px; }
+        .stint + .stint { margin-top: 12px; }
+        .role-line {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            gap: 10px;
+            margin-bottom: 6px;
+        }
+        .role-title {
+            font-size: 11.5px;
+            font-weight: 700;
+            color: var(--red-deep);
+            letter-spacing: 0.2px;
+        }
+        .role-dates { font-size: 9px; color: var(--gray); letter-spacing: 0.6px; white-space: nowrap; }
+
+        .bullets { list-style: none; }
+        .bullets li {
+            position: relative;
+            padding-left: 15px;
+            margin-bottom: 5px;
+            font-size: 11px;
+            line-height: 1.5;
+            color: var(--ink-soft);
+        }
+        .bullets li:last-child { margin-bottom: 0; }
+        .bullets li::before {
+            content: "";
+            position: absolute;
+            left: 0; top: 8px;
+            width: 6px; height: 1.5px;
+            background: var(--red);
+        }
+
+        .job.renner::before { background: var(--red); }
+
         @media print {
-            body {
-                font-size: 12px;
-                background: white;
-            }
-            
-            .cv-container {
-                box-shadow: none;
-                max-width: none;
-            }
-            
-            .section {
-                page-break-inside: avoid;
-                padding: 20px 30px;
-            }
-            
-            .header {
-                -webkit-print-color-adjust: exact;
-                print-color-adjust: exact;
-            }
-            
-            .skills-grid,
-            .achievements,
-            .education-grid,
-            .projects-grid {
-                grid-template-columns: repeat(2, 1fr);
-            }
-        }
-        
-        /* Mobile Responsiveness */
-        @media (max-width: 768px) {
-            .header {
-                padding: 30px 20px;
-            }
-            
-            .section {
-                padding: 25px 20px;
-            }
-            
-            .contact-info {
-                padding: 15px 20px;
-                flex-direction: column;
-                gap: 10px;
-            }
-            
-            .skills-grid,
-            .achievements,
-            .education-grid,
-            .projects-grid {
-                grid-template-columns: 1fr;
-                gap: 15px;
-            }
-            
-            .job-header {
-                flex-direction: column;
-                gap: 10px;
-            }
-            
-            .experience-timeline {
-                padding-left: 20px;
-            }
-            
-            .experience-item::before {
-                left: -28px;
-            }
+            body { background: #fff; }
+            .sheet { margin: 0; max-width: 100%; box-shadow: none; }
+            .pad { padding: 14mm 15mm 12mm; }
+            .job, .item, .block, .stint { page-break-inside: avoid; }
+            .grid { gap: 0 34px; }
+            * { -webkit-print-color-adjust: exact !important; print-color-adjust: exact !important; }
+            @page { size: A4; margin: 0; }
         }
     </style>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-    <script src="../assets/js/cv-texts.js"></script>
 </head>
 <body>
-    <div class="cv-container">
-        <!-- Header Section -->
-        <header class="header">
-            <div class="logo-container">
-                <img src="../assets/images/lojasrenner.png" alt="Lojas Renner" class="renner-logo">
+    <div class="sheet">
+        <div class="pad">
+
+            <!-- ===== MASTHEAD ===== -->
+            <header class="masthead">
+                <div>
+                    <h1 class="name">Pedro Henrique<br>Marconato</h1>
+                    <div class="role">CRM Management &nbsp;·&nbsp; Data Intelligence</div>
+                </div>
+                <div class="brandmark">
+                    <img src="../assets/images/lojasrenner.png" alt="Lojas Renner S.A.">
+                </div>
+            </header>
+
+            <div class="rule"></div>
+
+            <div class="contact">
+                <span><a href="mailto:pedrohmarconato@gmail.com">pedrohmarconato@gmail.com</a></span>
+                <span>+55 (55) 98114-7758</span>
+                <span>Cachoeira do Sul, Brazil</span>
+                <span><a href="https://linkedin.com/in/pedrohmarconato">linkedin.com/in/pedrohmarconato</a></span>
             </div>
-            <h1 id="cv-name">Pedro Marconato</h1>
-            <div class="role" id="cv-role">Full Stack Developer</div>
-            <div class="tagline">Fashion & Style Excellence</div>
-        </header>
-        
-        <!-- Contact Information -->
-        <div class="contact-info">
-            <div class="contact-item">
-                <i class="fas fa-envelope"></i>
-                <span id="cv-email">pedro@example.com</span>
-            </div>
-            <div class="contact-item">
-                <i class="fas fa-phone"></i>
-                <span id="cv-phone">(11) 99999-9999</span>
-            </div>
-            <div class="contact-item">
-                <i class="fas fa-map-marker-alt"></i>
-                <span id="cv-location">São Paulo, SP</span>
-            </div>
-            <div class="contact-item">
-                <i class="fab fa-linkedin"></i>
-                <span>linkedin.com/in/pedrohmarconato</span>
+
+            <!-- ===== BODY ===== -->
+            <div class="grid">
+
+                <!-- ---------- LEFT RAIL ---------- -->
+                <aside class="rail">
+
+                    <section class="block">
+                        <div class="label">Highlights</div>
+                        <div class="stat"><span class="n">+7 M</span><span class="d">customers under CRM management at Renner</span></div>
+                        <div class="stat"><span class="n">&minus;40%</span><span class="d">processing cost — AWS&rarr;GCP migration</span></div>
+                        <div class="stat"><span class="n">+67%</span><span class="d">data &amp; analytics team expansion</span></div>
+                    </section>
+
+                    <section class="block">
+                        <div class="label">Expertise</div>
+
+                        <div class="skill-group">
+                            <h4>Strategy &amp; CRM</h4>
+                            <div class="chips">
+                                <span class="chip key">CRM Management</span>
+                                <span class="chip key">Customer Equity</span>
+                                <span class="chip">Business Intelligence</span>
+                                <span class="chip">Brand Equity</span>
+                                <span class="chip">Team Leadership</span>
+                                <span class="chip">Customer Lifecycle</span>
+                            </div>
+                        </div>
+
+                        <div class="skill-group">
+                            <h4>Tools &amp; Data</h4>
+                            <div class="chips">
+                                <span class="chip">Databricks</span>
+                                <span class="chip">Oracle Responsys</span>
+                                <span class="chip">Power BI</span>
+                                <span class="chip">Python</span>
+                                <span class="chip">SQL</span>
+                                <span class="chip">Salesforce</span>
+                                <span class="chip">Tableau</span>
+                                <span class="chip">SAS</span>
+                                <span class="chip">Kanbanize</span>
+                                <span class="chip">Mailchimp</span>
+                            </div>
+                        </div>
+
+                        <div class="skill-group">
+                            <h4>Emerging Tech</h4>
+                            <div class="chips">
+                                <span class="chip">LLMs &amp; AI Agents</span>
+                                <span class="chip">AI for CRM</span>
+                                <span class="chip">Machine Learning</span>
+                                <span class="chip">Automation (n8n)</span>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section class="block">
+                        <div class="label">Education</div>
+                        <div class="item">
+                            <div class="t">Master's in Business Administration</div>
+                            <div class="s">Analytics track · UFSM</div>
+                            <div class="m">Completed 2019</div>
+                        </div>
+                        <div class="item">
+                            <div class="t">Bachelor's in Business Administration</div>
+                            <div class="s">Federal University of Santa Maria</div>
+                            <div class="m">Completed 2015</div>
+                        </div>
+                    </section>
+
+                    <section class="block">
+                        <div class="label">Certifications</div>
+                        <div class="cert">
+                            <div class="t">Marketing Analytics in Practice</div>
+                            <div class="s">Coursera · Intermediate R</div>
+                        </div>
+                        <div class="cert">
+                            <div class="t">Marketing Analytics in R</div>
+                            <div class="s">PPGA — Graduate Program in Business Administration</div>
+                        </div>
+                        <div class="cert">
+                            <div class="t">Marketing in a Digital World</div>
+                            <div class="s">University of Illinois</div>
+                        </div>
+                    </section>
+
+                    <section class="block">
+                        <div class="label">Languages</div>
+                        <div class="lang-row"><span class="l">Portuguese</span><span class="v">Native</span></div>
+                        <div class="lang-row"><span class="l">English</span><span class="v">Advanced</span></div>
+                    </section>
+
+                </aside>
+
+                <!-- ---------- RIGHT COLUMN ---------- -->
+                <main class="main">
+
+                    <section class="block">
+                        <div class="label">Profile</div>
+                        <p class="profile">
+                            <strong>Master's in Business Administration with an Analytics track</strong>, combining data
+                            intelligence, CRM, analytical visualization and automation to generate business value.
+                            Experience in large, high-complexity companies — <strong>Lojas Renner / Realize CFI</strong>,
+                            Grupo RBS and Rede Globo — leading strategic fronts in CRM, business intelligence and marketing
+                            performance. I blend analytical capability, strategic thinking and multidisciplinary team
+                            management, with recognized leadership even within consultative structures.
+                        </p>
+                    </section>
+
+                    <section class="block">
+                        <div class="label">Experience</div>
+                        <div class="exp">
+
+                            <div class="job">
+                                <div class="job-top">
+                                    <div class="company">Cadastra<small>Digital Marketing &amp; Performance Agency</small></div>
+                                    <div class="dates">2025 — Present</div>
+                                </div>
+                                <div class="stint">
+                                    <div class="role-line">
+                                        <span class="role-title">Data Analytics Coordinator</span>
+                                        <span class="role-dates">Sep 2025 — Present</span>
+                                    </div>
+                                    <ul class="bullets">
+                                        <li>Leading Data Analytics and AI operations for enterprise clients (technology, retail and education), heading a multidisciplinary team of DataViz, Data Engineering and Web Analytics.</li>
+                                        <li>Management of strategic accounts with direct interface to C-level stakeholders and the Performance, E-commerce and Commercial areas.</li>
+                                        <li>Restructuring of legacy data environments, including AWS→GCP migration with a projected 40% reduction in processing costs.</li>
+                                        <li>Team expansion (+67%) and the first generative-AI initiatives in client operations, with automations built on n8n and AI Agents (LLMs).</li>
+                                    </ul>
+                                </div>
+                            </div>
+
+                            <div class="job renner">
+                                <div class="job-top">
+                                    <div class="company">Lojas Renner &nbsp;·&nbsp; Realize CFI<small>Lojas Renner S.A. Group — Financial Services</small></div>
+                                    <div class="dates">2020 — 2025</div>
+                                </div>
+                                <div class="stint">
+                                    <div class="role-line">
+                                        <span class="role-title">CRM Manager</span>
+                                        <span class="role-dates">2021 — 2025</span>
+                                    </div>
+                                    <ul class="bullets">
+                                        <li>Led the strategic CRM front — area evolution, active-base growth and value generation, with OKRs connecting business goals to relationship indicators.</li>
+                                        <li>Personalized journeys by behavior and profile, driving loyalty across financial products (cards, loans, insurance and consumption in the Renner ecosystem).</li>
+                                        <li>Multichannel campaigns (email, SMS, push) with smart segmentation and automation, managing communication for over 7 million customers.</li>
+                                        <li>Technical management of Oracle Responsys, Databricks and Power BI, enabling automated segmentation and performance dashboards.</li>
+                                        <li>Agile cadence (Scrum/Kanban), backlog management by incremental value and technology-partner management, with continuous interface to IT, Products, Marketing, Stores and Commercial.</li>
+                                    </ul>
+                                </div>
+                                <div class="stint">
+                                    <div class="role-line">
+                                        <span class="role-title">Analytics Specialist</span>
+                                        <span class="role-dates">2020 — 2021</span>
+                                    </div>
+                                    <ul class="bullets">
+                                        <li>Strategic dashboards and indicators for Marketing, CRM, Credit and Channels, with an integrated, real-time view to support decisions.</li>
+                                        <li>Segmented databases and automated reports for the CRM team, driving efficiency gains and revenue through more precise actions.</li>
+                                        <li>SQL, BigQuery, Python and Power BI for exploratory analysis, automation and predictive models applied to the business.</li>
+                                    </ul>
+                                </div>
+                            </div>
+
+                            <div class="job">
+                                <div class="job-top">
+                                    <div class="company">DBC Company<small>National IT Consulting</small></div>
+                                    <div class="dates">2020 — 2021</div>
+                                </div>
+                                <div class="stint">
+                                    <div class="role-line">
+                                        <span class="role-title">Analytics Specialist</span>
+                                    </div>
+                                    <ul class="bullets">
+                                        <li>Supported the strategic restructuring of CRM at client Realize, implementing Kanban and processes that reduced campaign time-to-market and increased operational efficiency.</li>
+                                    </ul>
+                                </div>
+                            </div>
+
+                            <div class="job">
+                                <div class="job-top">
+                                    <div class="company">Grupo RBS<small>Media — serving client Rede Globo</small></div>
+                                    <div class="dates">2019 — 2020</div>
+                                </div>
+                                <div class="stint">
+                                    <div class="role-line">
+                                        <span class="role-title">Business Intelligence Analyst</span>
+                                    </div>
+                                    <ul class="bullets">
+                                        <li>Structured and analyzed commercial performance, audience and market-behavior data, supporting leadership in strategic decision-making.</li>
+                                        <li>Segmentation studies and consumption-potential mapping, with real-time analytical reports and dashboards.</li>
+                                    </ul>
+                                </div>
+                            </div>
+
+                        </div>
+                    </section>
+
+                </main>
             </div>
         </div>
-        
-        <!-- Profile Section -->
-        <section class="section">
-            <h2 class="section-title">Professional Profile</h2>
-            <p class="profile-text" id="cv-profile">
-                Full Stack Developer with extensive experience in modern technologies and agile methodologies. 
-                Specialized in React, Node.js and cloud computing, focused on delivering innovative solutions 
-                that drive business growth in the fashion and retail sector.
-            </p>
-        </section>
-        
-        <!-- Skills Section -->
-        <section class="section">
-            <h2 class="section-title">Technical Skills</h2>
-            <div class="skills-grid">
-                <div class="skills-category">
-                    <h3>Strategic</h3>
-                    <div id="skills-strategic">
-                        <div class="skill-item">
-                            <i class="fas fa-chart-line"></i>
-                            <span>Data Analysis</span>
-                        </div>
-                        <div class="skill-item">
-                            <i class="fas fa-users"></i>
-                            <span>Technical Leadership</span>
-                        </div>
-                        <div class="skill-item">
-                            <i class="fas fa-lightbulb"></i>
-                            <span>Innovation</span>
-                        </div>
-                    </div>
-                </div>
-                
-                <div class="skills-category">
-                    <h3>Tools</h3>
-                    <div id="skills-tools">
-                        <div class="tool-item">
-                            <div class="tool-header">
-                                <span class="tool-name">React/Next.js</span>
-                                <span class="tool-percentage">95%</span>
-                            </div>
-                            <div class="progress-bar">
-                                <div class="progress" style="width: 95%"></div>
-                            </div>
-                        </div>
-                        <div class="tool-item">
-                            <div class="tool-header">
-                                <span class="tool-name">Node.js</span>
-                                <span class="tool-percentage">90%</span>
-                            </div>
-                            <div class="progress-bar">
-                                <div class="progress" style="width: 90%"></div>
-                            </div>
-                        </div>
-                        <div class="tool-item">
-                            <div class="tool-header">
-                                <span class="tool-name">AWS</span>
-                                <span class="tool-percentage">85%</span>
-                            </div>
-                            <div class="progress-bar">
-                                <div class="progress" style="width: 85%"></div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                
-                <div class="skills-category">
-                    <h3>Emerging</h3>
-                    <div id="skills-emerging">
-                        <div class="skill-item">
-                            <i class="fas fa-robot"></i>
-                            <span>AI & Machine Learning</span>
-                        </div>
-                        <div class="skill-item">
-                            <i class="fas fa-cube"></i>
-                            <span>Blockchain</span>
-                        </div>
-                        <div class="skill-item">
-                            <i class="fas fa-mobile-alt"></i>
-                            <span>React Native</span>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </section>
-        
-        <!-- Experience Section -->
-        <section class="section">
-            <h2 class="section-title">Professional Experience</h2>
-            <div class="experience-timeline" id="cv-experience">
-                <!-- Experience items will be populated by JavaScript -->
-            </div>
-        </section>
-        
-        <!-- Education Section -->
-        <section class="section">
-            <h2 class="section-title">Education</h2>
-            <div class="education-grid" id="cv-education">
-                <!-- Education items will be populated by JavaScript -->
-            </div>
-        </section>
-        
-        <!-- Projects Section -->
-        <section class="section">
-            <h2 class="section-title">Featured Projects</h2>
-            <div class="projects-grid" id="cv-projects">
-                <!-- Project items will be populated by JavaScript -->
-            </div>
-        </section>
-        
-        <!-- Footer -->
-        <footer class="footer">
-            <p>This resume was created especially for Lojas Renner, demonstrating passion for innovation in fashion and technology.</p>
-            <p>🤖 Generated with <a href="https://claude.ai/code" style="color: #E85A70;">Claude Code</a></p>
-        </footer>
     </div>
-    
-    <script>
-        // Initialize CV content when page loads
-        document.addEventListener('DOMContentLoaded', function() {
-            // Check if cv-texts.js functions are available
-            if (typeof initializeBasicContent === 'function') {
-                initializeBasicContent('en');
-                
-                // Populate experience section
-                if (typeof getText === 'function') {
-                    renderExperience('en');
-                    renderEducation('en');
-                    renderProjects('en');
-                }
-            }
-        });
-        
-        function renderExperience(lang) {
-            const container = document.getElementById('cv-experience');
-            if (!container || typeof getText !== 'function') return;
-            
-            const experiences = getText('experience', lang);
-            let html = '';
-            
-            experiences.forEach((exp, index) => {
-                html += `
-                    <div class="experience-item">
-                        <div class="job-header">
-                            <div>
-                                <div class="job-title">${exp.title}</div>
-                                <div class="company">${exp.company}</div>
-                            </div>
-                            <div class="job-period">${exp.period}</div>
-                        </div>
-                        <div class="job-description">${exp.description}</div>
-                        <div class="achievements">
-                            ${exp.achievements.map(achievement => `
-                                <div class="achievement">
-                                    <div class="achievement-icon">
-                                        <i class="${achievement.icon}"></i>
-                                    </div>
-                                    <div class="achievement-text">
-                                        <div class="achievement-title">${achievement.title}</div>
-                                        <div>${achievement.description}</div>
-                                    </div>
-                                </div>
-                            `).join('')}
-                        </div>
-                    </div>
-                `;
-            });
-            
-            container.innerHTML = html;
-        }
-        
-        function renderEducation(lang) {
-            const container = document.getElementById('cv-education');
-            if (!container || typeof getText !== 'function') return;
-            
-            const education = getText('education', lang);
-            let html = '';
-            
-            education.forEach(edu => {
-                html += `
-                    <div class="education-item">
-                        <div class="degree">${edu.degree}</div>
-                        <div class="university">${edu.university}</div>
-                        <div class="thesis">${edu.thesis}</div>
-                    </div>
-                `;
-            });
-            
-            container.innerHTML = html;
-        }
-        
-        function renderProjects(lang) {
-            const container = document.getElementById('cv-projects');
-            if (!container || typeof getText !== 'function') return;
-            
-            const projects = getText('projects', lang);
-            let html = '';
-            
-            projects.forEach(project => {
-                html += `
-                    <div class="project-item">
-                        <div class="project-title">${project.title}</div>
-                        <div class="project-description">${project.description}</div>
-                        <div class="tech-tags">
-                            ${project.techs.map(tech => `<span class="tech-tag">${tech}</span>`).join('')}
-                        </div>
-                    </div>
-                `;
-            });
-            
-            container.innerHTML = html;
-        }
-    </script>
+    <script src="../assets/js/dynamic-favicon.js"></script>
 </body>
 </html>

--- a/cv_styles/cv_renner_style_PT.html
+++ b/cv_styles/cv_renner_style_PT.html
@@ -3,758 +3,565 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pedro Marconato - CV</title>
+    <title>Pedro Henrique Marconato — CV (Lojas Renner)</title>
+    <meta name="theme-color" content="#D2001F">
+    <meta name="msapplication-TileColor" content="#D2001F">
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap');
-        
-        /* Renner Professional CV Styles */
+        @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,500;0,600;0,700;0,800;1,500;1,600&family=Inter:wght@300;400;500;600;700&display=swap');
+
         :root {
-            --renner-red: #D2001F;
-            --renner-dark-red: #B30020;
-            --renner-light-red: #E85A70;
-            --pure-white: #FFFFFF;
-            --light-gray: #F8F8F8;
-            --dark-gray: #333333;
-            --text-color: #333333;
+            --ink: #1A1712;          /* preto quente */
+            --ink-soft: #4A453D;     /* corpo */
+            --gray: #8A8479;         /* secundário / datas */
+            --paper: #FBFAF7;        /* creme */
+            --panel: #F4F1EA;        /* painel discreto */
+            --line: #E3DED3;         /* hairline */
+            --line-strong: #C9C2B4;
+            --red: #D2001F;          /* Renner */
+            --red-deep: #A80019;
+            --font-serif: 'Playfair Display', Georgia, 'Times New Roman', serif;
+            --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
         }
-        
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-        
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
         body {
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            color: var(--text-color);
-            line-height: 1.5;
-            background: white;
-            font-size: 14px;
+            font-family: var(--font-sans);
+            color: var(--ink-soft);
+            background: #EDEAE2;
+            line-height: 1.55;
+            font-size: 12px;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
         }
-        
-        .cv-container {
-            max-width: 800px;
-            margin: 0 auto;
-            background: white;
-            box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
-        }
-        
-        /* Header with Renner branding */
-        .header {
-            background: linear-gradient(135deg, var(--renner-red) 0%, var(--renner-dark-red) 100%);
-            color: white;
-            padding: 40px;
-            text-align: center;
+
+        .sheet {
+            max-width: 210mm;
+            margin: 20px auto;
+            background: var(--paper);
             position: relative;
+            box-shadow: 0 10px 40px rgba(26, 23, 18, 0.14);
         }
-        
-        .header::after {
-            content: '';
+
+        /* filete vermelho superior full-bleed */
+        .sheet::before {
+            content: "";
             position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
+            top: 0; left: 0; right: 0;
             height: 4px;
-            background: linear-gradient(90deg, var(--renner-light-red) 0%, var(--renner-red) 50%, var(--renner-dark-red) 100%);
+            background: var(--red);
         }
-        
-        .logo-container {
-            margin-bottom: 20px;
+
+        .pad { padding: 46px 52px 40px; }
+
+        /* ===================== MASTHEAD ===================== */
+        .masthead {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            gap: 28px;
         }
-        
-        .renner-logo {
-            width: 120px;
-            height: auto;
-            filter: brightness(0) invert(1);
-        }
-        
-        .header h1 {
-            font-size: 32px;
+
+        .name {
+            font-family: var(--font-serif);
             font-weight: 800;
-            margin-bottom: 8px;
+            font-size: 39px;
+            line-height: 0.98;
             letter-spacing: -0.5px;
+            color: var(--ink);
         }
-        
+
         .role {
-            font-size: 18px;
-            font-weight: 500;
-            opacity: 0.9;
+            margin-top: 13px;
+            font-size: 10.5px;
+            font-weight: 600;
+            letter-spacing: 3.4px;
             text-transform: uppercase;
-            letter-spacing: 1px;
+            color: var(--gray);
         }
-        
-        .tagline {
-            font-size: 14px;
-            opacity: 0.8;
-            margin-top: 10px;
-            font-style: italic;
-        }
-        
-        /* Contact Information */
-        .contact-info {
-            background: var(--light-gray);
-            padding: 20px 40px;
-            display: flex;
-            justify-content: space-around;
-            flex-wrap: wrap;
-            gap: 20px;
-            border-bottom: 2px solid var(--renner-red);
-        }
-        
-        .contact-item {
-            display: flex;
-            align-items: center;
-            font-size: 13px;
-            color: var(--dark-gray);
-        }
-        
-        .contact-item i {
-            color: var(--renner-red);
-            margin-right: 8px;
-            width: 16px;
-            text-align: center;
-        }
-        
-        /* Sections */
-        .section {
-            padding: 30px 40px;
-            border-bottom: 1px solid #eee;
-        }
-        
-        .section:last-child {
-            border-bottom: none;
-        }
-        
-        .section-title {
-            font-size: 20px;
-            font-weight: 700;
-            color: var(--renner-dark-red);
-            margin-bottom: 20px;
-            padding-bottom: 8px;
-            border-bottom: 3px solid var(--renner-red);
-            position: relative;
-        }
-        
-        .section-title::after {
-            content: '';
-            position: absolute;
-            bottom: -3px;
-            right: 0;
-            width: 30px;
-            height: 3px;
-            background: var(--renner-light-red);
-        }
-        
-        /* Profile Section */
-        .profile-text {
-            font-size: 15px;
-            line-height: 1.7;
-            text-align: justify;
-            color: var(--dark-gray);
-        }
-        
-        /* Skills Section */
-        .skills-grid {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 30px;
-            margin-top: 20px;
-        }
-        
-        .skills-category {
-            background: linear-gradient(135deg, rgba(210, 0, 31, 0.05), rgba(0, 0, 0, 0.02));
-            padding: 20px;
-            border-radius: 8px;
-            border-left: 4px solid var(--renner-red);
-        }
-        
-        .skills-category h3 {
-            font-size: 16px;
-            font-weight: 600;
-            color: var(--renner-dark-red);
-            margin-bottom: 15px;
-        }
-        
-        .skill-item {
-            display: flex;
-            align-items: center;
-            margin-bottom: 10px;
-            font-size: 14px;
-        }
-        
-        .skill-item i {
-            color: var(--renner-red);
-            margin-right: 10px;
-            width: 16px;
-            font-size: 14px;
-        }
-        
-        /* Tool proficiency with progress bars */
-        .tool-item {
-            margin-bottom: 15px;
-        }
-        
-        .tool-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 5px;
-        }
-        
-        .tool-name {
-            font-weight: 500;
-            font-size: 14px;
-        }
-        
-        .tool-percentage {
-            font-size: 12px;
-            color: var(--renner-red);
-            font-weight: 600;
-        }
-        
-        .progress-bar {
-            height: 6px;
-            background: #e0e0e0;
-            border-radius: 3px;
+
+        .brandmark {
+            flex-shrink: 0;
+            width: 208px;
+            height: 34px;
             overflow: hidden;
+            margin-top: 4px;
         }
-        
-        .progress {
-            height: 100%;
-            background: linear-gradient(90deg, var(--renner-dark-red), var(--renner-red));
-            border-radius: 3px;
-            transition: width 0.3s ease;
+        .brandmark img {
+            width: 208px;
+            height: auto;
+            display: block;
         }
-        
-        /* Experience Section */
-        .experience-timeline {
-            position: relative;
-            padding-left: 30px;
+
+        /* linha divisória do masthead */
+        .rule {
+            height: 1px;
+            background: var(--line-strong);
+            margin: 22px 0 0;
         }
-        
-        .experience-timeline::before {
-            content: '';
-            position: absolute;
-            left: 15px;
-            top: 0;
-            bottom: 0;
-            width: 2px;
-            background: var(--renner-red);
-        }
-        
-        .experience-item {
-            position: relative;
-            margin-bottom: 30px;
-            background: white;
-            border: 1px solid #eee;
-            border-radius: 8px;
-            padding: 20px;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
-        }
-        
-        .experience-item::before {
-            content: '';
-            position: absolute;
-            left: -38px;
-            top: 25px;
-            width: 10px;
-            height: 10px;
-            background: var(--renner-red);
-            border: 3px solid white;
-            border-radius: 50%;
-            box-shadow: 0 0 0 2px var(--renner-red);
-        }
-        
-        .job-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: flex-start;
-            margin-bottom: 10px;
-        }
-        
-        .job-title {
-            font-size: 18px;
-            font-weight: 600;
-            color: var(--renner-dark-red);
-            margin-bottom: 5px;
-        }
-        
-        .company {
-            font-size: 16px;
-            color: var(--renner-red);
-            font-weight: 500;
-        }
-        
-        .job-period {
-            background: var(--renner-light-red);
-            color: white;
-            padding: 4px 10px;
-            border-radius: 4px;
-            font-size: 12px;
-            font-weight: 500;
-        }
-        
-        .job-description {
-            font-size: 14px;
-            line-height: 1.6;
-            margin-bottom: 15px;
-            color: var(--dark-gray);
-        }
-        
-        .achievements {
-            display: grid;
-            grid-template-columns: repeat(2, 1fr);
-            gap: 15px;
-        }
-        
-        .achievement {
-            display: flex;
-            align-items: flex-start;
-            gap: 10px;
-            padding: 12px;
-            background: rgba(210, 0, 31, 0.05);
-            border-radius: 6px;
-            border-left: 3px solid var(--renner-red);
-        }
-        
-        .achievement-icon {
-            color: var(--renner-red);
-            margin-top: 2px;
-            font-size: 16px;
-        }
-        
-        .achievement-text {
-            font-size: 13px;
-            line-height: 1.5;
-        }
-        
-        .achievement-title {
-            font-weight: 600;
-            margin-bottom: 3px;
-        }
-        
-        /* Education Section */
-        .education-grid {
-            display: grid;
-            grid-template-columns: repeat(2, 1fr);
-            gap: 20px;
-        }
-        
-        .education-item {
-            background: linear-gradient(135deg, rgba(210, 0, 31, 0.05), rgba(0, 0, 0, 0.02));
-            padding: 20px;
-            border-radius: 8px;
-            border-top: 3px solid var(--renner-red);
-        }
-        
-        .degree {
-            font-size: 16px;
-            font-weight: 600;
-            color: var(--renner-dark-red);
-            margin-bottom: 8px;
-        }
-        
-        .university {
-            font-size: 14px;
-            color: var(--renner-red);
-            font-weight: 500;
-            margin-bottom: 8px;
-        }
-        
-        .thesis {
-            font-size: 13px;
-            color: var(--dark-gray);
-            font-style: italic;
-            line-height: 1.4;
-        }
-        
-        /* Projects Section */
-        .projects-grid {
-            display: grid;
-            grid-template-columns: repeat(2, 1fr);
-            gap: 20px;
-        }
-        
-        .project-item {
-            background: white;
-            border: 1px solid #eee;
-            border-radius: 8px;
-            padding: 20px;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
-            position: relative;
-        }
-        
-        .project-item::before {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            height: 3px;
-            background: linear-gradient(90deg, var(--renner-dark-red), var(--renner-red));
-        }
-        
-        .project-title {
-            font-size: 16px;
-            font-weight: 600;
-            color: var(--renner-dark-red);
-            margin-bottom: 10px;
-        }
-        
-        .project-description {
-            font-size: 14px;
-            line-height: 1.6;
-            color: var(--dark-gray);
-            margin-bottom: 15px;
-        }
-        
-        .tech-tags {
+
+        .contact {
+            margin-top: 12px;
             display: flex;
             flex-wrap: wrap;
-            gap: 6px;
+            gap: 7px 0;
+            font-size: 10.5px;
+            letter-spacing: 0.2px;
+            color: var(--ink-soft);
         }
-        
-        .tech-tag {
-            background: rgba(210, 0, 31, 0.1);
-            color: var(--renner-red);
-            padding: 4px 8px;
-            border-radius: 12px;
-            font-size: 11px;
-            font-weight: 500;
-            border: 1px solid rgba(210, 0, 31, 0.2);
+        .contact span { display: inline-flex; align-items: center; }
+        .contact span::after {
+            content: "";
+            width: 4px; height: 4px;
+            border-radius: 50%;
+            background: var(--red);
+            margin: 0 13px;
         }
-        
-        /* Footer */
-        .footer {
-            background: var(--renner-dark-red);
-            color: white;
-            text-align: center;
-            padding: 20px;
+        .contact span:last-child::after { display: none; }
+        .contact a { color: inherit; text-decoration: none; }
+
+        /* ===================== CORPO 2 COLUNAS ===================== */
+        .grid {
+            display: grid;
+            grid-template-columns: 33% 1fr;
+            gap: 0 40px;
+            margin-top: 30px;
+        }
+
+        .rail { position: relative; }
+        .rail::after {
+            content: "";
+            position: absolute;
+            top: 4px; bottom: 4px; right: -20px;
+            width: 1px;
+            background: var(--line);
+        }
+
+        .block { margin-bottom: 26px; }
+        .block:last-child { margin-bottom: 0; }
+
+        .label {
+            display: flex;
+            align-items: center;
+            gap: 11px;
+            font-size: 10px;
+            font-weight: 700;
+            letter-spacing: 2.6px;
+            text-transform: uppercase;
+            color: var(--ink);
+            margin-bottom: 14px;
+        }
+        .label::before {
+            content: "";
+            width: 15px; height: 2px;
+            background: var(--red);
+            flex-shrink: 0;
+        }
+
+        /* ---- Perfil ---- */
+        .profile {
             font-size: 12px;
+            line-height: 1.72;
+            color: var(--ink-soft);
         }
-        
-        .footer::before {
-            content: '';
+        .profile strong { color: var(--ink); font-weight: 600; }
+
+        /* ---- Competências ---- */
+        .skill-group { margin-bottom: 15px; }
+        .skill-group:last-child { margin-bottom: 0; }
+        .skill-group h4 {
+            font-size: 9.5px;
+            font-weight: 600;
+            letter-spacing: 1.6px;
+            text-transform: uppercase;
+            color: var(--gray);
+            margin-bottom: 8px;
+        }
+        .chips { display: flex; flex-wrap: wrap; gap: 5px; }
+        .chip {
+            font-size: 9.5px;
+            font-weight: 500;
+            letter-spacing: 0.3px;
+            color: var(--ink);
+            border: 1px solid var(--line-strong);
+            border-radius: 2px;
+            padding: 3px 8px;
+            background: var(--paper);
+        }
+        .chip.key { border-color: var(--red); color: var(--red-deep); }
+
+        /* ---- Destaques (métricas) ---- */
+        .stat { display: flex; align-items: baseline; gap: 12px; padding: 8px 0; border-bottom: 1px solid var(--line); }
+        .stat:first-of-type { padding-top: 0; }
+        .stat:last-child { border-bottom: none; padding-bottom: 0; }
+        .stat .n { font-family: var(--font-serif); font-size: 20px; font-weight: 700; color: var(--red); line-height: 1; min-width: 56px; }
+        .stat .d { font-size: 10px; color: var(--ink-soft); line-height: 1.4; }
+
+        /* ---- Formação / Certificações ---- */
+        .item { margin-bottom: 12px; }
+        .item:last-child { margin-bottom: 0; }
+        .item .t {
+            font-family: var(--font-serif);
+            font-size: 12.5px;
+            font-weight: 600;
+            color: var(--ink);
+            line-height: 1.25;
+        }
+        .item .s { font-size: 10.5px; color: var(--ink-soft); margin-top: 2px; }
+        .item .m { font-size: 9.5px; color: var(--gray); font-style: italic; letter-spacing: 0.3px; margin-top: 2px; }
+
+        .cert { padding: 9px 0; border-bottom: 1px solid var(--line); }
+        .cert:first-of-type { padding-top: 0; }
+        .cert:last-child { border-bottom: none; padding-bottom: 0; }
+        .cert .t { font-family: var(--font-sans); font-size: 10.5px; font-weight: 600; color: var(--ink); line-height: 1.3; }
+        .cert .s { font-size: 9.5px; color: var(--gray); font-style: italic; margin-top: 2px; }
+
+        .lang-row { display: flex; justify-content: space-between; font-size: 10.5px; padding: 5px 0; border-bottom: 1px solid var(--line); }
+        .lang-row:last-child { border-bottom: none; }
+        .lang-row .l { color: var(--ink); font-weight: 500; }
+        .lang-row .v { color: var(--gray); letter-spacing: 0.4px; }
+
+        /* ===================== EXPERIÊNCIA ===================== */
+        .exp { position: relative; padding-left: 22px; }
+        .exp::before {
+            content: "";
+            position: absolute;
+            left: 3px; top: 6px; bottom: 6px;
+            width: 1.5px;
+            background: var(--line-strong);
+        }
+
+        .job { position: relative; margin-bottom: 22px; }
+        .job:last-child { margin-bottom: 0; }
+        .job::before {
+            content: "";
+            position: absolute;
+            left: -22px; top: 4px;
+            width: 9px; height: 9px;
+            border-radius: 50%;
+            background: var(--paper);
+            border: 2px solid var(--red);
+        }
+
+        .job-top {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            gap: 12px;
+        }
+        .company {
+            font-family: var(--font-serif);
+            font-size: 15.5px;
+            font-weight: 700;
+            color: var(--ink);
+            line-height: 1.15;
+        }
+        .company small {
             display: block;
-            height: 4px;
-            background: linear-gradient(90deg, var(--renner-light-red) 0%, var(--renner-red) 50%, var(--renner-dark-red) 100%);
-            margin-bottom: 15px;
+            font-family: var(--font-sans);
+            font-size: 9.5px;
+            font-weight: 400;
+            color: var(--gray);
+            letter-spacing: 0.2px;
+            margin-top: 1px;
         }
-        
-        /* Print Styles */
+        .dates {
+            flex-shrink: 0;
+            font-size: 9.5px;
+            font-weight: 500;
+            letter-spacing: 0.8px;
+            color: var(--gray);
+            text-transform: uppercase;
+            white-space: nowrap;
+            padding-top: 2px;
+        }
+
+        .stint { margin-top: 9px; }
+        .stint + .stint { margin-top: 12px; }
+        .role-line {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            gap: 10px;
+            margin-bottom: 6px;
+        }
+        .role-title {
+            font-size: 11.5px;
+            font-weight: 700;
+            color: var(--red-deep);
+            letter-spacing: 0.2px;
+        }
+        .role-dates { font-size: 9px; color: var(--gray); letter-spacing: 0.6px; white-space: nowrap; }
+
+        .bullets { list-style: none; }
+        .bullets li {
+            position: relative;
+            padding-left: 15px;
+            margin-bottom: 5px;
+            font-size: 11px;
+            line-height: 1.5;
+            color: var(--ink-soft);
+        }
+        .bullets li:last-child { margin-bottom: 0; }
+        .bullets li::before {
+            content: "";
+            position: absolute;
+            left: 0; top: 8px;
+            width: 6px; height: 1.5px;
+            background: var(--red);
+        }
+
+        .job.renner::before { background: var(--red); }
+        .flag {
+            display: inline-block;
+            font-size: 8px;
+            font-weight: 700;
+            letter-spacing: 1px;
+            text-transform: uppercase;
+            color: #fff;
+            background: var(--red);
+            padding: 2px 6px;
+            border-radius: 2px;
+            margin-left: 8px;
+            vertical-align: middle;
+        }
+
+        /* ===================== IMPRESSÃO ===================== */
         @media print {
-            body {
-                font-size: 12px;
-                background: white;
-            }
-            
-            .cv-container {
-                box-shadow: none;
-                max-width: none;
-            }
-            
-            .section {
-                page-break-inside: avoid;
-                padding: 20px 30px;
-            }
-            
-            .header {
-                -webkit-print-color-adjust: exact;
-                print-color-adjust: exact;
-            }
-            
-            .skills-grid,
-            .achievements,
-            .education-grid,
-            .projects-grid {
-                grid-template-columns: repeat(2, 1fr);
-            }
-        }
-        
-        /* Mobile Responsiveness */
-        @media (max-width: 768px) {
-            .header {
-                padding: 30px 20px;
-            }
-            
-            .section {
-                padding: 25px 20px;
-            }
-            
-            .contact-info {
-                padding: 15px 20px;
-                flex-direction: column;
-                gap: 10px;
-            }
-            
-            .skills-grid,
-            .achievements,
-            .education-grid,
-            .projects-grid {
-                grid-template-columns: 1fr;
-                gap: 15px;
-            }
-            
-            .job-header {
-                flex-direction: column;
-                gap: 10px;
-            }
-            
-            .experience-timeline {
-                padding-left: 20px;
-            }
-            
-            .experience-item::before {
-                left: -28px;
-            }
+            body { background: #fff; }
+            .sheet { margin: 0; max-width: 100%; box-shadow: none; }
+            .pad { padding: 14mm 15mm 12mm; }
+            .job, .item, .block, .stint { page-break-inside: avoid; }
+            .grid { gap: 0 34px; }
+            * { -webkit-print-color-adjust: exact !important; print-color-adjust: exact !important; }
+            @page { size: A4; margin: 0; }
         }
     </style>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-    <script src="../assets/js/cv-texts.js"></script>
 </head>
 <body>
-    <div class="cv-container">
-        <!-- Header Section -->
-        <header class="header">
-            <div class="logo-container">
-                <img src="../assets/images/lojasrenner.png" alt="Lojas Renner" class="renner-logo">
+    <div class="sheet">
+        <div class="pad">
+
+            <!-- ===== MASTHEAD ===== -->
+            <header class="masthead">
+                <div>
+                    <h1 class="name">Pedro Henrique<br>Marconato</h1>
+                    <div class="role">Gestão de CRM &nbsp;·&nbsp; Inteligência de Dados</div>
+                </div>
+                <div class="brandmark">
+                    <img src="../assets/images/lojasrenner.png" alt="Lojas Renner S.A.">
+                </div>
+            </header>
+
+            <div class="rule"></div>
+
+            <div class="contact">
+                <span><a href="mailto:pedrohmarconato@gmail.com">pedrohmarconato@gmail.com</a></span>
+                <span>+55 (55) 98114-7758</span>
+                <span>Cachoeira do Sul, RS</span>
+                <span><a href="https://linkedin.com/in/pedrohmarconato">linkedin.com/in/pedrohmarconato</a></span>
             </div>
-            <h1 id="cv-name">Pedro Marconato</h1>
-            <div class="role" id="cv-role">Desenvolvedor Full Stack</div>
-            <div class="tagline">Moda & Estilo Excelente</div>
-        </header>
-        
-        <!-- Contact Information -->
-        <div class="contact-info">
-            <div class="contact-item">
-                <i class="fas fa-envelope"></i>
-                <span id="cv-email">pedro@example.com</span>
-            </div>
-            <div class="contact-item">
-                <i class="fas fa-phone"></i>
-                <span id="cv-phone">(11) 99999-9999</span>
-            </div>
-            <div class="contact-item">
-                <i class="fas fa-map-marker-alt"></i>
-                <span id="cv-location">São Paulo, SP</span>
-            </div>
-            <div class="contact-item">
-                <i class="fab fa-linkedin"></i>
-                <span>linkedin.com/in/pedrohmarconato</span>
+
+            <!-- ===== CORPO ===== -->
+            <div class="grid">
+
+                <!-- ---------- COLUNA ESQUERDA ---------- -->
+                <aside class="rail">
+
+                    <section class="block">
+                        <div class="label">Destaques</div>
+                        <div class="stat"><span class="n">+7 Mi</span><span class="d">clientes sob gestão de CRM na Renner</span></div>
+                        <div class="stat"><span class="n">&minus;40%</span><span class="d">custo de processamento — migração AWS&rarr;GCP</span></div>
+                        <div class="stat"><span class="n">+67%</span><span class="d">expansão do time de dados &amp; analytics</span></div>
+                    </section>
+
+                    <section class="block">
+                        <div class="label">Competências</div>
+
+                        <div class="skill-group">
+                            <h4>Estratégia &amp; CRM</h4>
+                            <div class="chips">
+                                <span class="chip key">Gestão de CRM</span>
+                                <span class="chip key">Customer Equity</span>
+                                <span class="chip">Business Intelligence</span>
+                                <span class="chip">Brand Equity</span>
+                                <span class="chip">Liderança de Times</span>
+                                <span class="chip">Ciclo de Vida do Cliente</span>
+                            </div>
+                        </div>
+
+                        <div class="skill-group">
+                            <h4>Ferramentas &amp; Dados</h4>
+                            <div class="chips">
+                                <span class="chip">Databricks</span>
+                                <span class="chip">Oracle Responsys</span>
+                                <span class="chip">Power BI</span>
+                                <span class="chip">Python</span>
+                                <span class="chip">SQL</span>
+                                <span class="chip">Salesforce</span>
+                                <span class="chip">Tableau</span>
+                                <span class="chip">SAS</span>
+                                <span class="chip">Kanbanize</span>
+                                <span class="chip">Mailchimp</span>
+                            </div>
+                        </div>
+
+                        <div class="skill-group">
+                            <h4>Tecnologias Emergentes</h4>
+                            <div class="chips">
+                                <span class="chip">LLMs &amp; AI Agents</span>
+                                <span class="chip">IA aplicada a CRM</span>
+                                <span class="chip">Machine Learning</span>
+                                <span class="chip">Automação (n8n)</span>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section class="block">
+                        <div class="label">Formação</div>
+                        <div class="item">
+                            <div class="t">Mestrado em Administração</div>
+                            <div class="s">Ênfase em Analytics · UFSM</div>
+                            <div class="m">Conclusão 2019</div>
+                        </div>
+                        <div class="item">
+                            <div class="t">Bacharelado em Administração</div>
+                            <div class="s">Universidade Federal de Santa Maria</div>
+                            <div class="m">Conclusão 2015</div>
+                        </div>
+                    </section>
+
+                    <section class="block">
+                        <div class="label">Certificações</div>
+                        <div class="cert">
+                            <div class="t">Marketing Analytics in Practice</div>
+                            <div class="s">Coursera · Intermediate R</div>
+                        </div>
+                        <div class="cert">
+                            <div class="t">Marketing Analytics em R</div>
+                            <div class="s">PPGA — Pós-Graduação em Administração</div>
+                        </div>
+                        <div class="cert">
+                            <div class="t">Marketing in a Digital World</div>
+                            <div class="s">University of Illinois</div>
+                        </div>
+                    </section>
+
+                    <section class="block">
+                        <div class="label">Idiomas</div>
+                        <div class="lang-row"><span class="l">Português</span><span class="v">Nativo</span></div>
+                        <div class="lang-row"><span class="l">Inglês</span><span class="v">Avançado</span></div>
+                    </section>
+
+                </aside>
+
+                <!-- ---------- COLUNA DIREITA ---------- -->
+                <main class="main">
+
+                    <section class="block">
+                        <div class="label">Perfil</div>
+                        <p class="profile">
+                            <strong>Mestre em Administração com ênfase em Analytics</strong>, unindo inteligência de dados,
+                            CRM, visualização analítica e automação para gerar valor ao negócio. Atuação em empresas de
+                            grande porte e alta complexidade — <strong>Lojas Renner / Realize CFI</strong>, Grupo RBS e
+                            Rede Globo — liderando frentes estratégicas de CRM, inteligência comercial e performance de
+                            marketing. Combino capacidade analítica, pensamento estratégico e gestão de times
+                            multidisciplinares, com atuação reconhecida como liderança mesmo em estruturas consultivas.
+                        </p>
+                    </section>
+
+                    <section class="block">
+                        <div class="label">Experiência</div>
+                        <div class="exp">
+
+                            <div class="job">
+                                <div class="job-top">
+                                    <div class="company">Cadastra<small>Agência de Marketing Digital &amp; Performance</small></div>
+                                    <div class="dates">2025 — Atual</div>
+                                </div>
+                                <div class="stint">
+                                    <div class="role-line">
+                                        <span class="role-title">Coordenador de Data Analytics</span>
+                                        <span class="role-dates">Set 2025 — Atual</span>
+                                    </div>
+                                    <ul class="bullets">
+                                        <li>Liderança da operação de Data Analytics e IA para clientes de grande porte (tecnologia, varejo e educação), à frente de time multidisciplinar de DataViz, Engenharia de Dados e Web Analytics.</li>
+                                        <li>Gestão de contas estratégicas com interface direta a stakeholders C-level e às áreas de Performance, E-commerce e Comercial.</li>
+                                        <li>Reestruturação de ambientes de dados legados, incluindo migração AWS→GCP com redução projetada de 40% em custos de processamento.</li>
+                                        <li>Expansão do time (+67%) e das primeiras iniciativas de IA generativa em operações de clientes, com automações em n8n e AI Agents (LLMs).</li>
+                                    </ul>
+                                </div>
+                            </div>
+
+                            <div class="job renner">
+                                <div class="job-top">
+                                    <div class="company">Lojas Renner &nbsp;·&nbsp; Realize CFI<small>Grupo Lojas Renner S.A. — Serviços Financeiros</small></div>
+                                    <div class="dates">2020 — 2025</div>
+                                </div>
+                                <div class="stint">
+                                    <div class="role-line">
+                                        <span class="role-title">CRM Manager</span>
+                                        <span class="role-dates">2021 — 2025</span>
+                                    </div>
+                                    <ul class="bullets">
+                                        <li>Liderança da frente estratégica de CRM — evolução da área, crescimento da base ativa e geração de valor, com OKRs conectando metas de negócio a indicadores de relacionamento.</li>
+                                        <li>Jornadas personalizadas por comportamento e perfil, promovendo fidelização em produtos financeiros (cartões, empréstimos, seguros e consumo no ecossistema Renner).</li>
+                                        <li>Campanhas multicanal (e-mail, SMS, push) com segmentação inteligente e automações, gerindo comunicação para mais de 7 milhões de clientes.</li>
+                                        <li>Gestão técnica de Oracle Responsys, Databricks e Power BI, viabilizando segmentações automatizadas e dashboards de performance.</li>
+                                        <li>Ritmo ágil (Scrum/Kanban), gestão de backlog por valor incremental e de parceiros de tecnologia, com interface contínua a TI, Produtos, Marketing, Lojas e Comercial.</li>
+                                    </ul>
+                                </div>
+                                <div class="stint">
+                                    <div class="role-line">
+                                        <span class="role-title">Especialista de Analytics</span>
+                                        <span class="role-dates">2020 — 2021</span>
+                                    </div>
+                                    <ul class="bullets">
+                                        <li>Dashboards e indicadores estratégicos para Marketing, CRM, Crédito e Canais, com visão integrada e em tempo real para apoiar decisões.</li>
+                                        <li>Bases segmentadas e relatórios automatizados para o time de CRM, com ganho de eficiência e geração de receita por ações mais precisas.</li>
+                                        <li>SQL, BigQuery, Python e Power BI para análises exploratórias, automações e modelos preditivos aplicados ao negócio.</li>
+                                    </ul>
+                                </div>
+                            </div>
+
+                            <div class="job">
+                                <div class="job-top">
+                                    <div class="company">DBC Company<small>Consultoria Nacional de TI</small></div>
+                                    <div class="dates">2020 — 2021</div>
+                                </div>
+                                <div class="stint">
+                                    <div class="role-line">
+                                        <span class="role-title">Especialista de Analytics</span>
+                                    </div>
+                                    <ul class="bullets">
+                                        <li>Apoio à reestruturação estratégica do CRM no cliente Realize, implementando Kanban e processos que reduziram o time-to-market das campanhas e elevaram a eficiência operacional.</li>
+                                    </ul>
+                                </div>
+                            </div>
+
+                            <div class="job">
+                                <div class="job-top">
+                                    <div class="company">Grupo RBS<small>Mídia — atendimento ao cliente Rede Globo</small></div>
+                                    <div class="dates">2019 — 2020</div>
+                                </div>
+                                <div class="stint">
+                                    <div class="role-line">
+                                        <span class="role-title">Analista de Inteligência Comercial</span>
+                                    </div>
+                                    <ul class="bullets">
+                                        <li>Estruturação e análise de dados de desempenho comercial, audiência e comportamento de mercado, apoiando a liderança nas decisões estratégicas.</li>
+                                        <li>Estudos de segmentação e mapeamento de potencial de consumo, com relatórios e dashboards analíticos em tempo real.</li>
+                                    </ul>
+                                </div>
+                            </div>
+
+                        </div>
+                    </section>
+
+                </main>
             </div>
         </div>
-        
-        <!-- Profile Section -->
-        <section class="section">
-            <h2 class="section-title">Perfil Profissional</h2>
-            <p class="profile-text" id="cv-profile">
-                Desenvolvedor Full Stack com ampla experiência em tecnologias modernas e metodologias ágeis. 
-                Especializado em React, Node.js e cloud computing, com foco em entregar soluções inovadoras 
-                que impulsionam o crescimento dos negócios no setor de moda e varejo.
-            </p>
-        </section>
-        
-        <!-- Skills Section -->
-        <section class="section">
-            <h2 class="section-title">Competências Técnicas</h2>
-            <div class="skills-grid">
-                <div class="skills-category">
-                    <h3>Estratégicas</h3>
-                    <div id="skills-strategic">
-                        <div class="skill-item">
-                            <i class="fas fa-chart-line"></i>
-                            <span>Análise de Dados</span>
-                        </div>
-                        <div class="skill-item">
-                            <i class="fas fa-users"></i>
-                            <span>Liderança Técnica</span>
-                        </div>
-                        <div class="skill-item">
-                            <i class="fas fa-lightbulb"></i>
-                            <span>Inovação</span>
-                        </div>
-                    </div>
-                </div>
-                
-                <div class="skills-category">
-                    <h3>Ferramentas</h3>
-                    <div id="skills-tools">
-                        <div class="tool-item">
-                            <div class="tool-header">
-                                <span class="tool-name">React/Next.js</span>
-                                <span class="tool-percentage">95%</span>
-                            </div>
-                            <div class="progress-bar">
-                                <div class="progress" style="width: 95%"></div>
-                            </div>
-                        </div>
-                        <div class="tool-item">
-                            <div class="tool-header">
-                                <span class="tool-name">Node.js</span>
-                                <span class="tool-percentage">90%</span>
-                            </div>
-                            <div class="progress-bar">
-                                <div class="progress" style="width: 90%"></div>
-                            </div>
-                        </div>
-                        <div class="tool-item">
-                            <div class="tool-header">
-                                <span class="tool-name">AWS</span>
-                                <span class="tool-percentage">85%</span>
-                            </div>
-                            <div class="progress-bar">
-                                <div class="progress" style="width: 85%"></div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                
-                <div class="skills-category">
-                    <h3>Emergentes</h3>
-                    <div id="skills-emerging">
-                        <div class="skill-item">
-                            <i class="fas fa-robot"></i>
-                            <span>IA & Machine Learning</span>
-                        </div>
-                        <div class="skill-item">
-                            <i class="fas fa-cube"></i>
-                            <span>Blockchain</span>
-                        </div>
-                        <div class="skill-item">
-                            <i class="fas fa-mobile-alt"></i>
-                            <span>React Native</span>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </section>
-        
-        <!-- Experience Section -->
-        <section class="section">
-            <h2 class="section-title">Experiência Profissional</h2>
-            <div class="experience-timeline" id="cv-experience">
-                <!-- Experience items will be populated by JavaScript -->
-            </div>
-        </section>
-        
-        <!-- Education Section -->
-        <section class="section">
-            <h2 class="section-title">Formação Acadêmica</h2>
-            <div class="education-grid" id="cv-education">
-                <!-- Education items will be populated by JavaScript -->
-            </div>
-        </section>
-        
-        <!-- Projects Section -->
-        <section class="section">
-            <h2 class="section-title">Projetos Destacados</h2>
-            <div class="projects-grid" id="cv-projects">
-                <!-- Project items will be populated by JavaScript -->
-            </div>
-        </section>
-        
-        <!-- Footer -->
-        <footer class="footer">
-            <p>Este currículo foi criado especialmente para a Lojas Renner, demonstrando paixão pela inovação em moda e tecnologia.</p>
-            <p>🤖 Generated with <a href="https://claude.ai/code" style="color: #E85A70;">Claude Code</a></p>
-        </footer>
     </div>
-    
-    <script>
-        // Initialize CV content when page loads
-        document.addEventListener('DOMContentLoaded', function() {
-            // Check if cv-texts.js functions are available
-            if (typeof initializeBasicContent === 'function') {
-                initializeBasicContent('pt');
-                
-                // Populate experience section
-                if (typeof getText === 'function') {
-                    renderExperience('pt');
-                    renderEducation('pt');
-                    renderProjects('pt');
-                }
-            }
-        });
-        
-        function renderExperience(lang) {
-            const container = document.getElementById('cv-experience');
-            if (!container || typeof getText !== 'function') return;
-            
-            const experiences = getText('experience', lang);
-            let html = '';
-            
-            experiences.forEach((exp, index) => {
-                html += `
-                    <div class="experience-item">
-                        <div class="job-header">
-                            <div>
-                                <div class="job-title">${exp.title}</div>
-                                <div class="company">${exp.company}</div>
-                            </div>
-                            <div class="job-period">${exp.period}</div>
-                        </div>
-                        <div class="job-description">${exp.description}</div>
-                        <div class="achievements">
-                            ${exp.achievements.map(achievement => `
-                                <div class="achievement">
-                                    <div class="achievement-icon">
-                                        <i class="${achievement.icon}"></i>
-                                    </div>
-                                    <div class="achievement-text">
-                                        <div class="achievement-title">${achievement.title}</div>
-                                        <div>${achievement.description}</div>
-                                    </div>
-                                </div>
-                            `).join('')}
-                        </div>
-                    </div>
-                `;
-            });
-            
-            container.innerHTML = html;
-        }
-        
-        function renderEducation(lang) {
-            const container = document.getElementById('cv-education');
-            if (!container || typeof getText !== 'function') return;
-            
-            const education = getText('education', lang);
-            let html = '';
-            
-            education.forEach(edu => {
-                html += `
-                    <div class="education-item">
-                        <div class="degree">${edu.degree}</div>
-                        <div class="university">${edu.university}</div>
-                        <div class="thesis">${edu.thesis}</div>
-                    </div>
-                `;
-            });
-            
-            container.innerHTML = html;
-        }
-        
-        function renderProjects(lang) {
-            const container = document.getElementById('cv-projects');
-            if (!container || typeof getText !== 'function') return;
-            
-            const projects = getText('projects', lang);
-            let html = '';
-            
-            projects.forEach(project => {
-                html += `
-                    <div class="project-item">
-                        <div class="project-title">${project.title}</div>
-                        <div class="project-description">${project.description}</div>
-                        <div class="tech-tags">
-                            ${project.techs.map(tech => `<span class="tech-tag">${tech}</span>`).join('')}
-                        </div>
-                    </div>
-                `;
-            });
-            
-            container.innerHTML = html;
-        }
-    </script>
+    <script src="../assets/js/dynamic-favicon.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Antes
O PDF do Lojas Renner estava **feio e com conteúdo errado**:
- Competências mostravam **React/Next.js, Node.js, AWS, Blockchain, React Native** — que **não** são o perfil (CRM / Analytics / Dados).
- Caixas vermelhas pesadas, logo lavado sobre fundo vermelho, tagline estranha ("Moda & Estilo Excelente") e um rodapé "🤖 Generated with Claude Code".

## Depois — design editorial premium (EN + PT)
- **Papel creme**, tipografia **Playfair Display** (serif elegante) + **Inter**, vermelho Renner **#D2001F** como acento pontual.
- **Logo preto "LOJAS RENNER S.A."** sobre o claro (recortado do lockup, sem as submarcas) — enfim legível.
- **Layout de 2 colunas**: rail à esquerda (**Destaques** com métricas em serifa vermelha — +7 Mi clientes, −40% custo, +67% time —, Competências, Formação, Certificações, Idiomas) + coluna principal (Perfil + **timeline de Experiência**).
- **Conteúdo correto**: skills reais (Databricks, Oracle Responsys, Power BI, SQL, Python, CRM, Customer Equity, Brand Equity...). A passagem pelo **Renner é destacada** (ponto vermelho na timeline). Cargo da DBC corrigido para "Especialista de Analytics".

## Notas
- Segue o modelo **página ≠ PDF** (é o currículo estático; a página segue dinâmica).
- É um design **bespoke** do Renner (não passa pelo gerador padrão) — pode virar referência caso queira elevar outras marcas ao mesmo nível.
- `validate-project.py`: **0 erros / 0 avisos**. QA visual por render headless (Chrome) em EN e PT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)