### PR TITLE
feat: redesign editorial da página web do Lojas Renner

### DIFF
--- a/templates/companies/renner.html
+++ b/templates/companies/renner.html
@@ -3,1469 +3,315 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pedro Marconato - CV</title>
+    <title>Pedro Marconato — Lojas Renner (EN)</title>
+    <meta name="theme-color" content="#D2001F">
+    <meta name="msapplication-TileColor" content="#D2001F">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,500;0,600;0,700;0,800;1,500;1,600&family=Inter:wght@300;400;500;600;700&display=swap');
 
         :root {
-            /* Renner Colors - Based on brand specifications */
-            --renner-red: #D2001F;
-            --renner-dark-red: #B30020;
-            --renner-light-red: #E85A70;
-            --pure-white: #FFFFFF;
-            --light-gray: #F8F8F8;
-            --dark-gray: #333333;
-            --neutral-gray: #666666;
-            --off-white: #FAFAFA;
+            --ink: #1A1712;
+            --ink-soft: #4A453D;
+            --gray: #8A8479;
+            --paper: #FBFAF7;
+            --panel: #F5F2EB;
+            --line: #E3DED3;
+            --line-strong: #C9C2B4;
+            --red: #D2001F;
+            --red-deep: #A80019;
+            --font-serif: 'Playfair Display', Georgia, 'Times New Roman', serif;
+            --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 
-            /* Applied Colors */
+            /* aliases usados por modais + funções do cv-texts.js */
             --primary-color: #D2001F;
-            --secondary-color: #B30020;
-            --accent-color: #E85A70;
-            --text-color: #333333;
+            --renner-red: #D2001F;
+            --text-color: #1A1712;
+            --dark-gray: #8A8479;
             --white-text: #FFFFFF;
-            --gray-text: #666666;
-            --border-color: rgba(210, 0, 31, 0.2);
-            --background-gradient: linear-gradient(135deg, #D2001F 0%, #B30020 100%);
-            --glow-color: rgba(210, 0, 31, 0.3);
+            --background-gradient: linear-gradient(135deg, #D2001F 0%, #A80019 100%);
         }
 
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+        * { margin: 0; padding: 0; box-sizing: border-box; }
 
         body {
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            color: var(--text-color);
+            font-family: var(--font-sans);
+            color: var(--ink-soft);
+            background: #E9E5DC;
             line-height: 1.6;
-            background: white;
-            min-height: 100vh;
-            position: relative;
-            overflow-x: hidden;
-        }
-
-        /* Animated background with Renner style */
-        .animated-bg {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: white;
-            z-index: -2;
-        }
-
-        @keyframes gradientShift {
-            0% { background-position: 0% 50%; }
-            50% { background-position: 100% 50%; }
-            100% { background-position: 0% 50%; }
-        }
-
-        /* Floating geometric shapes - Renner modern style */
-        .shape {
-            position: absolute;
-            opacity: 0.08;
-            animation: float 25s infinite ease-in-out;
-        }
-
-        .shape:nth-child(1) {
-            width: 140px;
-            height: 140px;
-            background: linear-gradient(45deg, var(--renner-red), var(--renner-dark-red));
-            border-radius: 25px;
-            top: 8%;
-            left: 5%;
-            animation-delay: 0s;
-            transform: rotate(45deg);
-        }
-
-        .shape:nth-child(2) {
-            width: 90px;
-            height: 90px;
-            background: var(--pure-white);
-            border-radius: 50%;
-            top: 65%;
-            right: 8%;
-            animation-delay: 12s;
-        }
-
-        .shape:nth-child(3) {
-            width: 110px;
-            height: 110px;
-            background: linear-gradient(135deg, var(--renner-dark-red), var(--renner-light-red));
-            clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
-            bottom: 15%;
-            left: 20%;
-            animation-delay: 8s;
-        }
-
-        @keyframes float {
-            0%, 100% { transform: translateY(0) rotate(0deg); }
-            33% { transform: translateY(-50px) rotate(120deg); }
-            66% { transform: translateY(50px) rotate(240deg); }
+            font-size: 15px;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
         }
 
         .cv-container {
-            max-width: 1000px;
-            margin: 30px auto;
-            background: rgba(255, 255, 255, 0.98);
-            backdrop-filter: blur(20px) saturate(180%);
-            -webkit-backdrop-filter: blur(20px) saturate(180%);
-            border-radius: 28px;
-            box-shadow:
-                0 20px 50px rgba(0, 0, 0, 0.3),
-                0 15px 30px rgba(210, 0, 31, 0.15),
-                inset 0 1px 2px rgba(255, 255, 255, 0.9);
-            border: 1px solid rgba(210, 0, 31, 0.3);
-            overflow: hidden;
+            max-width: 940px;
+            margin: 34px auto;
+            background: var(--paper);
             position: relative;
-            animation: containerGlow 18s ease infinite;
+            box-shadow: 0 18px 60px rgba(26, 23, 18, 0.16);
+            overflow: hidden;
+            animation: fadeUp 0.7s ease both;
         }
-
-        @keyframes containerGlow {
-            0%, 100% {
-                box-shadow:
-                    0 20px 50px rgba(0, 0, 0, 0.3),
-                    0 15px 30px rgba(210, 0, 31, 0.15),
-                    0 0 80px rgba(210, 0, 31, 0.05),
-                    inset 0 1px 2px rgba(255, 255, 255, 0.9);
-            }
-            50% {
-                box-shadow:
-                    0 20px 50px rgba(0, 0, 0, 0.3),
-                    0 15px 30px rgba(210, 0, 31, 0.25),
-                    0 0 100px rgba(210, 0, 31, 0.1),
-                    inset 0 1px 2px rgba(255, 255, 255, 0.9);
-            }
-        }
+        @keyframes fadeUp { from { opacity: 0; transform: translateY(14px); } to { opacity: 1; transform: none; } }
 
         .cv-container::before {
-            content: '';
-            position: absolute;
-            top: -50%;
-            left: -50%;
-            width: 200%;
-            height: 200%;
-            background: radial-gradient(circle at 30% 50%, rgba(210, 0, 31, 0.03) 0%, transparent 50%),
-                        radial-gradient(circle at 70% 30%, rgba(179, 0, 32, 0.03) 0%, transparent 50%),
-                        radial-gradient(circle at 50% 80%, rgba(232, 90, 112, 0.02) 0%, transparent 50%);
-            animation: rotate 30s linear infinite;
-            pointer-events: none;
+            content: "";
+            position: absolute; top: 0; left: 0; right: 0; height: 5px;
+            background: var(--red);
         }
 
-        @keyframes rotate {
-            from { transform: rotate(0deg); }
-            to { transform: rotate(360deg); }
-        }
-
+        /* ==================== HERO ==================== */
         .header {
-            background: var(--background-gradient);
-            padding: 40px 60px 60px 60px;
+            padding: 58px 64px 34px;
             position: relative;
-            overflow: hidden;
-            min-height: 300px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
         }
-
-        /* Animated wave backgrounds - Renner modern style */
-        .header::before {
-            content: '';
-            position: absolute;
-            top: -50%;
-            left: -50%;
-            width: 200%;
-            height: 200%;
-            background: radial-gradient(circle at 20% 50%, rgba(232, 90, 112, 0.15) 0%, transparent 50%),
-                        radial-gradient(circle at 80% 50%, rgba(255, 255, 255, 0.1) 0%, transparent 50%),
-                        radial-gradient(circle at 40% 80%, rgba(210, 0, 31, 0.2) 0%, transparent 50%);
-            animation: waveMotion 22s ease-in-out infinite;
-            z-index: -1;
-        }
-
-        .header::after {
-            content: '';
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 320"><path fill="%23ffffff" fill-opacity="0.1" d="M0,96L48,112C96,128,192,160,288,165.3C384,171,480,149,576,128C672,107,768,85,864,96C960,107,1056,149,1152,165.3C1248,181,1344,171,1392,165.3L1440,160L1440,320L1392,320C1344,320,1248,320,1152,320C1056,320,960,320,864,320C768,320,672,320,576,320C480,320,384,320,288,320C192,320,96,320,48,320L0,320Z"></path></svg>') repeat-x;
-            background-size: 1440px 320px;
-            animation: wave 15s cubic-bezier(0.36, 0.45, 0.63, 0.53) infinite;
-            transform: translate3d(0, 0, 0);
-            z-index: -1;
-        }
-
-        @keyframes waveMotion {
-            0%, 100% { transform: rotate(0deg) scale(1); }
-            25% { transform: rotate(2deg) scale(1.05); }
-            50% { transform: rotate(-2deg) scale(0.98); }
-            75% { transform: rotate(1deg) scale(1.02); }
-        }
-
-        @keyframes wave {
-            0% { transform: translateX(0); }
-            100% { transform: translateX(-1440px); }
-        }
-
-        /* Floating particles - modern geometric style */
-        .particle {
-            position: absolute;
-            background: rgba(255, 255, 255, 0.2);
-            pointer-events: none;
-            z-index: -1;
-        }
-
-        .particle:nth-child(1) {
-            width: 70px;
-            height: 70px;
-            top: 15%;
-            left: 8%;
-            border-radius: 50%;
-            animation: floatUp 12s infinite ease-in-out;
-        }
-
-        .particle:nth-child(2) {
-            width: 45px;
-            height: 45px;
-            top: 35%;
-            right: 15%;
-            border-radius: 8px;
-            animation: floatUp 14s infinite ease-in-out 3s;
-            background: rgba(232, 90, 112, 0.2);
-        }
-
-        .particle:nth-child(3) {
-            width: 85px;
-            height: 85px;
-            bottom: 25%;
-            left: 25%;
-            clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
-            animation: floatUp 16s infinite ease-in-out 6s;
-            background: rgba(210, 0, 31, 0.2);
-        }
-
-        @keyframes floatUp {
-            0%, 100% {
-                transform: translateY(0) rotate(0deg);
-                opacity: 0.2;
-            }
-            50% {
-                transform: translateY(-70px) rotate(180deg);
-                opacity: 0.4;
-            }
-        }
-
-        .header-content {
-            position: relative;
-            z-index: 100;
-            text-align: center;
-            width: 100%;
-            max-width: 1000px;
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            gap: 40px;
-        }
-
-        /* Logo container with animation */
-        .logo-container {
-            flex: 0 0 auto;
-            animation: logoEntrance 1.5s ease-out;
-            position: relative;
-            z-index: 101;
-        }
-
-        @keyframes logoEntrance {
-            0% {
-                transform: scale(0) rotate(-180deg);
-                opacity: 0;
-            }
-            50% {
-                transform: scale(1.2) rotate(90deg);
-            }
-            100% {
-                transform: scale(1) rotate(0deg);
-                opacity: 1;
-            }
-        }
-
-        .renner-logo-header {
-            width: 180px;
-            height: auto;
-            filter: drop-shadow(0 8px 25px rgba(0, 0, 0, 0.4))
-                    drop-shadow(0 2px 10px rgba(255, 255, 255, 0.3));
-            transition: all 0.5s ease;
-            animation: logoFloat 4s ease-in-out infinite;
-            position: relative;
-            z-index: 102;
-        }
-
-        @keyframes logoFloat {
-            0%, 100% { transform: translateY(0px) scale(1); }
-            50% { transform: translateY(-10px) scale(1.03); }
-        }
-
-        .renner-logo-header:hover {
-            transform: scale(1.1) rotate(2deg);
-            filter: drop-shadow(0 12px 30px rgba(0, 0, 0, 0.5))
-                    drop-shadow(0 4px 15px rgba(210, 0, 31, 0.4));
-        }
-
-        /* Header text content */
-        .header-text-content {
-            flex: 1;
-            text-align: left;
-            position: relative;
-            z-index: 101;
-        }
-
-        /* Animated tagline */
-        .company-tagline {
-            font-size: 20px;
-            font-weight: 600;
-            color: var(--white-text);
-            text-transform: uppercase;
-            letter-spacing: 2px;
-            margin-bottom: 20px;
-            text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
-            opacity: 0.95;
-            background: linear-gradient(45deg, #ffffff, #E85A70);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-        }
-
-        .header-text {
-            max-width: 100%;
-            margin: 0;
-        }
+        .header-content { display: flex; justify-content: space-between; align-items: flex-start; gap: 32px; }
 
         .header h1 {
-            font-size: 36px;
+            font-family: var(--font-serif);
             font-weight: 800;
-            color: var(--white-text);
-            margin-bottom: 12px;
-            letter-spacing: -0.5px;
-            text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
-            animation: nameSlide 1s ease-out 0.5s both;
+            font-size: 44px;
+            line-height: 1.02;
+            letter-spacing: -0.6px;
+            color: var(--ink);
         }
-
-        @keyframes nameSlide {
-            from {
-                transform: translateX(-100px);
-                opacity: 0;
-            }
-            to {
-                transform: translateX(0);
-                opacity: 1;
-            }
-        }
-
         .role {
-            font-size: 18px;
+            margin-top: 16px;
+            font-size: 12px;
             font-weight: 600;
-            color: var(--white-text);
-            margin-bottom: 20px;
-            text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
+            letter-spacing: 3.5px;
             text-transform: uppercase;
-            letter-spacing: 1px;
-            animation: roleSlide 1s ease-out 0.7s both;
-            opacity: 0.9;
+            color: var(--gray);
         }
 
-        @keyframes roleSlide {
-            from {
-                transform: translateX(100px);
-                opacity: 0;
-            }
-            to {
-                transform: translateX(0);
-                opacity: 1;
-            }
-        }
+        .brandmark { flex-shrink: 0; width: 232px; height: 38px; overflow: hidden; margin-top: 8px; }
+        .brandmark img { width: 232px; height: auto; display: block; }
 
-        /* Contact section styling */
-        .contact-section {
-            margin-top: 30px;
-            padding: 0 60px;
-            position: relative;
-            z-index: 100;
-        }
+        .header-divider { height: 1px; background: var(--line-strong); margin: 30px 64px 0; }
 
-        .contact-info {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 12px;
-            align-items: center;
-            justify-content: center;
-            position: relative;
-            z-index: 101;
-        }
-
+        /* contatos */
+        .contact-section { padding: 20px 64px 6px; }
+        .contact-info { display: flex; flex-wrap: wrap; align-items: center; gap: 10px 22px; }
+        .contact-item { display: inline-flex; align-items: baseline; gap: 8px; }
         .contact-button {
-            display: inline-flex;
-            align-items: center;
-            background: rgba(255, 255, 255, 0.15);
-            backdrop-filter: blur(10px);
-            border-radius: 12px;
-            padding: 10px 16px;
-            text-decoration: none;
-            color: var(--white-text);
-            font-size: 14px;
-            font-weight: 500;
-            transition: all 0.3s ease;
-            border: 1px solid rgba(255, 255, 255, 0.2);
-            cursor: pointer;
-            position: relative;
-            overflow: visible;
-            z-index: 102;
+            display: inline-flex; align-items: center; gap: 8px;
+            background: none; border: none; padding: 0;
+            font-family: var(--font-sans); font-size: 13.5px; font-weight: 500;
+            color: var(--ink); cursor: pointer; text-decoration: none;
+            transition: color 0.2s;
         }
+        .contact-button i { color: var(--red); font-size: 12px; }
+        .contact-button:hover { color: var(--red); }
+        a.contact-button { cursor: pointer; }
+        .contact-cta { font-size: 10.5px; color: var(--gray); letter-spacing: 0.2px; }
+        .location { display: inline-flex; align-items: center; gap: 8px; font-size: 13.5px; color: var(--ink); }
+        .location i { color: var(--red); font-size: 12px; }
 
-        .contact-button:hover {
-            background: rgba(210, 0, 31, 0.3);
-            transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(210, 0, 31, 0.4);
-            border-color: rgba(210, 0, 31, 0.5);
-        }
-
-        .contact-button i {
-            margin-right: 8px;
-            font-size: 16px;
-        }
-
-        .contact-item {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 4px;
-        }
-
-        .contact-cta {
-            font-size: 11px;
-            color: rgba(255, 255, 255, 0.8);
-            font-weight: 400;
-            animation: gentlePulse 3s ease-in-out infinite;
-        }
-
-        @keyframes gentlePulse {
-            0%, 100% {
-                opacity: 0.8;
-                transform: scale(1);
-            }
-            50% {
-                opacity: 1;
-                transform: scale(1.02);
-            }
-        }
-
-        .location {
-            display: flex;
-            align-items: center;
-            font-size: 14px;
-            color: var(--white-text);
-        }
-
-        .location i {
-            margin-right: 6px;
-        }
-
-        .section {
-            padding: 35px 80px;
-            position: relative;
-        }
-
-        .section:not(:last-child)::after {
-            content: '';
-            position: absolute;
-            bottom: 0;
-            left: 80px;
-            right: 80px;
-            height: 1px;
-            background: linear-gradient(to right, transparent, var(--border-color), transparent);
-        }
+        /* ==================== SEÇÕES ==================== */
+        .section { padding: 30px 64px; border-top: 1px solid var(--line); }
+        .section:first-of-type { border-top: none; }
 
         .section-title {
-            background: var(--background-gradient);
-            color: var(--white-text);
-            font-size: 20px;
-            font-weight: 600;
-            margin-bottom: 20px;
-            padding: 12px 20px;
-            border-radius: 14px;
-            letter-spacing: 0.3px;
-            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
-            display: inline-block;
-            position: relative;
-            overflow: hidden;
+            display: flex; align-items: center; gap: 13px;
+            font-family: var(--font-sans);
+            font-size: 12px; font-weight: 700; letter-spacing: 3px;
+            text-transform: uppercase; color: var(--ink);
+            margin-bottom: 22px;
         }
+        .section-title::before { content: ""; width: 22px; height: 2px; background: var(--red); flex-shrink: 0; }
 
-        .section-title::before {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: -100%;
-            width: 100%;
-            height: 100%;
-            background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
-            animation: titleShimmer 6s infinite;
+        .profile-text { font-size: 15.5px; line-height: 1.8; color: var(--ink-soft); max-width: 62ch; }
+
+        /* ==================== SKILLS ==================== */
+        .skills-container { display: grid; grid-template-columns: repeat(3, 1fr); gap: 34px; }
+        .skills-column h3 {
+            font-family: var(--font-serif) !important;
+            font-size: 16px !important; font-weight: 700 !important;
+            color: var(--ink) !important; margin-bottom: 16px !important;
+            padding-bottom: 9px; border-bottom: 1px solid var(--line);
         }
+        .tool-item { margin-bottom: 14px; }
+        .tool-name { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 6px; }
+        .tool-name > span:first-child { font-size: 13px; font-weight: 500; color: var(--ink); }
+        .tool-percentage { font-size: 10px; font-weight: 600; letter-spacing: 0.6px; text-transform: uppercase; color: var(--red-deep); }
+        .dots-container { display: flex; gap: 4px; }
+        .dot { width: 100%; height: 3px; border-radius: 2px; background: var(--line); flex: 1; }
+        .dot.filled { background: var(--red); }
 
-        @keyframes titleShimmer {
-            0% { left: -100%; }
-            50%, 100% { left: 100%; }
-        }
-
-        .profile-text {
-            font-size: 16px;
-            line-height: 1.8;
-            color: var(--text-color);
-            text-align: justify;
-        }
-
-        .skills-container {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 30px;
-        }
-
-        @media (max-width: 1000px) {
-            .skills-container {
-                grid-template-columns: repeat(2, 1fr);
-            }
-        }
-
-        @media (max-width: 600px) {
-            .skills-container {
-                grid-template-columns: 1fr;
-            }
-        }
-
-        .skills-column {
-            background: linear-gradient(135deg, rgba(210, 0, 31, 0.08), rgba(0, 0, 0, 0.05));
-            padding: 25px;
-            border-radius: 16px;
-            border: 1px solid rgba(210, 0, 31, 0.2);
-            backdrop-filter: blur(10px);
-            transition: all 0.3s ease;
-        }
-
-        .skills-column:hover {
-            transform: translateY(-3px);
-            box-shadow: 0 8px 24px rgba(210, 0, 31, 0.2);
-            border-color: rgba(210, 0, 31, 0.4);
-        }
-
-        .skill-item {
-            display: flex;
-            align-items: center;
-            margin-bottom: 12px;
-            font-size: 15px;
-            color: var(--text-color);
-            font-weight: 500;
-            transition: transform 0.2s ease;
-        }
-
-        .skill-item:hover {
-            transform: translateX(5px);
-        }
-
-        .skill-item i {
-            color: var(--renner-red);
-            margin-right: 12px;
-            font-size: 18px;
-        }
-
-        .tool-item {
-            margin-bottom: 18px;
-        }
-
-        .tool-name {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            font-weight: 600;
-            font-size: 14px;
-            margin-bottom: 8px;
-            color: var(--text-color);
-        }
-
-        .tool-percentage {
-            font-size: 13px;
-            color: var(--renner-red);
-            font-weight: 700;
-        }
-
-        .progress-bar {
-            height: 8px;
-            background: rgba(210, 0, 31, 0.1);
-            border-radius: 10px;
-            overflow: hidden;
-            box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
-        }
-
-        .progress {
-            height: 100%;
-            background: linear-gradient(90deg, var(--renner-dark-red), var(--renner-red));
-            border-radius: 10px;
-            position: relative;
-            animation: progressGrow 1.5s ease-out;
-        }
-
-        /* Renner colored progress bars */
-        .tool-item:nth-child(3n+1) .progress {
-            background: linear-gradient(90deg, #D2001F 0%, #E85A70 100%);
-        }
-
-        .tool-item:nth-child(3n+2) .progress {
-            background: linear-gradient(90deg, #B30020 0%, #D2001F 100%);
-        }
-
-        .tool-item:nth-child(3n) .progress {
-            background: linear-gradient(90deg, #E85A70 0%, #B30020 100%);
-        }
-
-        @keyframes progressGrow {
-            from { width: 0; }
-        }
-
-        .progress::after {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
-            background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.3), transparent);
-            animation: progressShimmer 2s infinite;
-        }
-
-        @keyframes progressShimmer {
-            0% { transform: translateX(-100%); }
-            100% { transform: translateX(100%); }
-        }
-
-        /* Tooltip styles - Renner themed */
-        .tooltip {
-            position: relative;
-            display: inline-block;
-            cursor: help;
-        }
-
-        .tooltip .tooltip-icon {
-            color: var(--renner-red);
-            font-size: 14px;
-            margin-left: 5px;
-            transition: transform 0.2s, color 0.2s;
-        }
-
-        .tooltip:hover .tooltip-icon,
-        .tooltip:focus .tooltip-icon,
-        .tooltip:active .tooltip-icon {
-            color: var(--renner-light-red);
-            transform: scale(1.2);
-        }
-
-        .tooltip .tooltip-text {
-            visibility: hidden;
-            width: 380px;
-            background: linear-gradient(145deg, var(--renner-dark-red), var(--renner-red));
-            color: var(--white-text);
-            text-align: left;
-            border-radius: 12px;
-            padding: 0;
-            position: absolute;
-            z-index: 100;
-            bottom: 125%;
-            left: 50%;
-            margin-left: -190px;
-            opacity: 0;
-            transition: opacity 0.4s, transform 0.3s;
-            transform: translateY(10px);
-            font-size: 13px;
-            line-height: 1.5;
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
-            overflow: hidden;
-            max-height: 85vh;
-            overflow-y: auto;
-        }
-
-        .tooltip .tooltip-text::after {
-            content: "";
-            position: absolute;
-            top: 100%;
-            left: 50%;
-            margin-left: -8px;
-            border-width: 8px;
-            border-style: solid;
-            border-color: var(--renner-dark-red) transparent transparent transparent;
-        }
-
-        .tooltip:hover .tooltip-text,
-        .tooltip:focus .tooltip-text,
-        .tooltip:active .tooltip-text,
-        .tooltip.tooltip-active .tooltip-text {
-            visibility: visible;
-            opacity: 1;
-            transform: translateY(0);
-            min-height: 330px;
-        }
-
-        .tooltip-active .tooltip-text {
-            position: absolute;
-            z-index: 9999;
-            overflow-y: auto;
-        }
-
-        .tooltip-header {
-            background-color: rgba(210, 0, 31, 0.2);
-            padding: 12px 18px;
-            font-weight: 600;
-            font-size: 1.05em;
-            border-bottom: 1px solid rgba(210, 0, 31, 0.3);
-            color: var(--white-text);
-        }
-
-        .tooltip-content {
-            padding: 18px;
-        }
-
-        .tooltip-section {
-            margin-bottom: 15px;
-        }
-
-        .tooltip-section:last-of-type {
-            margin-bottom: 0;
-        }
-
-        .tooltip-section-title {
-            display: flex;
-            align-items: center;
-            font-weight: 500;
-            font-size: 1em;
-            color: #ffffff;
-            margin-bottom: 10px;
-        }
-
-        .tooltip-section-title .fas {
-            margin-right: 12px;
-            font-size: 1.1em;
-            width: 20px;
-            text-align: center;
-            opacity: 1;
-            color: #f0f0f0;
-        }
-
-        .tooltip-list {
-            list-style-position: outside;
-            padding-left: 20px;
-            margin-top: 5px;
-        }
-
-        .tooltip-list li {
-            margin-bottom: 10px;
-            line-height: 1.5;
-        }
-
-        .tooltip-list li::marker {
-            color: rgba(255, 255, 255, 0.7);
-        }
-
-        /* Mobile responsiveness for tooltips */
-        @media (max-width: 768px) {
-            .tooltip .tooltip-text {
-                width: 90vw;
-                max-width: 320px;
-                left: 50%;
-                transform: translateX(-50%);
-                margin-left: 0;
-                font-size: 12px;
-                max-height: 75vh;
-            }
-
-            .tooltip-active .tooltip-text {
-                position: fixed;
-                top: 50%;
-                left: 50%;
-                transform: translate(-50%, -50%) !important;
-                width: 90vw;
-                max-width: 380px;
-                z-index: 10000;
-            }
-        }
-
-        .experience-timeline {
-            position: relative;
-            margin-left: 30px;
-            padding-left: 40px;
-        }
-
+        /* ==================== EXPERIÊNCIA ==================== */
+        .experience-timeline { position: relative; padding-left: 30px; }
         .experience-timeline::before {
-            content: "";
-            position: absolute;
-            left: 0;
-            top: 0;
-            bottom: 0;
-            width: 3px;
-            background: linear-gradient(to bottom, var(--renner-dark-red), var(--renner-red));
-            border-radius: 3px;
+            content: ""; position: absolute; left: 5px; top: 8px; bottom: 8px;
+            width: 1.5px; background: var(--line-strong);
         }
-
-        .experience-item {
-            margin-bottom: 25px;
-            position: relative;
-            padding: 25px;
-            border-radius: 16px;
-            background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.9));
-            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
-            border: 1px solid rgba(210, 0, 31, 0.2);
-            transition: all 0.3s ease;
-        }
-
-        .experience-item:hover {
-            transform: translateX(5px);
-            box-shadow: 0 4px 20px rgba(210, 0, 31, 0.2);
-            border-color: rgba(210, 0, 31, 0.4);
-        }
-
+        .experience-item { position: relative; margin-bottom: 30px; }
+        .experience-item:last-child { margin-bottom: 0; }
         .experience-item::before {
-            content: "";
-            position: absolute;
-            left: -46px;
-            top: 35px;
-            width: 12px;
-            height: 12px;
-            border-radius: 50%;
-            background: var(--renner-red);
-            border: 3px solid white;
-            box-shadow: 0 0 0 3px rgba(210, 0, 31, 0.3);
-            z-index: 1;
+            content: ""; position: absolute; left: -30px; top: 4px;
+            width: 11px; height: 11px; border-radius: 50%;
+            background: var(--paper); border: 2px solid var(--red);
         }
 
         .job-title {
-            font-weight: 600;
-            font-size: 20px;
-            color: var(--text-color);
-            margin-bottom: 8px;
-            display: flex;
-            align-items: center;
-            gap: 12px;
+            display: flex; align-items: center; gap: 11px;
+            font-family: var(--font-serif); font-size: 20px; font-weight: 700;
+            color: var(--ink); line-height: 1.2;
         }
-
         .job-number {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            width: 36px;
-            height: 36px;
-            background: var(--background-gradient);
-            color: var(--white-text);
-            border-radius: 50%;
-            font-size: 16px;
-            font-weight: 600;
-            box-shadow: 0 3px 10px rgba(210, 0, 31, 0.3);
+            flex-shrink: 0;
+            width: 25px; height: 25px; border-radius: 50%;
+            background: var(--red); color: #fff;
+            font-family: var(--font-sans); font-size: 12px; font-weight: 700;
+            display: inline-flex; align-items: center; justify-content: center;
         }
-
-        .company {
-            font-weight: 500;
-            font-size: 16px;
-            color: var(--gray-text);
-            margin-bottom: 5px;
-        }
-
+        .company { font-size: 14px; font-weight: 600; color: var(--red-deep); margin-top: 7px; }
         .period {
-            font-size: 14px;
-            color: var(--text-color);
-            font-style: italic;
-            margin-bottom: 15px;
-            display: inline-block;
-            background: rgba(210, 0, 31, 0.1);
-            padding: 4px 12px;
-            border-radius: 20px;
+            display: inline-block; margin-top: 4px;
+            font-size: 11px; font-weight: 500; letter-spacing: 0.8px; text-transform: uppercase;
+            color: var(--gray);
         }
+        .job-description { font-size: 14px; line-height: 1.7; color: var(--ink-soft); margin: 12px 0 16px; max-width: 66ch; }
 
-        .job-description {
-            font-size: 15px;
-            line-height: 1.6;
-            color: var(--text-color);
-            margin-bottom: 20px;
-        }
-
-        .achievements-container {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 15px;
-        }
-
-        @media (max-width: 900px) {
-            .achievements-container {
-                grid-template-columns: repeat(2, 1fr);
-            }
-        }
-
-        @media (max-width: 600px) {
-            .achievements-container {
-                grid-template-columns: 1fr;
-            }
-        }
-
+        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
         .achievement-item {
-            background: linear-gradient(135deg, rgba(210, 0, 31, 0.05), rgba(0, 0, 0, 0.02));
-            border-radius: 12px;
-            padding: 18px;
-            border: 1px solid rgba(210, 0, 31, 0.2);
-            display: flex;
-            align-items: flex-start;
-            gap: 12px;
-            transition: all 0.3s ease;
+            display: flex; gap: 12px;
+            background: var(--panel); border: 1px solid var(--line);
+            border-radius: 3px; padding: 14px 16px;
+            transition: border-color 0.2s, transform 0.2s;
         }
-
-        .achievement-item:hover {
-            transform: translateY(-3px);
-            box-shadow: 0 6px 20px rgba(210, 0, 31, 0.2);
-            border-color: var(--renner-red);
-        }
-
+        .achievement-item:hover { border-color: var(--line-strong); transform: translateY(-2px); }
         .achievement-icon {
-            font-size: 24px;
-            color: var(--renner-red);
-            flex-shrink: 0;
+            flex-shrink: 0; width: 30px; height: 30px; border-radius: 50%;
+            background: rgba(210, 0, 31, 0.08); color: var(--red);
+            display: inline-flex; align-items: center; justify-content: center; font-size: 13px;
         }
+        .achievement-title { font-size: 12.5px; font-weight: 700; color: var(--ink); margin-bottom: 3px; letter-spacing: 0.2px; }
+        .achievement-description { font-size: 12px; line-height: 1.55; color: var(--ink-soft); }
 
-        .achievement-content {
-            flex: 1;
+        /* tooltip */
+        .tooltip { position: relative; display: inline-flex; }
+        .tooltip-icon { font-size: 13px; color: var(--gray); cursor: pointer; }
+        .tooltip-text {
+            visibility: hidden; opacity: 0; position: absolute; z-index: 20;
+            top: 130%; left: 0; width: 300px;
+            background: var(--ink); color: #F3EFE8; border-radius: 6px; padding: 14px 16px;
+            font-family: var(--font-sans); box-shadow: 0 12px 30px rgba(0,0,0,0.25);
+            transition: opacity 0.2s;
         }
+        .tooltip:hover .tooltip-text, .tooltip.tooltip-active .tooltip-text { visibility: visible; opacity: 1; }
+        .tooltip-header { font-size: 12px; font-weight: 700; margin-bottom: 8px; color: #fff; }
+        .tooltip-section-title { font-size: 11px; font-weight: 600; color: #F0B8BE; margin: 8px 0 4px; }
+        .tooltip-list { list-style: none; }
+        .tooltip-list li { font-size: 11px; line-height: 1.5; padding-left: 12px; position: relative; }
+        .tooltip-list li::before { content: "—"; position: absolute; left: 0; color: var(--red); }
 
-        .achievement-title {
-            font-weight: 600;
-            font-size: 15px;
-            color: var(--text-color);
-            margin-bottom: 6px;
+        /* ==================== FORMAÇÃO / PROJETOS ==================== */
+        .education-container, .projects-container { display: grid; grid-template-columns: 1fr 1fr; gap: 22px; }
+        .education-item, .project-item {
+            padding: 20px 22px; background: var(--panel);
+            border: 1px solid var(--line); border-radius: 3px;
         }
-
-        .achievement-description {
-            font-size: 14px;
-            line-height: 1.5;
-            color: var(--text-color);
-        }
-
-        .education-container {
-            display: grid;
-            grid-template-columns: repeat(2, 1fr);
-            gap: 25px;
-        }
-
-        @media (max-width: 700px) {
-            .education-container {
-                grid-template-columns: 1fr;
-            }
-        }
-
-        .education-item {
-            background: linear-gradient(135deg, rgba(210, 0, 31, 0.08), rgba(0, 0, 0, 0.05));
-            padding: 25px;
-            border-radius: 16px;
-            border: 1px solid rgba(210, 0, 31, 0.2);
-            transition: all 0.3s ease;
-        }
-
-        .education-item:hover {
-            transform: translateY(-3px);
-            box-shadow: 0 8px 24px rgba(210, 0, 31, 0.15);
-        }
-
-        .degree {
-            font-weight: 600;
-            font-size: 18px;
-            color: var(--text-color);
-            margin-bottom: 8px;
-        }
-
-        .university {
-            font-size: 15px;
-            color: var(--text-color);
-            margin-bottom: 8px;
-        }
-
-        .thesis {
-            font-size: 14px;
-            font-style: italic;
-            color: var(--gray-text);
-        }
-
-        .projects-container {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 20px;
-        }
-
-        @media (max-width: 900px) {
-            .projects-container {
-                grid-template-columns: repeat(2, 1fr);
-            }
-        }
-
-        @media (max-width: 600px) {
-            .projects-container {
-                grid-template-columns: 1fr;
-            }
-        }
-
-        .project-item {
-            background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.9));
-            border-radius: 16px;
-            padding: 30px;
-            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
-            border: 1px solid rgba(210, 0, 31, 0.2);
-            transition: all 0.3s ease;
-            position: relative;
-            overflow: hidden;
-        }
-
-        .project-item::before {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            height: 3px;
-            background: var(--background-gradient);
-            transform: scaleX(0);
-            transform-origin: left;
-            transition: transform 0.3s ease;
-        }
-
-        .project-item:hover::before {
-            transform: scaleX(1);
-        }
-
-        .project-item:hover {
-            transform: translateY(-5px);
-            box-shadow: 0 8px 30px rgba(210, 0, 31, 0.2);
-            border-color: var(--renner-red);
-        }
-
-        .project-title {
-            font-weight: 600;
-            font-size: 18px;
-            color: var(--text-color);
-            margin-bottom: 12px;
-        }
-
-        .project-description {
-            font-size: 14px;
-            line-height: 1.6;
-            color: var(--text-color);
-            margin-bottom: 15px;
-        }
-
+        .degree, .project-title { font-family: var(--font-serif); font-size: 17px; font-weight: 700; color: var(--ink); line-height: 1.25; }
+        .university { font-size: 13px; color: var(--ink-soft); margin-top: 5px; }
+        .thesis { font-size: 12px; color: var(--gray); font-style: italic; margin-top: 5px; line-height: 1.5; }
+        .project-description { font-size: 13px; line-height: 1.65; color: var(--ink-soft); margin-top: 8px; }
         .tech-tag {
-            display: inline-block;
-            background: rgba(210, 0, 31, 0.1);
-            color: var(--text-color);
-            padding: 5px 12px;
-            border-radius: 20px;
-            font-size: 12px;
-            font-weight: 500;
-            margin-right: 8px;
-            margin-bottom: 8px;
-            border: 1px solid rgba(210, 0, 31, 0.3);
-            transition: all 0.2s ease;
+            display: inline-block; margin: 4px 4px 0 0; padding: 3px 9px;
+            font-size: 10.5px; font-weight: 500; letter-spacing: 0.3px;
+            color: var(--ink); background: var(--paper);
+            border: 1px solid var(--line-strong); border-radius: 2px;
         }
-
-        .tech-tag:hover {
-            background: var(--renner-red);
-            color: var(--white-text);
-            transform: translateY(-2px);
-            box-shadow: 0 2px 8px rgba(210, 0, 31, 0.4);
+        .cta-button {
+            display: inline-flex; align-items: center; gap: 7px; margin-top: 12px;
+            padding: 8px 15px; font-size: 12px; font-weight: 600;
+            color: #fff; background: var(--red); border-radius: 3px;
+            text-decoration: none; transition: background 0.2s;
         }
+        .cta-button:hover { background: var(--red-deep); }
 
-        /* Print button */
-        .print-button {
-            position: fixed;
-            bottom: 30px;
-            right: 30px;
-            background: var(--background-gradient);
-            color: var(--white-text);
-            border: none;
-            border-radius: 50%;
-            width: 60px;
-            height: 60px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            cursor: pointer;
-            box-shadow: 0 4px 20px rgba(210, 0, 31, 0.4);
-            transition: all 0.3s ease;
-            z-index: 100;
-        }
-
-        /* Language toggle button */
+        /* ==================== TOGGLE / FAB ==================== */
         .language-toggle {
-            position: fixed;
-            top: 30px;
-            right: 30px;
-            background: rgba(255, 255, 255, 0.95);
-            backdrop-filter: blur(10px);
-            border-radius: 30px;
-            padding: 5px;
-            display: flex;
-            align-items: center;
-            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
-            transition: all 0.3s ease;
-            z-index: 100;
-            border: 2px solid rgba(210, 0, 31, 0.3);
+            position: fixed; top: 24px; right: 24px; z-index: 100;
+            display: flex; align-items: center; gap: 4px;
+            background: var(--paper); border: 1px solid var(--line-strong);
+            border-radius: 40px; padding: 5px 6px; box-shadow: 0 6px 20px rgba(26,23,18,0.15);
         }
-
-        .language-toggle:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 6px 30px rgba(210, 0, 31, 0.4);
-            border-color: rgba(210, 0, 31, 0.5);
-        }
-
         .language-option {
-            padding: 8px 20px;
-            border-radius: 25px;
-            font-weight: 600;
-            font-size: 14px;
-            transition: all 0.3s ease;
-            cursor: pointer;
-            text-decoration: none;
-            color: var(--text-color);
-            position: relative;
-            display: flex;
-            align-items: center;
-            gap: 6px;
+            display: inline-flex; align-items: center; gap: 5px;
+            padding: 6px 14px; border-radius: 30px; text-decoration: none;
+            font-size: 12px; font-weight: 700; letter-spacing: 1px; color: var(--gray);
+            transition: all 0.2s;
         }
+        .language-option.active { background: var(--red); color: #fff; }
+        .language-divider { width: 1px; height: 16px; background: var(--line-strong); }
 
-        .language-option i {
-            font-size: 14px;
-            opacity: 0.7;
+        .print-button {
+            position: fixed; bottom: 26px; right: 26px; z-index: 100;
+            width: 56px; height: 56px; border-radius: 50%;
+            background: var(--red); color: #fff; border: none; cursor: pointer;
+            display: inline-flex; align-items: center; justify-content: center; font-size: 20px;
+            box-shadow: 0 8px 24px rgba(210, 0, 31, 0.4); transition: transform 0.2s, background 0.2s;
         }
+        .print-button:hover { background: var(--red-deep); transform: translateY(-3px) scale(1.05); }
 
-        .language-option.active {
-            background: var(--background-gradient);
-            color: var(--white-text);
-            box-shadow: 0 2px 10px rgba(210, 0, 31, 0.4);
-            animation: pulseActive 2s ease-in-out infinite;
-        }
-
-        @keyframes pulseActive {
-            0%, 100% {
-                transform: scale(1);
-            }
-            50% {
-                transform: scale(1.05);
-            }
-        }
-
-        .language-option.active i {
-            opacity: 1;
-            animation: checkRotate 0.5s ease-out;
-        }
-
-        @keyframes checkRotate {
-            from {
-                transform: rotate(-180deg);
-                opacity: 0;
-            }
-            to {
-                transform: rotate(0deg);
-                opacity: 1;
-            }
-        }
-
-        .language-option:not(.active):hover {
-            background: rgba(210, 0, 31, 0.1);
-            color: var(--text-color);
-        }
-
-        .language-divider {
-            width: 1px;
-            height: 20px;
-            background: rgba(210, 0, 31, 0.3);
-            margin: 0 5px;
-        }
-
-        .print-button:hover {
-            transform: scale(1.1);
-            box-shadow: 0 6px 30px rgba(210, 0, 31, 0.5);
-        }
-
-        .print-button i {
-            font-size: 24px;
-        }
-
-        /* Responsive design */
-        @media (max-width: 768px) {
-            .cv-container {
-                margin: 0;
-                border-radius: 0;
-                max-width: 100%;
-            }
-
-            .header {
-                padding: 30px 20px;
-            }
-
-            .header h1 {
-                font-size: 22px;
-                text-align: center;
-            }
-            .header-tagline,
-            .role {
-                font-size: 14px;
-                text-align: center;
-            }
-            .contact-info {
-                justify-content: center;
-                flex-direction: column;
-                gap: 6px;
-            }
-            .contact-item {
-                font-size: 12px;
-                padding: 6px 10px;
-                width: 100%;
-            }
-            .language-option i {
-                font-size: 14px;
-                opacity: 0.7;
-            }
-
-            .language-option.active {
-                background: var(--background-gradient);
-                color: var(--white-text);
-                box-shadow: 0 2px 10px rgba(210, 0, 31, 0.4);
-                animation: pulseActive 2s ease-in-out infinite;
-            }
-
-            @keyframes pulseActive {
-                0%, 100% {
-                    transform: scale(1);
-                }
-                50% {
-                    transform: scale(1.05);
-                }
-            }
-
-            .language-option.active i {
-                opacity: 1;
-                animation: checkRotate 0.5s ease-out;
-            }
-
-            @keyframes checkRotate {
-                from {
-                    transform: rotate(-180deg);
-                    opacity: 0;
-                }
-                to {
-                    transform: rotate(0deg);
-                    opacity: 1;
-                }
-            }
-
-            .language-option:not(.active):hover {
-                background: rgba(210, 0, 31, 0.1);
-                color: var(--text-color);
-            }
-
-            .language-divider {
-                width: 1px;
-                height: 20px;
-                background: rgba(210, 0, 31, 0.3);
-                margin: 0 5px;
-            }
-
-            .print-button:hover {
-                transform: scale(1.1);
-                box-shadow: 0 6px 30px rgba(210, 0, 31, 0.5);
-            }
-
-            .print-button i {
-                font-size: 24px;
-            }
-                padding: 25px 15px;
-            }
-
-            .section-title {
-                font-size: 16px;
-            }
-        }
-
-        /* Print styles */
-        @media print {
-            body {
-                background: white;
-            }
-
-            .animated-bg,
-            .shape,
-            .print-button,
-            .language-toggle {
-                display: none !important;
-            }
-
-            .cv-container {
-                box-shadow: none;
-                border: none;
-                margin: 0;
-            }
-
-            .section-title {
-                background: var(--renner-dark-red) !important;
-                color: var(--white-text) !important;
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
-            }
-
-            .header {
-                background: var(--background-gradient) !important;
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
-                page-break-inside: avoid;
-                padding: 30px !important;
-            }
-
-            .header-text {
-                padding-right: 0 !important;
-            }
-
-            /* Hide decorative elements */
-            .header::after,
-            .header::before {
-                display: none !important;
-            }
-        }
-
-        /* Dots container for skills from cv-texts.js - Renner colors */
-        .dots-container {
-            display: flex;
-            align-items: center;
-            gap: 4px;
-            flex-wrap: nowrap;
-        }
-
-        .dot {
-            width: 6px;
-            height: 6px;
-            border-radius: 50%;
-            background-color: rgba(210, 0, 31, 0.2);
-            transition: all 0.3s ease;
-            flex-shrink: 0;
-        }
-
-        .dot.filled {
-            background: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
-            box-shadow: 0 1px 3px rgba(210, 0, 31, 0.4);
-            animation: dotPulse 2s ease-in-out infinite alternate;
-        }
-
-        @keyframes dotPulse {
-            0% {
-                transform: scale(1);
-                box-shadow: 0 1px 3px rgba(210, 0, 31, 0.4);
-            }
-            100% {
-                transform: scale(1.1);
-                box-shadow: 0 2px 6px rgba(210, 0, 31, 0.6);
-            }
-        }
-
-        .tool-item {
-            margin-bottom: 15px;
-        }
-
-        .tool-name {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 8px;
-            font-size: 14px;
-            font-weight: 500;
-        }
-
-        .tool-percentage {
-            font-size: 12px;
-            color: var(--renner-red);
-            font-weight: 600;
+        /* ==================== RESPONSIVO ==================== */
+        @media (max-width: 820px) {
+            .cv-container { margin: 0; }
+            .header { padding: 42px 26px 26px; }
+            .header-content { flex-direction: column; }
+            .header h1 { font-size: 40px; max-width: none; }
+            .brandmark { margin-top: 4px; }
+            .header-divider, .contact-section, .section { padding-left: 26px; padding-right: 26px; }
+            .header-divider { margin-left: 26px; margin-right: 26px; }
+            .skills-container { grid-template-columns: 1fr; gap: 26px; }
+            .achievements-container, .education-container, .projects-container { grid-template-columns: 1fr; }
         }
     </style>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-    <script src="../../assets/js/cv-texts.js"></script>
-    <!-- Favicon Meta Tags -->
-    <meta name="theme-color" content="#D2001F">
-    <meta name="msapplication-TileColor" content="#D2001F">
-    <meta name="msapplication-config" content="assets/favicons/browserconfig.xml">
 </head>
 <body>
-    <div class="animated-bg"></div>
-
-    <!-- Floating shapes -->
-    <div class="shape"></div>
-    <div class="shape"></div>
-    <div class="shape"></div>
-
     <div class="cv-container">
         <header class="header">
-            <div class="particle"></div>
-            <div class="particle"></div>
-            <div class="particle"></div>
-
             <div class="header-content">
-                <div class="logo-container">
-                    <img src="../../assets/images/lojasrenner.png" alt="Lojas Renner" class="renner-logo-header">
+                <div class="header-text">
+                    <h1 id="cv-name"></h1>
+                    <div class="role" id="cv-role"></div>
                 </div>
-
-                <div class="header-text-content">
-                    <div class="company-tagline">Fashion & Style Excellence</div>
-                    <div class="header-text">
-                        <h1 id="cv-name"></h1>
-                        <div class="role" id="cv-role"></div>
-                    </div>
+                <div class="brandmark">
+                    <img src="../../assets/images/lojasrenner.png" alt="Lojas Renner S.A.">
                 </div>
-            </div>
-
-            <!-- Contact section moved outside header-content -->
-            <div class="contact-section">
-                <div class="contact-info">
-                        <div class="contact-item">
-                            <button class="contact-button" onclick="openEmailForm()">
-                                <i class="fas fa-envelope"></i> <span id="cv-email"></span>
-                            </button>
-                            <span class="contact-cta" id="cv-cta-email"></span>
-                        </div>
-
-                        <div class="contact-item">
-                            <button class="contact-button" onclick="openPhoneForm()">
-                                <i class="fas fa-phone"></i> <span id="cv-phone"></span>
-                            </button>
-                            <span class="contact-cta" id="cv-cta-phone"></span>
-                        </div>
-
-                        <div class="location" id="cv-location">
-                            <i class="fas fa-map-marker-alt"></i> <span></span>
-                        </div>
-
-                        <div class="contact-item">
-                            <a href="https://linkedin.com/in/pedrohmarconato" class="contact-button" target="_blank">
-                                <i class="fab fa-linkedin"></i> <span id="cv-linkedin"></span>
-                            </a>
-                            <span class="contact-cta" id="cv-cta-linkedin"></span>
-                        </div>
-
-                        <div class="contact-item">
-                            <a href="https://github.com/pedrohmarconato/Pedro-Marconato-CV" class="contact-button" target="_blank">
-                                <i class="fab fa-github"></i> <span id="cv-repository"></span>
-                            </a>
-                            <span class="contact-cta" id="cv-cta-repository"></span>
-                        </div>
-                    </div>
             </div>
         </header>
+
+        <div class="header-divider"></div>
+
+        <div class="contact-section">
+            <div class="contact-info">
+                <div class="contact-item">
+                    <button class="contact-button" onclick="openEmailForm()">
+                        <i class="fas fa-envelope"></i> <span id="cv-email"></span>
+                    </button>
+                </div>
+                <div class="contact-item">
+                    <button class="contact-button" onclick="openPhoneForm()">
+                        <i class="fas fa-phone"></i> <span id="cv-phone"></span>
+                    </button>
+                </div>
+                <div class="location" id="cv-location">
+                    <i class="fas fa-map-marker-alt"></i> <span></span>
+                </div>
+                <div class="contact-item">
+                    <a href="https://linkedin.com/in/pedrohmarconato" class="contact-button" target="_blank">
+                        <i class="fab fa-linkedin"></i> <span id="cv-linkedin"></span>
+                    </a>
+                </div>
+                <div class="contact-item">
+                    <a href="https://github.com/pedrohmarconato/Pedro-Marconato-CV" class="contact-button" target="_blank">
+                        <i class="fab fa-github"></i> <span id="cv-repository"></span>
+                    </a>
+                </div>
+            </div>
+        </div>
 
         <section class="section">
             <h2 class="section-title" id="section-profile"></h2>
@@ -1483,90 +329,85 @@
 
         <section class="section">
             <h2 class="section-title" id="section-experience"></h2>
-            <div class="experience-timeline" id="cv-experience"></div>
+            <div class="experience-timeline" id="experience-container"></div>
         </section>
 
         <section class="section">
             <h2 class="section-title" id="section-education"></h2>
-            <div class="education-container" id="cv-education"></div>
+            <div class="education-container" id="education-container"></div>
         </section>
 
         <section class="section">
             <h2 class="section-title" id="section-projects"></h2>
-            <div class="projects-container" id="cv-projects"></div>
+            <div class="projects-container" id="projects-container"></div>
         </section>
     </div>
 
-    <!-- Language toggle button -->
+    <!-- Toggle de idioma -->
     <div class="language-toggle">
-        <a href="renner.html" class="language-option active">
-            <i class="fas fa-check-circle"></i>
-            <span id="lang-en">EN</span>
-        </a>
+        <a href="renner.html" class="language-option active"><i class="fas fa-check-circle"></i><span id="lang-en">EN</span></a>
         <div class="language-divider"></div>
-        <a href="renner_pt.html" class="language-option">
-            <span id="lang-pt">PT</span>
-        </a>
+        <a href="renner_pt.html" class="language-option"><span id="lang-pt">PT</span></a>
     </div>
 
-    <!-- Print button -->
-    <button class="print-button" onclick="var win = window.open('../../cv_styles/cv_renner_style_EN.html', '_blank'); win.onload = function() { win.print(); }">
+    <!-- FAB imprimir (abre o PDF editorial) -->
+    <button class="print-button" title="Download PDF" onclick="var win = window.open('../../cv_styles/cv_renner_style_EN.html', '_blank'); win.onload = function() { win.print(); }">
         <i class="fas fa-file-pdf"></i>
     </button>
 
-    <!-- Email Modal -->
+    <!-- Modal Email -->
     <div id="emailModal" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background-color:rgba(0,0,0,0.7); z-index:1000; justify-content:center; align-items:center;">
-        <div style="background-color:white; padding:40px; border-radius:16px; width:90%; max-width:500px; position:relative; box-shadow: 0 10px 40px rgba(0,0,0,0.2);">
+        <div style="background-color:white; padding:40px; border-radius:8px; width:90%; max-width:500px; position:relative; box-shadow: 0 10px 40px rgba(0,0,0,0.2);">
             <button onclick="closeEmailModal()" style="position:absolute; top:15px; right:15px; background:none; border:none; font-size:24px; cursor:pointer; color: var(--dark-gray);">×</button>
-            <h3 id="email-modal-title" style="margin-bottom:25px; color: var(--text-color); font-size: 24px;">Send Email</h3>
+            <h3 id="email-modal-title" style="margin-bottom:25px; color: var(--text-color); font-size: 24px; font-family: var(--font-serif);">Send Email</h3>
             <form action="https://formspree.io/f/mdkekegw" method="POST">
                 <div style="margin-bottom:20px;">
                     <label id="email-label-name" style="display:block; margin-bottom:8px; font-weight:500; color: var(--text-color);">Your Name</label>
-                    <input type="text" name="name" required style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:8px; font-size: 16px; transition: border-color 0.3s;">
+                    <input type="text" name="name" required style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:6px; font-size: 16px;">
                 </div>
                 <div style="margin-bottom:20px;">
                     <label id="email-label-email" style="display:block; margin-bottom:8px; font-weight:500; color: var(--text-color);">Your Email</label>
-                    <input type="email" name="email" required style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:8px; font-size: 16px; transition: border-color 0.3s;">
+                    <input type="email" name="email" required style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:6px; font-size: 16px;">
                 </div>
                 <div style="margin-bottom:20px;">
                     <label id="email-label-subject" style="display:block; margin-bottom:8px; font-weight:500; color: var(--text-color);">Subject</label>
-                    <input type="text" name="subject" required style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:8px; font-size: 16px; transition: border-color 0.3s;">
+                    <input type="text" name="subject" required style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:6px; font-size: 16px;">
                 </div>
                 <div style="margin-bottom:25px;">
                     <label id="email-label-message" style="display:block; margin-bottom:8px; font-weight:500; color: var(--text-color);">Message</label>
-                    <textarea name="message" required rows="5" style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:8px; font-size: 16px; transition: border-color 0.3s; resize: vertical;"></textarea>
+                    <textarea name="message" required rows="5" style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:6px; font-size: 16px; resize: vertical;"></textarea>
                 </div>
-                <button id="email-button" type="submit" style="background: var(--background-gradient); color: var(--white-text); border:none; padding:14px 28px; border-radius:8px; cursor:pointer; font-weight:600; font-size: 16px; transition: all 0.3s; box-shadow: 0 4px 15px rgba(210, 0, 31, 0.4);">Send</button>
+                <button id="email-button" type="submit" style="background: var(--background-gradient); color: var(--white-text); border:none; padding:14px 28px; border-radius:6px; cursor:pointer; font-weight:600; font-size: 16px; box-shadow: 0 4px 15px rgba(210, 0, 31, 0.4);">Send</button>
             </form>
         </div>
     </div>
 
-    <!-- Phone Modal -->
+    <!-- Modal Telefone -->
     <div id="phoneModal" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background-color:rgba(0,0,0,0.7); z-index:1000; justify-content:center; align-items:center;">
-        <div style="background-color:white; padding:40px; border-radius:16px; width:90%; max-width:500px; position:relative; box-shadow: 0 10px 40px rgba(0,0,0,0.2);">
+        <div style="background-color:white; padding:40px; border-radius:8px; width:90%; max-width:500px; position:relative; box-shadow: 0 10px 40px rgba(0,0,0,0.2);">
             <button onclick="closePhoneModal()" style="position:absolute; top:15px; right:15px; background:none; border:none; font-size:24px; cursor:pointer; color: var(--dark-gray);">×</button>
-            <h3 id="phone-modal-title" style="margin-bottom:25px; color: var(--text-color); font-size: 24px;">Get in Touch</h3>
+            <h3 id="phone-modal-title" style="margin-bottom:25px; color: var(--text-color); font-size: 24px; font-family: var(--font-serif);">Get in Touch</h3>
             <form action="https://formspree.io/f/mdkekegw" method="POST">
                 <input type="hidden" name="contact_type" value="phone_request">
                 <div style="margin-bottom:20px;">
-                    <label id="email-label-name" style="display:block; margin-bottom:8px; font-weight:500; color: var(--text-color);">Your Name</label>
-                    <input type="text" name="name" required style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:8px; font-size: 16px; transition: border-color 0.3s;">
+                    <label id="phone-label-name" style="display:block; margin-bottom:8px; font-weight:500; color: var(--text-color);">Your Name</label>
+                    <input type="text" name="name" required style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:6px; font-size: 16px;">
                 </div>
                 <div style="margin-bottom:20px;">
                     <label id="phone-label-phone" style="display:block; margin-bottom:8px; font-weight:500; color: var(--text-color);">Your Phone</label>
-                    <input type="tel" name="phone" required style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:8px; font-size: 16px; transition: border-color 0.3s;">
+                    <input type="tel" name="phone" required style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:6px; font-size: 16px;">
                 </div>
                 <div style="margin-bottom:20px;">
                     <label id="phone-label-besttime" style="display:block; margin-bottom:8px; font-weight:500; color: var(--text-color);">Best time to contact</label>
-                    <input type="text" name="best_time" required style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:8px; font-size: 16px; transition: border-color 0.3s;">
+                    <input type="text" name="best_time" required style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:6px; font-size: 16px;">
                 </div>
                 <div style="margin-bottom:25px;">
                     <label id="phone-label-message" style="display:block; margin-bottom:8px; font-weight:500; color: var(--text-color);">Message (Optional)</label>
-                    <textarea name="message" rows="3" style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:8px; font-size: 16px; transition: border-color 0.3s; resize: vertical;"></textarea>
+                    <textarea name="message" rows="3" style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:6px; font-size: 16px; resize: vertical;"></textarea>
                 </div>
-                <div style="display:flex; gap:15px;">
-                    <button id="phone-button" type="submit" style="background: var(--background-gradient); color: var(--white-text); border:none; padding:14px 28px; border-radius:8px; cursor:pointer; font-weight:600; font-size: 16px; transition: all 0.3s; box-shadow: 0 4px 15px rgba(210, 0, 31, 0.4);">Request Contact</button>
-                    <a href="https://wa.me/55981147758" target="_blank" style="display:inline-flex; align-items:center; background-color:#25D366; color:white; text-decoration:none; border:none; padding:14px 28px; border-radius:8px; cursor:pointer; font-weight:600; font-size: 16px; transition: all 0.3s; box-shadow: 0 4px 15px rgba(37, 211, 102, 0.3);">
+                <div style="display:flex; gap:15px; flex-wrap: wrap;">
+                    <button id="phone-button" type="submit" style="background: var(--background-gradient); color: var(--white-text); border:none; padding:14px 28px; border-radius:6px; cursor:pointer; font-weight:600; font-size: 16px; box-shadow: 0 4px 15px rgba(210, 0, 31, 0.4);">Request Contact</button>
+                    <a href="https://wa.me/55981147758" target="_blank" style="display:inline-flex; align-items:center; background-color:#25D366; color:white; text-decoration:none; padding:14px 28px; border-radius:6px; font-weight:600; font-size: 16px;">
                         <i class="fab fa-whatsapp" style="margin-right:8px;"></i> <span id="whatsapp-text">WhatsApp</span>
                     </a>
                 </div>
@@ -1574,176 +415,56 @@
         </div>
     </div>
 
-    <script>
-        function openEmailForm() {
-            document.getElementById('emailModal').style.display = 'flex';
-        }
-
-        function closeEmailModal() {
-            document.getElementById('emailModal').style.display = 'none';
-        }
-
-        function openPhoneForm() {
-            document.getElementById('phoneModal').style.display = 'flex';
-        }
-
-        function closePhoneModal() {
-            document.getElementById('phoneModal').style.display = 'none';
-        }
-
-        // Close modal when clicking outside
-        window.onclick = function(event) {
-            if (event.target == document.getElementById('emailModal')) {
-                closeEmailModal();
-            }
-            if (event.target == document.getElementById('phoneModal')) {
-                closePhoneModal();
-            }
-        }
-
-        // Style form inputs on focus
-        document.addEventListener('DOMContentLoaded', function() {
-            // Initialize modal texts
-            initializeModalTexts('en');
-
-            const inputs = document.querySelectorAll('input, textarea');
-            inputs.forEach(input => {
-                input.addEventListener('focus', function() {
-                    this.style.borderColor = 'var(--renner-red)';
-                });
-                input.addEventListener('blur', function() {
-                    this.style.borderColor = '#e5e7eb';
-                });
-            });
-
-            // Tooltip functionality for mobile
-            const tooltips = document.querySelectorAll('.tooltip');
-            tooltips.forEach(tooltip => {
-                tooltip.addEventListener('click', function(e) {
-                    e.stopPropagation();
-
-                    // Close all other tooltips
-                    tooltips.forEach(t => {
-                        if (t !== this) {
-                            t.classList.remove('tooltip-active');
-                        }
-                    });
-
-                    // Toggle current tooltip
-                    this.classList.toggle('tooltip-active');
-                });
-            });
-
-            // Close tooltips when clicking outside
-            document.addEventListener('click', function() {
-                tooltips.forEach(tooltip => {
-                    tooltip.classList.remove('tooltip-active');
-                });
-            });
-
-            // Initialize CV content from cv-texts.js
-            initializeBasicContent('en');
-
-            // Update additional section titles
-            const experienceTitleEl = document.getElementById('section-experience');
-            if (experienceTitleEl) experienceTitleEl.textContent = getText('sections.experience', 'en');
-
-            const educationTitleEl = document.getElementById('section-education');
-            if (educationTitleEl) educationTitleEl.textContent = getText('sections.education', 'en');
-
-            const projectsTitleEl = document.getElementById('section-projects');
-            if (projectsTitleEl) projectsTitleEl.textContent = getText('sections.projects', 'en');
-
-            // Skills sections
-            renderSkills('skills-strategic', 'strategic', 'en');
-            renderSkills('skills-tools', 'tools', 'en');
-            renderSkills('skills-emerging', 'emerging', 'en');
-
-            // Experience section
-            renderExperience('en');
-
-            // Education section
-            renderEducation('en');
-
-            // Projects section
-            renderProjects('en');
-        });
-
-        // Render experience section
-        function renderExperience(lang = 'en') {
-            const container = document.getElementById('cv-experience');
-            if (!container) return;
-
-            const experiences = getText('experience', lang);
-            let html = '';
-
-            experiences.forEach((exp, index) => {
-                html += `
-                    <div class="experience-item">
-                        <div class="job-title">
-                            <div class="job-number">${index + 1}</div>
-                            ${exp.title}
-                            ${renderTooltip(exp.tooltip)}
-                        </div>
-                        <div class="company">${exp.company}</div>
-                        <div class="period">${exp.period}</div>
-                        <div class="job-description">${exp.description}</div>
-                        <div class="achievements-container">
-                            ${renderAchievements(exp.achievements)}
-                        </div>
-                    </div>
-                `;
-            });
-
-            container.innerHTML = html;
-        }
-
-        // Render education section
-        function renderEducation(lang = 'en') {
-            const container = document.getElementById('cv-education');
-            if (!container) return;
-
-            const education = getText('education', lang);
-            let html = '';
-
-            education.forEach(edu => {
-                html += `
-                    <div class="education-item">
-                        <div class="degree">${edu.degree}</div>
-                        <div class="university">${edu.university}</div>
-                        <div class="thesis">${edu.thesis}</div>
-                    </div>
-                `;
-            });
-
-            container.innerHTML = html;
-        }
-
-        // Render projects section
-        function renderProjects(lang = 'en') {
-            const container = document.getElementById('cv-projects');
-            if (!container) return;
-
-            const projects = getText('projects', lang);
-            let html = '';
-
-            projects.forEach(project => {
-                html += `
-                    <div class="project-item">
-                        <div class="project-title">${project.title}</div>
-                        <div class="project-description">${project.description}</div>
-                        <div style="margin-top: 15px;">
-                            ${renderTechTags(project.techs)}
-                        </div>
-                    </div>
-                `;
-            });
-
-            container.innerHTML = html;
-        }
-    </script>
-
-    <!-- Dynamic Favicon System -->
+    <script src="../../assets/js/cv-texts.js"></script>
     <script src="../../assets/js/dynamic-favicon.js"></script>
+    <script>
+        function openEmailForm() { document.getElementById('emailModal').style.display = 'flex'; }
+        function closeEmailModal() { document.getElementById('emailModal').style.display = 'none'; }
+        function openPhoneForm() { document.getElementById('phoneModal').style.display = 'flex'; }
+        function closePhoneModal() { document.getElementById('phoneModal').style.display = 'none'; }
+        window.onclick = function(event) {
+            if (event.target == document.getElementById('emailModal')) closeEmailModal();
+            if (event.target == document.getElementById('phoneModal')) closePhoneModal();
+        };
+
+        document.addEventListener('DOMContentLoaded', function() {
+            var lang = 'en';
+            initializeModalTexts(lang);
+            initializeBasicContent(lang);
+
+            var exp = document.getElementById('section-experience');
+            if (exp) exp.textContent = getText('sections.experience', lang);
+            var edu = document.getElementById('section-education');
+            if (edu) edu.textContent = getText('sections.education', lang);
+            var proj = document.getElementById('section-projects');
+            if (proj) proj.textContent = getText('sections.projects', lang);
+
+            renderSkills('skills-strategic', 'strategic', lang);
+            renderSkills('skills-tools', 'tools', lang);
+            renderSkills('skills-emerging', 'emerging', lang);
+            renderExperienceTimeline(lang);
+            renderEducation(lang);
+            renderProjects(lang);
+
+            // realce de borda nos inputs
+            document.querySelectorAll('input, textarea').forEach(function(input) {
+                input.addEventListener('focus', function() { this.style.borderColor = 'var(--renner-red)'; });
+                input.addEventListener('blur', function() { this.style.borderColor = '#e5e7eb'; });
+            });
+
+            // tooltips (toque no mobile)
+            var tips = document.querySelectorAll('.tooltip');
+            tips.forEach(function(t) {
+                t.addEventListener('click', function(e) {
+                    e.stopPropagation();
+                    tips.forEach(function(o) { if (o !== t) o.classList.remove('tooltip-active'); });
+                    t.classList.toggle('tooltip-active');
+                });
+            });
+            document.addEventListener('click', function() {
+                tips.forEach(function(t) { t.classList.remove('tooltip-active'); });
+            });
+        });
+    </script>
 </body>
 </html>

--- a/templates/companies/renner_pt.html
+++ b/templates/companies/renner_pt.html
@@ -3,1475 +3,321 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pedro Marconato - CV</title>
-    <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap');
-        
-        :root {
-            /* Renner Colors - Based on brand specifications */
-            --renner-red: #D2001F;
-            --renner-dark-red: #B30020;
-            --renner-light-red: #E85A70;
-            --pure-white: #FFFFFF;
-            --light-gray: #F8F8F8;
-            --dark-gray: #333333;
-            --neutral-gray: #666666;
-            --off-white: #FAFAFA;
-            
-            /* Applied Colors */
-            --primary-color: #D2001F;
-            --secondary-color: #B30020;
-            --accent-color: #E85A70;
-            --text-color: #333333;
-            --white-text: #FFFFFF;
-            --gray-text: #666666;
-            --border-color: rgba(210, 0, 31, 0.2);
-            --background-gradient: linear-gradient(135deg, #D2001F 0%, #B30020 100%);
-            --glow-color: rgba(210, 0, 31, 0.3);
-        }
-        
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-        
-        body {
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            color: var(--text-color);
-            line-height: 1.6;
-            background: white;
-            min-height: 100vh;
-            position: relative;
-            overflow-x: hidden;
-        }
-
-        /* Animated background with Renner style */
-        .animated-bg {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: white;
-            z-index: -2;
-        }
-
-        @keyframes gradientShift {
-            0% { background-position: 0% 50%; }
-            50% { background-position: 100% 50%; }
-            100% { background-position: 0% 50%; }
-        }
-
-        /* Floating geometric shapes - Renner modern style */
-        .shape {
-            position: absolute;
-            opacity: 0.08;
-            animation: float 25s infinite ease-in-out;
-        }
-
-        .shape:nth-child(1) {
-            width: 140px;
-            height: 140px;
-            background: linear-gradient(45deg, var(--renner-red), var(--renner-dark-red));
-            border-radius: 25px;
-            top: 8%;
-            left: 5%;
-            animation-delay: 0s;
-            transform: rotate(45deg);
-        }
-
-        .shape:nth-child(2) {
-            width: 90px;
-            height: 90px;
-            background: var(--pure-white);
-            border-radius: 50%;
-            top: 65%;
-            right: 8%;
-            animation-delay: 12s;
-        }
-
-        .shape:nth-child(3) {
-            width: 110px;
-            height: 110px;
-            background: linear-gradient(135deg, var(--renner-dark-red), var(--renner-light-red));
-            clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
-            bottom: 15%;
-            left: 20%;
-            animation-delay: 8s;
-        }
-
-        @keyframes float {
-            0%, 100% { transform: translateY(0) rotate(0deg); }
-            33% { transform: translateY(-50px) rotate(120deg); }
-            66% { transform: translateY(50px) rotate(240deg); }
-        }
-        
-        .cv-container {
-            max-width: 1000px;
-            margin: 30px auto;
-            background: rgba(255, 255, 255, 0.98);
-            backdrop-filter: blur(20px) saturate(180%);
-            -webkit-backdrop-filter: blur(20px) saturate(180%);
-            border-radius: 28px;
-            box-shadow: 
-                0 20px 50px rgba(0, 0, 0, 0.3),
-                0 15px 30px rgba(210, 0, 31, 0.15),
-                inset 0 1px 2px rgba(255, 255, 255, 0.9);
-            border: 1px solid rgba(210, 0, 31, 0.3);
-            overflow: hidden;
-            position: relative;
-            animation: containerGlow 18s ease infinite;
-        }
-
-        @keyframes containerGlow {
-            0%, 100% { 
-                box-shadow: 
-                    0 20px 50px rgba(0, 0, 0, 0.3),
-                    0 15px 30px rgba(210, 0, 31, 0.15),
-                    0 0 80px rgba(210, 0, 31, 0.05),
-                    inset 0 1px 2px rgba(255, 255, 255, 0.9);
-            }
-            50% { 
-                box-shadow: 
-                    0 20px 50px rgba(0, 0, 0, 0.3),
-                    0 15px 30px rgba(210, 0, 31, 0.25),
-                    0 0 100px rgba(210, 0, 31, 0.1),
-                    inset 0 1px 2px rgba(255, 255, 255, 0.9);
-            }
-        }
-
-        .cv-container::before {
-            content: '';
-            position: absolute;
-            top: -50%;
-            left: -50%;
-            width: 200%;
-            height: 200%;
-            background: radial-gradient(circle at 30% 50%, rgba(210, 0, 31, 0.03) 0%, transparent 50%),
-                        radial-gradient(circle at 70% 30%, rgba(179, 0, 32, 0.03) 0%, transparent 50%),
-                        radial-gradient(circle at 50% 80%, rgba(232, 90, 112, 0.02) 0%, transparent 50%);
-            animation: rotate 30s linear infinite;
-            pointer-events: none;
-        }
-
-        @keyframes rotate {
-            from { transform: rotate(0deg); }
-            to { transform: rotate(360deg); }
-        }
-        
-        .header {
-            background: var(--background-gradient);
-            padding: 40px 60px 60px 60px;
-            position: relative;
-            overflow: hidden;
-            min-height: 300px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-        
-        /* Animated wave backgrounds - Renner modern style */
-        .header::before {
-            content: '';
-            position: absolute;
-            top: -50%;
-            left: -50%;
-            width: 200%;
-            height: 200%;
-            background: radial-gradient(circle at 20% 50%, rgba(232, 90, 112, 0.15) 0%, transparent 50%),
-                        radial-gradient(circle at 80% 50%, rgba(255, 255, 255, 0.1) 0%, transparent 50%),
-                        radial-gradient(circle at 40% 80%, rgba(210, 0, 31, 0.2) 0%, transparent 50%);
-            animation: waveMotion 22s ease-in-out infinite;
-            z-index: -1;
-        }
-
-        .header::after {
-            content: '';
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 320"><path fill="%23ffffff" fill-opacity="0.1" d="M0,96L48,112C96,128,192,160,288,165.3C384,171,480,149,576,128C672,107,768,85,864,96C960,107,1056,149,1152,165.3C1248,181,1344,171,1392,165.3L1440,160L1440,320L1392,320C1344,320,1248,320,1152,320C1056,320,960,320,864,320C768,320,672,320,576,320C480,320,384,320,288,320C192,320,96,320,48,320L0,320Z"></path></svg>') repeat-x;
-            background-size: 1440px 320px;
-            animation: wave 15s cubic-bezier(0.36, 0.45, 0.63, 0.53) infinite;
-            transform: translate3d(0, 0, 0);
-            z-index: -1;
-        }
-
-        @keyframes waveMotion {
-            0%, 100% { transform: rotate(0deg) scale(1); }
-            25% { transform: rotate(2deg) scale(1.05); }
-            50% { transform: rotate(-2deg) scale(0.98); }
-            75% { transform: rotate(1deg) scale(1.02); }
-        }
-
-        @keyframes wave {
-            0% { transform: translateX(0); }
-            100% { transform: translateX(-1440px); }
-        }
-
-        /* Floating particles - modern geometric style */
-        .particle {
-            position: absolute;
-            background: rgba(255, 255, 255, 0.2);
-            pointer-events: none;
-            z-index: -1;
-        }
-
-        .particle:nth-child(1) {
-            width: 70px;
-            height: 70px;
-            top: 15%;
-            left: 8%;
-            border-radius: 50%;
-            animation: floatUp 12s infinite ease-in-out;
-        }
-
-        .particle:nth-child(2) {
-            width: 45px;
-            height: 45px;
-            top: 35%;
-            right: 15%;
-            border-radius: 8px;
-            animation: floatUp 14s infinite ease-in-out 3s;
-            background: rgba(232, 90, 112, 0.2);
-        }
-
-        .particle:nth-child(3) {
-            width: 85px;
-            height: 85px;
-            bottom: 25%;
-            left: 25%;
-            clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
-            animation: floatUp 16s infinite ease-in-out 6s;
-            background: rgba(210, 0, 31, 0.2);
-        }
-
-        @keyframes floatUp {
-            0%, 100% { 
-                transform: translateY(0) rotate(0deg);
-                opacity: 0.2;
-            }
-            50% { 
-                transform: translateY(-70px) rotate(180deg);
-                opacity: 0.4;
-            }
-        }
-
-        .header-content {
-            position: relative;
-            z-index: 100;
-            text-align: center;
-            width: 100%;
-            max-width: 1000px;
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            gap: 40px;
-        }
-
-        /* Logo container with animation */
-        .logo-container {
-            flex: 0 0 auto;
-            animation: logoEntrance 1.5s ease-out;
-            position: relative;
-            z-index: 101;
-        }
-
-        @keyframes logoEntrance {
-            0% {
-                transform: scale(0) rotate(-180deg);
-                opacity: 0;
-            }
-            50% {
-                transform: scale(1.2) rotate(90deg);
-            }
-            100% {
-                transform: scale(1) rotate(0deg);
-                opacity: 1;
-            }
-        }
-
-        .renner-logo-header {
-            width: 180px;
-            height: auto;
-            filter: drop-shadow(0 8px 25px rgba(0, 0, 0, 0.4))
-                    drop-shadow(0 2px 10px rgba(255, 255, 255, 0.3));
-            transition: all 0.5s ease;
-            animation: logoFloat 4s ease-in-out infinite;
-            position: relative;
-            z-index: 102;
-        }
-
-        @keyframes logoFloat {
-            0%, 100% { transform: translateY(0px) scale(1); }
-            50% { transform: translateY(-10px) scale(1.03); }
-        }
-
-        .renner-logo-header:hover {
-            transform: scale(1.1) rotate(2deg);
-            filter: drop-shadow(0 12px 30px rgba(0, 0, 0, 0.5))
-                    drop-shadow(0 4px 15px rgba(210, 0, 31, 0.4));
-        }
-
-        /* Header text content */
-        .header-text-content {
-            flex: 1;
-            text-align: left;
-            position: relative;
-            z-index: 101;
-        }
-        
-        /* Animated tagline */
-        .company-tagline {
-            font-size: 20px;
-            font-weight: 600;
-            color: var(--white-text);
-            text-transform: uppercase;
-            letter-spacing: 2px;
-            margin-bottom: 20px;
-            text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
-            opacity: 0.95;
-            background: linear-gradient(45deg, #ffffff, #E85A70);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-        }
-
-        .header-text {
-            max-width: 100%;
-            margin: 0;
-        }
-        
-        .header h1 {
-            font-size: 36px;
-            font-weight: 800;
-            color: var(--white-text);
-            margin-bottom: 12px;
-            letter-spacing: -0.5px;
-            text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
-            animation: nameSlide 1s ease-out 0.5s both;
-        }
-
-        @keyframes nameSlide {
-            from {
-                transform: translateX(-100px);
-                opacity: 0;
-            }
-            to {
-                transform: translateX(0);
-                opacity: 1;
-            }
-        }
-        
-        .role {
-            font-size: 18px;
-            font-weight: 600;
-            color: var(--white-text);
-            margin-bottom: 20px;
-            text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
-            text-transform: uppercase;
-            letter-spacing: 1px;
-            animation: roleSlide 1s ease-out 0.7s both;
-            opacity: 0.9;
-        }
-
-        @keyframes roleSlide {
-            from {
-                transform: translateX(100px);
-                opacity: 0;
-            }
-            to {
-                transform: translateX(0);
-                opacity: 1;
-            }
-        }
-        
-        /* Contact section styling */
-        .contact-section {
-            margin-top: 30px;
-            padding: 0 60px;
-            position: relative;
-            z-index: 100;
-        }
-        
-        .contact-info {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 12px;
-            align-items: center;
-            justify-content: center;
-            position: relative;
-            z-index: 101;
-        }
-        
-        .contact-button {
-            display: inline-flex;
-            align-items: center;
-            background: rgba(255, 255, 255, 0.15);
-            backdrop-filter: blur(10px);
-            border-radius: 12px;
-            padding: 10px 16px;
-            text-decoration: none;
-            color: var(--white-text);
-            font-size: 14px;
-            font-weight: 500;
-            transition: all 0.3s ease;
-            border: 1px solid rgba(255, 255, 255, 0.2);
-            cursor: pointer;
-            position: relative;
-            overflow: visible;
-            z-index: 102;
-        }
-        
-        .contact-button:hover {
-            background: rgba(210, 0, 31, 0.3);
-            transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(210, 0, 31, 0.4);
-            border-color: rgba(210, 0, 31, 0.5);
-        }
-        
-        .contact-button i {
-            margin-right: 8px;
-            font-size: 16px;
-        }
-        
-        .contact-item {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 4px;
-        }
-        
-        .contact-cta {
-            font-size: 11px;
-            color: rgba(255, 255, 255, 0.8);
-            font-weight: 400;
-            animation: gentlePulse 3s ease-in-out infinite;
-        }
-        
-        @keyframes gentlePulse {
-            0%, 100% {
-                opacity: 0.8;
-                transform: scale(1);
-            }
-            50% {
-                opacity: 1;
-                transform: scale(1.02);
-            }
-        }
-        
-        .location {
-            display: flex;
-            align-items: center;
-            font-size: 14px;
-            color: var(--white-text);
-        }
-        
-        .location i {
-            margin-right: 6px;
-        }
-        
-        .section {
-            padding: 35px 80px;
-            position: relative;
-        }
-
-        .section:not(:last-child)::after {
-            content: '';
-            position: absolute;
-            bottom: 0;
-            left: 80px;
-            right: 80px;
-            height: 1px;
-            background: linear-gradient(to right, transparent, var(--border-color), transparent);
-        }
-        
-        .section-title {
-            background: var(--background-gradient);
-            color: var(--white-text);
-            font-size: 20px;
-            font-weight: 600;
-            margin-bottom: 20px;
-            padding: 12px 20px;
-            border-radius: 14px;
-            letter-spacing: 0.3px;
-            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
-            display: inline-block;
-            position: relative;
-            overflow: hidden;
-        }
-
-        .section-title::before {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: -100%;
-            width: 100%;
-            height: 100%;
-            background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
-            animation: titleShimmer 6s infinite;
-        }
-
-        @keyframes titleShimmer {
-            0% { left: -100%; }
-            50%, 100% { left: 100%; }
-        }
-        
-        .profile-text {
-            font-size: 16px;
-            line-height: 1.8;
-            color: var(--text-color);
-            text-align: justify;
-        }
-        
-        .skills-container {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 30px;
-        }
-        
-        @media (max-width: 1000px) {
-            .skills-container {
-                grid-template-columns: repeat(2, 1fr);
-            }
-        }
-        
-        @media (max-width: 600px) {
-            .skills-container {
-                grid-template-columns: 1fr;
-            }
-        }
-        
-        .skills-column {
-            background: linear-gradient(135deg, rgba(210, 0, 31, 0.08), rgba(0, 0, 0, 0.05));
-            padding: 25px;
-            border-radius: 16px;
-            border: 1px solid rgba(210, 0, 31, 0.2);
-            backdrop-filter: blur(10px);
-            transition: all 0.3s ease;
-        }
-
-        .skills-column:hover {
-            transform: translateY(-3px);
-            box-shadow: 0 8px 24px rgba(210, 0, 31, 0.2);
-            border-color: rgba(210, 0, 31, 0.4);
-        }
-        
-        .skill-item {
-            display: flex;
-            align-items: center;
-            margin-bottom: 12px;
-            font-size: 15px;
-            color: var(--text-color);
-            font-weight: 500;
-            transition: transform 0.2s ease;
-        }
-
-        .skill-item:hover {
-            transform: translateX(5px);
-        }
-        
-        .skill-item i {
-            color: var(--renner-red);
-            margin-right: 12px;
-            font-size: 18px;
-        }
-        
-        .tool-item {
-            margin-bottom: 18px;
-        }
-        
-        .tool-name {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            font-weight: 600;
-            font-size: 14px;
-            margin-bottom: 8px;
-            color: var(--text-color);
-        }
-
-        .tool-percentage {
-            font-size: 13px;
-            color: var(--renner-red);
-            font-weight: 700;
-        }
-        
-        .progress-bar {
-            height: 8px;
-            background: rgba(210, 0, 31, 0.1);
-            border-radius: 10px;
-            overflow: hidden;
-            box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
-        }
-        
-        .progress {
-            height: 100%;
-            background: linear-gradient(90deg, var(--renner-dark-red), var(--renner-red));
-            border-radius: 10px;
-            position: relative;
-            animation: progressGrow 1.5s ease-out;
-        }
-        
-        /* Renner colored progress bars */
-        .tool-item:nth-child(3n+1) .progress {
-            background: linear-gradient(90deg, #D2001F 0%, #E85A70 100%);
-        }
-        
-        .tool-item:nth-child(3n+2) .progress {
-            background: linear-gradient(90deg, #B30020 0%, #D2001F 100%);
-        }
-        
-        .tool-item:nth-child(3n) .progress {
-            background: linear-gradient(90deg, #E85A70 0%, #B30020 100%);
-        }
-
-        @keyframes progressGrow {
-            from { width: 0; }
-        }
-
-        .progress::after {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
-            background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.3), transparent);
-            animation: progressShimmer 2s infinite;
-        }
-
-        @keyframes progressShimmer {
-            0% { transform: translateX(-100%); }
-            100% { transform: translateX(100%); }
-        }
-        
-        /* Tooltip styles - Renner themed */
-        .tooltip {
-            position: relative;
-            display: inline-block;
-            cursor: help;
-        }
-        
-        .tooltip .tooltip-icon {
-            color: var(--renner-red);
-            font-size: 14px;
-            margin-left: 5px;
-            transition: transform 0.2s, color 0.2s;
-        }
-        
-        .tooltip:hover .tooltip-icon,
-        .tooltip:focus .tooltip-icon,
-        .tooltip:active .tooltip-icon {
-            color: var(--renner-light-red);
-            transform: scale(1.2);
-        }
-        
-        .tooltip .tooltip-text {
-            visibility: hidden;
-            width: 380px;
-            background: linear-gradient(145deg, var(--renner-dark-red), var(--renner-red));
-            color: var(--white-text);
-            text-align: left;
-            border-radius: 12px;
-            padding: 0;
-            position: absolute;
-            z-index: 100;
-            bottom: 125%;
-            left: 50%;
-            margin-left: -190px;
-            opacity: 0;
-            transition: opacity 0.4s, transform 0.3s;
-            transform: translateY(10px);
-            font-size: 13px;
-            line-height: 1.5;
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
-            overflow: hidden;
-            max-height: 85vh;
-            overflow-y: auto;
-        }
-        
-        .tooltip .tooltip-text::after {
-            content: "";
-            position: absolute;
-            top: 100%;
-            left: 50%;
-            margin-left: -8px;
-            border-width: 8px;
-            border-style: solid;
-            border-color: var(--renner-dark-red) transparent transparent transparent;
-        }
-        
-        .tooltip:hover .tooltip-text,
-        .tooltip:focus .tooltip-text,
-        .tooltip:active .tooltip-text,
-        .tooltip.tooltip-active .tooltip-text {
-            visibility: visible;
-            opacity: 1;
-            transform: translateY(0);
-            min-height: 330px;
-        }
-        
-        .tooltip-active .tooltip-text {
-            position: absolute;
-            z-index: 9999;
-            overflow-y: auto;
-        }
-        
-        .tooltip-header {
-            background-color: rgba(210, 0, 31, 0.2);
-            padding: 12px 18px;
-            font-weight: 600;
-            font-size: 1.05em;
-            border-bottom: 1px solid rgba(210, 0, 31, 0.3);
-            color: var(--white-text);
-        }
-        
-        .tooltip-content {
-            padding: 18px;
-        }
-        
-        .tooltip-section {
-            margin-bottom: 15px;
-        }
-        
-        .tooltip-section:last-of-type {
-            margin-bottom: 0;
-        }
-        
-        .tooltip-section-title {
-            display: flex;
-            align-items: center;
-            font-weight: 500;
-            font-size: 1em;
-            color: #ffffff;
-            margin-bottom: 10px;
-        }
-        
-        .tooltip-section-title .fas {
-            margin-right: 12px;
-            font-size: 1.1em;
-            width: 20px;
-            text-align: center;
-            opacity: 1;
-            color: #f0f0f0;
-        }
-        
-        .tooltip-list {
-            list-style-position: outside;
-            padding-left: 20px;
-            margin-top: 5px;
-        }
-        
-        .tooltip-list li {
-            margin-bottom: 10px;
-            line-height: 1.5;
-        }
-        
-        .tooltip-list li::marker {
-            color: rgba(255, 255, 255, 0.7);
-        }
-        
-        /* Mobile responsiveness for tooltips */
-        @media (max-width: 768px) {
-            .tooltip .tooltip-text {
-                width: 90vw;
-                max-width: 320px;
-                left: 50%;
-                transform: translateX(-50%);
-                margin-left: 0;
-                font-size: 12px;
-                max-height: 75vh;
-            }
-            
-            .tooltip-active .tooltip-text {
-                position: fixed;
-                top: 50%;
-                left: 50%;
-                transform: translate(-50%, -50%) !important;
-                width: 90vw;
-                max-width: 380px;
-                z-index: 10000;
-            }
-        }
-        
-        .experience-timeline {
-            position: relative;
-            margin-left: 30px;
-            padding-left: 40px;
-        }
-        
-        .experience-timeline::before {
-            content: "";
-            position: absolute;
-            left: 0;
-            top: 0;
-            bottom: 0;
-            width: 3px;
-            background: linear-gradient(to bottom, var(--renner-dark-red), var(--renner-red));
-            border-radius: 3px;
-        }
-        
-        .experience-item {
-            margin-bottom: 25px;
-            position: relative;
-            padding: 25px;
-            border-radius: 16px;
-            background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.9));
-            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
-            border: 1px solid rgba(210, 0, 31, 0.2);
-            transition: all 0.3s ease;
-        }
-
-        .experience-item:hover {
-            transform: translateX(5px);
-            box-shadow: 0 4px 20px rgba(210, 0, 31, 0.2);
-            border-color: rgba(210, 0, 31, 0.4);
-        }
-        
-        .experience-item::before {
-            content: "";
-            position: absolute;
-            left: -46px;
-            top: 35px;
-            width: 12px;
-            height: 12px;
-            border-radius: 50%;
-            background: var(--renner-red);
-            border: 3px solid white;
-            box-shadow: 0 0 0 3px rgba(210, 0, 31, 0.3);
-            z-index: 1;
-        }
-        
-        .job-title {
-            font-weight: 600;
-            font-size: 20px;
-            color: var(--text-color);
-            margin-bottom: 8px;
-            display: flex;
-            align-items: center;
-            gap: 12px;
-        }
-        
-        .job-number {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            width: 36px;
-            height: 36px;
-            background: var(--background-gradient);
-            color: var(--white-text);
-            border-radius: 50%;
-            font-size: 16px;
-            font-weight: 600;
-            box-shadow: 0 3px 10px rgba(210, 0, 31, 0.3);
-        }
-        
-        .company {
-            font-weight: 500;
-            font-size: 16px;
-            color: var(--gray-text);
-            margin-bottom: 5px;
-        }
-        
-        .period {
-            font-size: 14px;
-            color: var(--text-color);
-            font-style: italic;
-            margin-bottom: 15px;
-            display: inline-block;
-            background: rgba(210, 0, 31, 0.1);
-            padding: 4px 12px;
-            border-radius: 20px;
-        }
-        
-        .job-description {
-            font-size: 15px;
-            line-height: 1.6;
-            color: var(--text-color);
-            margin-bottom: 20px;
-        }
-        
-        .achievements-container {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 15px;
-        }
-        
-        @media (max-width: 900px) {
-            .achievements-container {
-                grid-template-columns: repeat(2, 1fr);
-            }
-        }
-        
-        @media (max-width: 600px) {
-            .achievements-container {
-                grid-template-columns: 1fr;
-            }
-        }
-        
-        .achievement-item {
-            background: linear-gradient(135deg, rgba(210, 0, 31, 0.05), rgba(0, 0, 0, 0.02));
-            border-radius: 12px;
-            padding: 18px;
-            border: 1px solid rgba(210, 0, 31, 0.2);
-            display: flex;
-            align-items: flex-start;
-            gap: 12px;
-            transition: all 0.3s ease;
-        }
-        
-        .achievement-item:hover {
-            transform: translateY(-3px);
-            box-shadow: 0 6px 20px rgba(210, 0, 31, 0.2);
-            border-color: var(--renner-red);
-        }
-        
-        .achievement-icon {
-            font-size: 24px;
-            color: var(--renner-red);
-            flex-shrink: 0;
-        }
-        
-        .achievement-content {
-            flex: 1;
-        }
-        
-        .achievement-title {
-            font-weight: 600;
-            font-size: 15px;
-            color: var(--text-color);
-            margin-bottom: 6px;
-        }
-        
-        .achievement-description {
-            font-size: 14px;
-            line-height: 1.5;
-            color: var(--text-color);
-        }
-        
-        .education-container {
-            display: grid;
-            grid-template-columns: repeat(2, 1fr);
-            gap: 25px;
-        }
-        
-        @media (max-width: 700px) {
-            .education-container {
-                grid-template-columns: 1fr;
-            }
-        }
-        
-        .education-item {
-            background: linear-gradient(135deg, rgba(210, 0, 31, 0.08), rgba(0, 0, 0, 0.05));
-            padding: 25px;
-            border-radius: 16px;
-            border: 1px solid rgba(210, 0, 31, 0.2);
-            transition: all 0.3s ease;
-        }
-
-        .education-item:hover {
-            transform: translateY(-3px);
-            box-shadow: 0 8px 24px rgba(210, 0, 31, 0.15);
-        }
-        
-        .degree {
-            font-weight: 600;
-            font-size: 18px;
-            color: var(--text-color);
-            margin-bottom: 8px;
-        }
-        
-        .university {
-            font-size: 15px;
-            color: var(--text-color);
-            margin-bottom: 8px;
-        }
-        
-        .thesis {
-            font-size: 14px;
-            font-style: italic;
-            color: var(--gray-text);
-        }
-
-        .projects-container {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 20px;
-        }
-        
-        @media (max-width: 900px) {
-            .projects-container {
-                grid-template-columns: repeat(2, 1fr);
-            }
-        }
-        
-        @media (max-width: 600px) {
-            .projects-container {
-                grid-template-columns: 1fr;
-            }
-        }
-        
-        .project-item {
-            background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.9));
-            border-radius: 16px;
-            padding: 30px;
-            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
-            border: 1px solid rgba(210, 0, 31, 0.2);
-            transition: all 0.3s ease;
-            position: relative;
-            overflow: hidden;
-        }
-
-        .project-item::before {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            height: 3px;
-            background: var(--background-gradient);
-            transform: scaleX(0);
-            transform-origin: left;
-            transition: transform 0.3s ease;
-        }
-
-        .project-item:hover::before {
-            transform: scaleX(1);
-        }
-        
-        .project-item:hover {
-            transform: translateY(-5px);
-            box-shadow: 0 8px 30px rgba(210, 0, 31, 0.2);
-            border-color: var(--renner-red);
-        }
-        
-        .project-title {
-            font-weight: 600;
-            font-size: 18px;
-            color: var(--text-color);
-            margin-bottom: 12px;
-        }
-        
-        .project-description {
-            font-size: 14px;
-            line-height: 1.6;
-            color: var(--text-color);
-            margin-bottom: 15px;
-        }
-        
-        .tech-tag {
-            display: inline-block;
-            background: rgba(210, 0, 31, 0.1);
-            color: var(--text-color);
-            padding: 5px 12px;
-            border-radius: 20px;
-            font-size: 12px;
-            font-weight: 500;
-            margin-right: 8px;
-            margin-bottom: 8px;
-            border: 1px solid rgba(210, 0, 31, 0.3);
-            transition: all 0.2s ease;
-        }
-
-        .tech-tag:hover {
-            background: var(--renner-red);
-            color: var(--white-text);
-            transform: translateY(-2px);
-            box-shadow: 0 2px 8px rgba(210, 0, 31, 0.4);
-        }
-
-        /* Print button */
-        .print-button {
-            position: fixed;
-            bottom: 30px;
-            right: 30px;
-            background: var(--background-gradient);
-            color: var(--white-text);
-            border: none;
-            border-radius: 50%;
-            width: 60px;
-            height: 60px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            cursor: pointer;
-            box-shadow: 0 4px 20px rgba(210, 0, 31, 0.4);
-            transition: all 0.3s ease;
-            z-index: 100;
-        }
-        
-        /* Language toggle button */
-        .language-toggle {
-            position: fixed;
-            top: 30px;
-            right: 30px;
-            background: rgba(255, 255, 255, 0.95);
-            backdrop-filter: blur(10px);
-            border-radius: 30px;
-            padding: 5px;
-            display: flex;
-            align-items: center;
-            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
-            transition: all 0.3s ease;
-            z-index: 100;
-            border: 2px solid rgba(210, 0, 31, 0.3);
-        }
-        
-        .language-toggle:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 6px 30px rgba(210, 0, 31, 0.4);
-            border-color: rgba(210, 0, 31, 0.5);
-        }
-        
-        .language-option {
-            padding: 8px 20px;
-            border-radius: 25px;
-            font-weight: 600;
-            font-size: 14px;
-            transition: all 0.3s ease;
-            cursor: pointer;
-            text-decoration: none;
-            color: var(--text-color);
-            position: relative;
-            display: flex;
-            align-items: center;
-            gap: 6px;
-        }
-        
-        .language-option i {
-            font-size: 14px;
-            opacity: 0.7;
-        }
-        
-        .language-option.active {
-            background: var(--background-gradient);
-            color: var(--white-text);
-            box-shadow: 0 2px 10px rgba(210, 0, 31, 0.4);
-            animation: pulseActive 2s ease-in-out infinite;
-        }
-        
-        @keyframes pulseActive {
-            0%, 100% {
-                transform: scale(1);
-            }
-            50% {
-                transform: scale(1.05);
-            }
-        }
-        
-        .language-option.active i {
-            opacity: 1;
-            animation: checkRotate 0.5s ease-out;
-        }
-        
-        @keyframes checkRotate {
-            from {
-                transform: rotate(-180deg);
-                opacity: 0;
-            }
-            to {
-                transform: rotate(0deg);
-                opacity: 1;
-            }
-        }
-        
-        .language-option:not(.active):hover {
-            background: rgba(210, 0, 31, 0.1);
-            color: var(--text-color);
-        }
-        
-        .language-divider {
-            width: 1px;
-            height: 20px;
-            background: rgba(210, 0, 31, 0.3);
-            margin: 0 5px;
-        }
-
-        .print-button:hover {
-            transform: scale(1.1);
-            box-shadow: 0 6px 30px rgba(210, 0, 31, 0.5);
-        }
-
-        .print-button i {
-            font-size: 24px;
-        }
-
-        /* Responsive design */
-        @media (max-width: 768px) {
-            .cv-container {
-                margin: 0;
-                border-radius: 0;
-                max-width: 100%;
-            }
-            
-            .header {
-                padding: 30px 20px;
-            }
-            
-            .header h1 {
-                font-size: 22px;
-                text-align: center;
-            }
-            .header-tagline,
-            .role {
-                font-size: 14px;
-                text-align: center;
-            }
-            .contact-info {
-                justify-content: center;
-                flex-direction: column;
-                gap: 6px;
-            }
-            .contact-item {
-                font-size: 12px;
-                padding: 6px 10px;
-                width: 100%;
-            }
-            .language-option i {
-                font-size: 14px;
-                opacity: 0.7;
-            }
-            
-            .language-option.active {
-                background: var(--background-gradient);
-                color: var(--white-text);
-                box-shadow: 0 2px 10px rgba(210, 0, 31, 0.4);
-                animation: pulseActive 2s ease-in-out infinite;
-            }
-            
-            @keyframes pulseActive {
-                0%, 100% {
-                    transform: scale(1);
-                }
-                50% {
-                    transform: scale(1.05);
-                }
-            }
-            
-            .language-option.active i {
-                opacity: 1;
-                animation: checkRotate 0.5s ease-out;
-            }
-            
-            @keyframes checkRotate {
-                from {
-                    transform: rotate(-180deg);
-                    opacity: 0;
-                }
-                to {
-                    transform: rotate(0deg);
-                    opacity: 1;
-                }
-            }
-            
-            .language-option:not(.active):hover {
-                background: rgba(210, 0, 31, 0.1);
-                color: var(--text-color);
-            }
-            
-            .language-divider {
-                width: 1px;
-                height: 20px;
-                background: rgba(210, 0, 31, 0.3);
-                margin: 0 5px;
-            }
-
-            .print-button:hover {
-                transform: scale(1.1);
-                box-shadow: 0 6px 30px rgba(210, 0, 31, 0.5);
-            }
-
-            .print-button i {
-                font-size: 24px;
-            }
-                padding: 25px 15px;
-            }
-            
-            .section-title {
-                font-size: 16px;
-            }
-        }
-
-        /* Print styles */
-        @media print {
-            body {
-                background: white;
-            }
-
-            .animated-bg,
-            .shape,
-            .print-button,
-            .language-toggle {
-                display: none !important;
-            }
-
-            .cv-container {
-                box-shadow: none;
-                border: none;
-                margin: 0;
-            }
-
-            .section-title {
-                background: var(--renner-dark-red) !important;
-                color: var(--white-text) !important;
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
-            }
-
-            .header {
-                background: var(--background-gradient) !important;
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
-                page-break-inside: avoid;
-                padding: 30px !important;
-            }
-            
-            .header-text {
-                padding-right: 0 !important;
-            }
-            
-            /* Hide decorative elements */
-            .header::after,
-            .header::before {
-                display: none !important;
-            }
-        }
-
-        /* Dots container for skills from cv-texts.js - Renner colors */
-        .dots-container {
-            display: flex;
-            align-items: center;
-            gap: 4px;
-            flex-wrap: nowrap;
-        }
-
-        .dot {
-            width: 6px;
-            height: 6px;
-            border-radius: 50%;
-            background-color: rgba(210, 0, 31, 0.2);
-            transition: all 0.3s ease;
-            flex-shrink: 0;
-        }
-
-        .dot.filled {
-            background: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
-            box-shadow: 0 1px 3px rgba(210, 0, 31, 0.4);
-            animation: dotPulse 2s ease-in-out infinite alternate;
-        }
-
-        @keyframes dotPulse {
-            0% {
-                transform: scale(1);
-                box-shadow: 0 1px 3px rgba(210, 0, 31, 0.4);
-            }
-            100% {
-                transform: scale(1.1);
-                box-shadow: 0 2px 6px rgba(210, 0, 31, 0.6);
-            }
-        }
-
-        .tool-item {
-            margin-bottom: 15px;
-        }
-
-        .tool-name {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 8px;
-            font-size: 14px;
-            font-weight: 500;
-        }
-
-        .tool-percentage {
-            font-size: 12px;
-            color: var(--renner-red);
-            font-weight: 600;
-        }
-    </style>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-    <script src="../../assets/js/cv-texts.js"></script>
-    <!-- Favicon Meta Tags -->
+    <title>Pedro Marconato — Lojas Renner</title>
     <meta name="theme-color" content="#D2001F">
     <meta name="msapplication-TileColor" content="#D2001F">
-    <meta name="msapplication-config" content="assets/favicons/browserconfig.xml">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,500;0,600;0,700;0,800;1,500;1,600&family=Inter:wght@300;400;500;600;700&display=swap');
+
+        :root {
+            --ink: #1A1712;
+            --ink-soft: #4A453D;
+            --gray: #8A8479;
+            --paper: #FBFAF7;
+            --panel: #F5F2EB;
+            --line: #E3DED3;
+            --line-strong: #C9C2B4;
+            --red: #D2001F;
+            --red-deep: #A80019;
+            --font-serif: 'Playfair Display', Georgia, 'Times New Roman', serif;
+            --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+
+            /* aliases usados por modais + funções do cv-texts.js */
+            --primary-color: #D2001F;
+            --renner-red: #D2001F;
+            --text-color: #1A1712;
+            --dark-gray: #8A8479;
+            --white-text: #FFFFFF;
+            --background-gradient: linear-gradient(135deg, #D2001F 0%, #A80019 100%);
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
+            font-family: var(--font-sans);
+            color: var(--ink-soft);
+            background: #E9E5DC;
+            line-height: 1.6;
+            font-size: 15px;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+        }
+
+        .cv-container {
+            max-width: 940px;
+            margin: 34px auto;
+            background: var(--paper);
+            position: relative;
+            box-shadow: 0 18px 60px rgba(26, 23, 18, 0.16);
+            overflow: hidden;
+            animation: fadeUp 0.7s ease both;
+        }
+        @keyframes fadeUp { from { opacity: 0; transform: translateY(14px); } to { opacity: 1; transform: none; } }
+
+        .cv-container::before {
+            content: "";
+            position: absolute; top: 0; left: 0; right: 0; height: 5px;
+            background: var(--red);
+        }
+
+        /* ==================== HERO ==================== */
+        .header {
+            padding: 58px 64px 34px;
+            position: relative;
+        }
+        .header-content { display: flex; justify-content: space-between; align-items: flex-start; gap: 32px; }
+
+        .header h1 {
+            font-family: var(--font-serif);
+            font-weight: 800;
+            font-size: 44px;
+            line-height: 1.02;
+            letter-spacing: -0.6px;
+            color: var(--ink);
+        }
+        .role {
+            margin-top: 16px;
+            font-size: 12px;
+            font-weight: 600;
+            letter-spacing: 3.5px;
+            text-transform: uppercase;
+            color: var(--gray);
+        }
+
+        .brandmark { flex-shrink: 0; width: 232px; height: 38px; overflow: hidden; margin-top: 8px; }
+        .brandmark img { width: 232px; height: auto; display: block; }
+
+        .header-divider { height: 1px; background: var(--line-strong); margin: 30px 64px 0; }
+
+        /* contatos */
+        .contact-section { padding: 20px 64px 6px; }
+        .contact-info { display: flex; flex-wrap: wrap; align-items: center; gap: 10px 22px; }
+        .contact-item { display: inline-flex; align-items: baseline; gap: 8px; }
+        .contact-button {
+            display: inline-flex; align-items: center; gap: 8px;
+            background: none; border: none; padding: 0;
+            font-family: var(--font-sans); font-size: 13.5px; font-weight: 500;
+            color: var(--ink); cursor: pointer; text-decoration: none;
+            transition: color 0.2s;
+        }
+        .contact-button i { color: var(--red); font-size: 12px; }
+        .contact-button:hover { color: var(--red); }
+        a.contact-button { cursor: pointer; }
+        .contact-cta { font-size: 10.5px; color: var(--gray); letter-spacing: 0.2px; }
+        .location { display: inline-flex; align-items: center; gap: 8px; font-size: 13.5px; color: var(--ink); }
+        .location i { color: var(--red); font-size: 12px; }
+
+        /* ==================== SEÇÕES ==================== */
+        .section { padding: 30px 64px; border-top: 1px solid var(--line); }
+        .section:first-of-type { border-top: none; }
+
+        .section-title {
+            display: flex; align-items: center; gap: 13px;
+            font-family: var(--font-sans);
+            font-size: 12px; font-weight: 700; letter-spacing: 3px;
+            text-transform: uppercase; color: var(--ink);
+            margin-bottom: 22px;
+        }
+        .section-title::before { content: ""; width: 22px; height: 2px; background: var(--red); flex-shrink: 0; }
+
+        .profile-text { font-size: 15.5px; line-height: 1.8; color: var(--ink-soft); max-width: 62ch; }
+
+        /* ==================== SKILLS ==================== */
+        .skills-container { display: grid; grid-template-columns: repeat(3, 1fr); gap: 34px; }
+        .skills-column h3 {
+            font-family: var(--font-serif) !important;
+            font-size: 16px !important; font-weight: 700 !important;
+            color: var(--ink) !important; margin-bottom: 16px !important;
+            padding-bottom: 9px; border-bottom: 1px solid var(--line);
+        }
+        .tool-item { margin-bottom: 14px; }
+        .tool-name { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 6px; }
+        .tool-name > span:first-child { font-size: 13px; font-weight: 500; color: var(--ink); }
+        .tool-percentage { font-size: 10px; font-weight: 600; letter-spacing: 0.6px; text-transform: uppercase; color: var(--red-deep); }
+        .dots-container { display: flex; gap: 4px; }
+        .dot { width: 100%; height: 3px; border-radius: 2px; background: var(--line); flex: 1; }
+        .dot.filled { background: var(--red); }
+
+        /* ==================== EXPERIÊNCIA ==================== */
+        .experience-timeline { position: relative; padding-left: 30px; }
+        .experience-timeline::before {
+            content: ""; position: absolute; left: 5px; top: 8px; bottom: 8px;
+            width: 1.5px; background: var(--line-strong);
+        }
+        .experience-item { position: relative; margin-bottom: 30px; }
+        .experience-item:last-child { margin-bottom: 0; }
+        .experience-item::before {
+            content: ""; position: absolute; left: -30px; top: 4px;
+            width: 11px; height: 11px; border-radius: 50%;
+            background: var(--paper); border: 2px solid var(--red);
+        }
+
+        .job-title {
+            display: flex; align-items: center; gap: 11px;
+            font-family: var(--font-serif); font-size: 20px; font-weight: 700;
+            color: var(--ink); line-height: 1.2;
+        }
+        .job-number {
+            flex-shrink: 0;
+            width: 25px; height: 25px; border-radius: 50%;
+            background: var(--red); color: #fff;
+            font-family: var(--font-sans); font-size: 12px; font-weight: 700;
+            display: inline-flex; align-items: center; justify-content: center;
+        }
+        .company { font-size: 14px; font-weight: 600; color: var(--red-deep); margin-top: 7px; }
+        .period {
+            display: inline-block; margin-top: 4px;
+            font-size: 11px; font-weight: 500; letter-spacing: 0.8px; text-transform: uppercase;
+            color: var(--gray);
+        }
+        .job-description { font-size: 14px; line-height: 1.7; color: var(--ink-soft); margin: 12px 0 16px; max-width: 66ch; }
+
+        .achievements-container { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+        .achievement-item {
+            display: flex; gap: 12px;
+            background: var(--panel); border: 1px solid var(--line);
+            border-radius: 3px; padding: 14px 16px;
+            transition: border-color 0.2s, transform 0.2s;
+        }
+        .achievement-item:hover { border-color: var(--line-strong); transform: translateY(-2px); }
+        .achievement-icon {
+            flex-shrink: 0; width: 30px; height: 30px; border-radius: 50%;
+            background: rgba(210, 0, 31, 0.08); color: var(--red);
+            display: inline-flex; align-items: center; justify-content: center; font-size: 13px;
+        }
+        .achievement-title { font-size: 12.5px; font-weight: 700; color: var(--ink); margin-bottom: 3px; letter-spacing: 0.2px; }
+        .achievement-description { font-size: 12px; line-height: 1.55; color: var(--ink-soft); }
+
+        /* tooltip */
+        .tooltip { position: relative; display: inline-flex; }
+        .tooltip-icon { font-size: 13px; color: var(--gray); cursor: pointer; }
+        .tooltip-text {
+            visibility: hidden; opacity: 0; position: absolute; z-index: 20;
+            top: 130%; left: 0; width: 300px;
+            background: var(--ink); color: #F3EFE8; border-radius: 6px; padding: 14px 16px;
+            font-family: var(--font-sans); box-shadow: 0 12px 30px rgba(0,0,0,0.25);
+            transition: opacity 0.2s;
+        }
+        .tooltip:hover .tooltip-text, .tooltip.tooltip-active .tooltip-text { visibility: visible; opacity: 1; }
+        .tooltip-header { font-size: 12px; font-weight: 700; margin-bottom: 8px; color: #fff; }
+        .tooltip-section-title { font-size: 11px; font-weight: 600; color: #F0B8BE; margin: 8px 0 4px; }
+        .tooltip-list { list-style: none; }
+        .tooltip-list li { font-size: 11px; line-height: 1.5; padding-left: 12px; position: relative; }
+        .tooltip-list li::before { content: "—"; position: absolute; left: 0; color: var(--red); }
+
+        /* ==================== FORMAÇÃO / PROJETOS ==================== */
+        .education-container, .projects-container { display: grid; grid-template-columns: 1fr 1fr; gap: 22px; }
+        .education-item, .project-item {
+            padding: 20px 22px; background: var(--panel);
+            border: 1px solid var(--line); border-radius: 3px;
+        }
+        .degree, .project-title { font-family: var(--font-serif); font-size: 17px; font-weight: 700; color: var(--ink); line-height: 1.25; }
+        .university { font-size: 13px; color: var(--ink-soft); margin-top: 5px; }
+        .thesis { font-size: 12px; color: var(--gray); font-style: italic; margin-top: 5px; line-height: 1.5; }
+        .project-description { font-size: 13px; line-height: 1.65; color: var(--ink-soft); margin-top: 8px; }
+        .tech-tag {
+            display: inline-block; margin: 4px 4px 0 0; padding: 3px 9px;
+            font-size: 10.5px; font-weight: 500; letter-spacing: 0.3px;
+            color: var(--ink); background: var(--paper);
+            border: 1px solid var(--line-strong); border-radius: 2px;
+        }
+        .cta-button {
+            display: inline-flex; align-items: center; gap: 7px; margin-top: 12px;
+            padding: 8px 15px; font-size: 12px; font-weight: 600;
+            color: #fff; background: var(--red); border-radius: 3px;
+            text-decoration: none; transition: background 0.2s;
+        }
+        .cta-button:hover { background: var(--red-deep); }
+
+        /* ==================== TOGGLE / FAB ==================== */
+        .language-toggle {
+            position: fixed; top: 24px; right: 24px; z-index: 100;
+            display: flex; align-items: center; gap: 4px;
+            background: var(--paper); border: 1px solid var(--line-strong);
+            border-radius: 40px; padding: 5px 6px; box-shadow: 0 6px 20px rgba(26,23,18,0.15);
+        }
+        .language-option {
+            display: inline-flex; align-items: center; gap: 5px;
+            padding: 6px 14px; border-radius: 30px; text-decoration: none;
+            font-size: 12px; font-weight: 700; letter-spacing: 1px; color: var(--gray);
+            transition: all 0.2s;
+        }
+        .language-option.active { background: var(--red); color: #fff; }
+        .language-divider { width: 1px; height: 16px; background: var(--line-strong); }
+
+        .print-button {
+            position: fixed; bottom: 26px; right: 26px; z-index: 100;
+            width: 56px; height: 56px; border-radius: 50%;
+            background: var(--red); color: #fff; border: none; cursor: pointer;
+            display: inline-flex; align-items: center; justify-content: center; font-size: 20px;
+            box-shadow: 0 8px 24px rgba(210, 0, 31, 0.4); transition: transform 0.2s, background 0.2s;
+        }
+        .print-button:hover { background: var(--red-deep); transform: translateY(-3px) scale(1.05); }
+
+        /* ==================== RESPONSIVO ==================== */
+        @media (max-width: 820px) {
+            .cv-container { margin: 0; }
+            .header { padding: 42px 26px 26px; }
+            .header-content { flex-direction: column; }
+            .header h1 { font-size: 40px; max-width: none; }
+            .brandmark { margin-top: 4px; }
+            .header-divider, .contact-section, .section { padding-left: 26px; padding-right: 26px; }
+            .header-divider { margin-left: 26px; margin-right: 26px; }
+            .skills-container { grid-template-columns: 1fr; gap: 26px; }
+            .achievements-container, .education-container, .projects-container { grid-template-columns: 1fr; }
+        }
+    </style>
 </head>
 <body>
-    <div class="animated-bg"></div>
-    
-    <!-- Floating shapes -->
-    <div class="shape"></div>
-    <div class="shape"></div>
-    <div class="shape"></div>
-    
     <div class="cv-container">
         <header class="header">
-            <div class="particle"></div>
-            <div class="particle"></div>
-            <div class="particle"></div>
-            
             <div class="header-content">
-                <div class="logo-container">
-                    <img src="../../assets/images/lojasrenner.png" alt="Lojas Renner" class="renner-logo-header">
+                <div class="header-text">
+                    <h1 id="cv-name"></h1>
+                    <div class="role" id="cv-role"></div>
                 </div>
-                
-                <div class="header-text-content">
-                    <div class="company-tagline">Moda & Estilo Excelente</div>
-                    <div class="header-text">
-                        <h1 id="cv-name"></h1>
-                        <div class="role" id="cv-role"></div>
-                    </div>
+                <div class="brandmark">
+                    <img src="../../assets/images/lojasrenner.png" alt="Lojas Renner S.A.">
                 </div>
-            </div>
-            
-            <!-- Contact section moved outside header-content -->
-            <div class="contact-section">
-                <div class="contact-info">
-                        <div class="contact-item">
-                            <button class="contact-button" onclick="openEmailForm()">
-                                <i class="fas fa-envelope"></i> <span id="cv-email"></span>
-                            </button>
-                            <span class="contact-cta" id="cv-cta-email"></span>
-                        </div>
-                        
-                        <div class="contact-item">
-                            <button class="contact-button" onclick="openPhoneForm()">
-                                <i class="fas fa-phone"></i> <span id="cv-phone"></span>
-                            </button>
-                            <span class="contact-cta" id="cv-cta-phone"></span>
-                        </div>
-                        
-                        <div class="location" id="cv-location">
-                            <i class="fas fa-map-marker-alt"></i> <span></span>
-                        </div>
-                        
-                        <div class="contact-item">
-                            <a href="https://linkedin.com/in/pedrohmarconato" class="contact-button" target="_blank">
-                                <i class="fab fa-linkedin"></i> <span id="cv-linkedin"></span>
-                            </a>
-                            <span class="contact-cta" id="cv-cta-linkedin"></span>
-                        </div>
-                        
-                        <div class="contact-item">
-                            <a href="https://github.com/pedrohmarconato/Pedro-Marconato-CV" class="contact-button" target="_blank">
-                                <i class="fab fa-github"></i> <span id="cv-repository"></span>
-                            </a>
-                            <span class="contact-cta" id="cv-cta-repository"></span>
-                        </div>
-                    </div>
             </div>
         </header>
-        
+
+        <div class="header-divider"></div>
+
+        <div class="contact-section">
+            <div class="contact-info">
+                <div class="contact-item">
+                    <button class="contact-button" onclick="openEmailForm()">
+                        <i class="fas fa-envelope"></i> <span id="cv-email"></span>
+                    </button>
+                </div>
+                <div class="contact-item">
+                    <button class="contact-button" onclick="openPhoneForm()">
+                        <i class="fas fa-phone"></i> <span id="cv-phone"></span>
+                    </button>
+                </div>
+                <div class="location" id="cv-location">
+                    <i class="fas fa-map-marker-alt"></i> <span></span>
+                </div>
+                <div class="contact-item">
+                    <a href="https://linkedin.com/in/pedrohmarconato" class="contact-button" target="_blank">
+                        <i class="fab fa-linkedin"></i> <span id="cv-linkedin"></span>
+                    </a>
+                </div>
+                <div class="contact-item">
+                    <a href="https://github.com/pedrohmarconato/Pedro-Marconato-CV" class="contact-button" target="_blank">
+                        <i class="fab fa-github"></i> <span id="cv-repository"></span>
+                    </a>
+                </div>
+            </div>
+        </div>
+
         <section class="section">
             <h2 class="section-title" id="section-profile"></h2>
             <p class="profile-text" id="cv-profile"></p>
         </section>
-        
+
         <section class="section">
             <h2 class="section-title" id="section-skills"></h2>
             <div class="skills-container">
@@ -1480,270 +326,145 @@
                 <div class="skills-column" id="skills-emerging"></div>
             </div>
         </section>
-        
+
         <section class="section">
             <h2 class="section-title" id="section-experience"></h2>
-            <div class="experience-timeline" id="cv-experience"></div>
+            <div class="experience-timeline" id="experience-container"></div>
         </section>
-        
+
         <section class="section">
             <h2 class="section-title" id="section-education"></h2>
-            <div class="education-container" id="cv-education"></div>
+            <div class="education-container" id="education-container"></div>
         </section>
-        
+
         <section class="section">
             <h2 class="section-title" id="section-projects"></h2>
-            <div class="projects-container" id="cv-projects"></div>
+            <div class="projects-container" id="projects-container"></div>
         </section>
     </div>
-    
-    <!-- Language toggle button -->
+
+    <!-- Toggle de idioma -->
     <div class="language-toggle">
-        <a href="renner.html" class="language-option">
-            <span id="lang-en">EN</span>
-        </a>
+        <a href="renner.html" class="language-option"><span id="lang-en">EN</span></a>
         <div class="language-divider"></div>
-        <a href="renner_pt.html" class="language-option active">
-            <i class="fas fa-check-circle"></i>
-            <span id="lang-pt">PT</span>
-        </a>
+        <a href="renner_pt.html" class="language-option active"><i class="fas fa-check-circle"></i><span id="lang-pt">PT</span></a>
     </div>
-    
-    <!-- Print button -->
-    <button class="print-button" onclick="var win = window.open('../../cv_styles/cv_renner_style_PT.html', '_blank'); win.onload = function() { win.print(); }">
+
+    <!-- FAB imprimir (abre o PDF editorial) -->
+    <button class="print-button" title="Baixar PDF" onclick="var win = window.open('../../cv_styles/cv_renner_style_PT.html', '_blank'); win.onload = function() { win.print(); }">
         <i class="fas fa-file-pdf"></i>
     </button>
-    
-    <!-- Email Modal -->
+
+    <!-- Modal Email -->
     <div id="emailModal" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background-color:rgba(0,0,0,0.7); z-index:1000; justify-content:center; align-items:center;">
-        <div style="background-color:white; padding:40px; border-radius:16px; width:90%; max-width:500px; position:relative; box-shadow: 0 10px 40px rgba(0,0,0,0.2);">
+        <div style="background-color:white; padding:40px; border-radius:8px; width:90%; max-width:500px; position:relative; box-shadow: 0 10px 40px rgba(0,0,0,0.2);">
             <button onclick="closeEmailModal()" style="position:absolute; top:15px; right:15px; background:none; border:none; font-size:24px; cursor:pointer; color: var(--dark-gray);">×</button>
-            <h3 id="email-modal-title" style="margin-bottom:25px; color: var(--text-color); font-size: 24px;">Enviar Email</h3>
+            <h3 id="email-modal-title" style="margin-bottom:25px; color: var(--text-color); font-size: 24px; font-family: var(--font-serif);">Enviar Email</h3>
             <form action="https://formspree.io/f/mdkekegw" method="POST">
                 <div style="margin-bottom:20px;">
                     <label id="email-label-name" style="display:block; margin-bottom:8px; font-weight:500; color: var(--text-color);">Seu Nome</label>
-                    <input type="text" name="name" required style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:8px; font-size: 16px; transition: border-color 0.3s;">
+                    <input type="text" name="name" required style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:6px; font-size: 16px;">
                 </div>
                 <div style="margin-bottom:20px;">
                     <label id="email-label-email" style="display:block; margin-bottom:8px; font-weight:500; color: var(--text-color);">Seu Email</label>
-                    <input type="email" name="email" required style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:8px; font-size: 16px; transition: border-color 0.3s;">
+                    <input type="email" name="email" required style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:6px; font-size: 16px;">
                 </div>
                 <div style="margin-bottom:20px;">
                     <label id="email-label-subject" style="display:block; margin-bottom:8px; font-weight:500; color: var(--text-color);">Assunto</label>
-                    <input type="text" name="subject" required style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:8px; font-size: 16px; transition: border-color 0.3s;">
+                    <input type="text" name="subject" required style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:6px; font-size: 16px;">
                 </div>
                 <div style="margin-bottom:25px;">
                     <label id="email-label-message" style="display:block; margin-bottom:8px; font-weight:500; color: var(--text-color);">Mensagem</label>
-                    <textarea name="message" required rows="5" style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:8px; font-size: 16px; transition: border-color 0.3s; resize: vertical;"></textarea>
+                    <textarea name="message" required rows="5" style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:6px; font-size: 16px; resize: vertical;"></textarea>
                 </div>
-                <button id="email-button" type="submit" style="background: var(--background-gradient); color: var(--white-text); border:none; padding:14px 28px; border-radius:8px; cursor:pointer; font-weight:600; font-size: 16px; transition: all 0.3s; box-shadow: 0 4px 15px rgba(210, 0, 31, 0.4);">Enviar</button>
+                <button id="email-button" type="submit" style="background: var(--background-gradient); color: var(--white-text); border:none; padding:14px 28px; border-radius:6px; cursor:pointer; font-weight:600; font-size: 16px; box-shadow: 0 4px 15px rgba(210, 0, 31, 0.4);">Enviar</button>
             </form>
         </div>
     </div>
-    
-    <!-- Phone Modal -->
+
+    <!-- Modal Telefone -->
     <div id="phoneModal" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background-color:rgba(0,0,0,0.7); z-index:1000; justify-content:center; align-items:center;">
-        <div style="background-color:white; padding:40px; border-radius:16px; width:90%; max-width:500px; position:relative; box-shadow: 0 10px 40px rgba(0,0,0,0.2);">
+        <div style="background-color:white; padding:40px; border-radius:8px; width:90%; max-width:500px; position:relative; box-shadow: 0 10px 40px rgba(0,0,0,0.2);">
             <button onclick="closePhoneModal()" style="position:absolute; top:15px; right:15px; background:none; border:none; font-size:24px; cursor:pointer; color: var(--dark-gray);">×</button>
-            <h3 id="phone-modal-title" style="margin-bottom:25px; color: var(--text-color); font-size: 24px;">Entrar em Contato</h3>
+            <h3 id="phone-modal-title" style="margin-bottom:25px; color: var(--text-color); font-size: 24px; font-family: var(--font-serif);">Entrar em Contato</h3>
             <form action="https://formspree.io/f/mdkekegw" method="POST">
                 <input type="hidden" name="contact_type" value="phone_request">
                 <div style="margin-bottom:20px;">
-                    <label id="email-label-name" style="display:block; margin-bottom:8px; font-weight:500; color: var(--text-color);">Seu Nome</label>
-                    <input type="text" name="name" required style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:8px; font-size: 16px; transition: border-color 0.3s;">
+                    <label id="phone-label-name" style="display:block; margin-bottom:8px; font-weight:500; color: var(--text-color);">Seu Nome</label>
+                    <input type="text" name="name" required style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:6px; font-size: 16px;">
                 </div>
                 <div style="margin-bottom:20px;">
                     <label id="phone-label-phone" style="display:block; margin-bottom:8px; font-weight:500; color: var(--text-color);">Seu Telefone</label>
-                    <input type="tel" name="phone" required style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:8px; font-size: 16px; transition: border-color 0.3s;">
+                    <input type="tel" name="phone" required style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:6px; font-size: 16px;">
                 </div>
                 <div style="margin-bottom:20px;">
                     <label id="phone-label-besttime" style="display:block; margin-bottom:8px; font-weight:500; color: var(--text-color);">Melhor horário para contato</label>
-                    <input type="text" name="best_time" required style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:8px; font-size: 16px; transition: border-color 0.3s;">
+                    <input type="text" name="best_time" required style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:6px; font-size: 16px;">
                 </div>
                 <div style="margin-bottom:25px;">
                     <label id="phone-label-message" style="display:block; margin-bottom:8px; font-weight:500; color: var(--text-color);">Mensagem (Opcional)</label>
-                    <textarea name="message" rows="3" style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:8px; font-size: 16px; transition: border-color 0.3s; resize: vertical;"></textarea>
+                    <textarea name="message" rows="3" style="width:100%; padding:12px; border:2px solid #e5e7eb; border-radius:6px; font-size: 16px; resize: vertical;"></textarea>
                 </div>
-                <div style="display:flex; gap:15px;">
-                    <button id="phone-button" type="submit" style="background: var(--background-gradient); color: var(--white-text); border:none; padding:14px 28px; border-radius:8px; cursor:pointer; font-weight:600; font-size: 16px; transition: all 0.3s; box-shadow: 0 4px 15px rgba(210, 0, 31, 0.4);">Solicitar Contato</button>
-                    <a href="https://wa.me/55981147758" target="_blank" style="display:inline-flex; align-items:center; background-color:#25D366; color:white; text-decoration:none; border:none; padding:14px 28px; border-radius:8px; cursor:pointer; font-weight:600; font-size: 16px; transition: all 0.3s; box-shadow: 0 4px 15px rgba(37, 211, 102, 0.3);">
+                <div style="display:flex; gap:15px; flex-wrap: wrap;">
+                    <button id="phone-button" type="submit" style="background: var(--background-gradient); color: var(--white-text); border:none; padding:14px 28px; border-radius:6px; cursor:pointer; font-weight:600; font-size: 16px; box-shadow: 0 4px 15px rgba(210, 0, 31, 0.4);">Solicitar Contato</button>
+                    <a href="https://wa.me/55981147758" target="_blank" style="display:inline-flex; align-items:center; background-color:#25D366; color:white; text-decoration:none; padding:14px 28px; border-radius:6px; font-weight:600; font-size: 16px;">
                         <i class="fab fa-whatsapp" style="margin-right:8px;"></i> <span id="whatsapp-text">WhatsApp</span>
                     </a>
                 </div>
             </form>
         </div>
     </div>
-    
-    <script>
-        function openEmailForm() {
-            document.getElementById('emailModal').style.display = 'flex';
-        }
-        
-        function closeEmailModal() {
-            document.getElementById('emailModal').style.display = 'none';
-        }
-        
-        function openPhoneForm() {
-            document.getElementById('phoneModal').style.display = 'flex';
-        }
-        
-        function closePhoneModal() {
-            document.getElementById('phoneModal').style.display = 'none';
-        }
-        
-        // Close modal when clicking outside
-        window.onclick = function(event) {
-            if (event.target == document.getElementById('emailModal')) {
-                closeEmailModal();
-            }
-            if (event.target == document.getElementById('phoneModal')) {
-                closePhoneModal();
-            }
-        }
 
-        // Style form inputs on focus
-        document.addEventListener('DOMContentLoaded', function() {
-            // Initialize modal texts
-            initializeModalTexts('pt');
-            
-            const inputs = document.querySelectorAll('input, textarea');
-            inputs.forEach(input => {
-                input.addEventListener('focus', function() {
-                    this.style.borderColor = 'var(--renner-red)';
-                });
-                input.addEventListener('blur', function() {
-                    this.style.borderColor = '#e5e7eb';
-                });
-            });
-            
-            // Tooltip functionality for mobile
-            const tooltips = document.querySelectorAll('.tooltip');
-            tooltips.forEach(tooltip => {
-                tooltip.addEventListener('click', function(e) {
-                    e.stopPropagation();
-                    
-                    // Close all other tooltips
-                    tooltips.forEach(t => {
-                        if (t !== this) {
-                            t.classList.remove('tooltip-active');
-                        }
-                    });
-                    
-                    // Toggle current tooltip
-                    this.classList.toggle('tooltip-active');
-                });
-            });
-            
-            // Close tooltips when clicking outside
-            document.addEventListener('click', function() {
-                tooltips.forEach(tooltip => {
-                    tooltip.classList.remove('tooltip-active');
-                });
-            });
-
-            // Initialize CV content from cv-texts.js
-            initializeBasicContent('pt');
-            
-            // Update additional section titles
-            const experienceTitleEl = document.getElementById('section-experience');
-            if (experienceTitleEl) experienceTitleEl.textContent = getText('sections.experience', 'pt');
-            
-            const educationTitleEl = document.getElementById('section-education');
-            if (educationTitleEl) educationTitleEl.textContent = getText('sections.education', 'pt');
-            
-            const projectsTitleEl = document.getElementById('section-projects');
-            if (projectsTitleEl) projectsTitleEl.textContent = getText('sections.projects', 'pt');
-            
-            // Skills sections
-            renderSkills('skills-strategic', 'strategic', 'pt');
-            renderSkills('skills-tools', 'tools', 'pt');
-            renderSkills('skills-emerging', 'emerging', 'pt');
-            
-            // Experience section
-            renderExperience('pt');
-            
-            // Education section
-            renderEducation('pt');
-            
-            // Projects section
-            renderProjects('pt');
-        });
-        
-        // Render experience section
-        function renderExperience(lang = 'pt') {
-            const container = document.getElementById('cv-experience');
-            if (!container) return;
-            
-            const experiences = getText('experience', lang);
-            let html = '';
-            
-            experiences.forEach((exp, index) => {
-                html += `
-                    <div class="experience-item">
-                        <div class="job-title">
-                            <div class="job-number">${index + 1}</div>
-                            ${exp.title}
-                            ${renderTooltip(exp.tooltip)}
-                        </div>
-                        <div class="company">${exp.company}</div>
-                        <div class="period">${exp.period}</div>
-                        <div class="job-description">${exp.description}</div>
-                        <div class="achievements-container">
-                            ${renderAchievements(exp.achievements)}
-                        </div>
-                    </div>
-                `;
-            });
-            
-            container.innerHTML = html;
-        }
-        
-        // Render education section
-        function renderEducation(lang = 'pt') {
-            const container = document.getElementById('cv-education');
-            if (!container) return;
-            
-            const education = getText('education', lang);
-            let html = '';
-            
-            education.forEach(edu => {
-                html += `
-                    <div class="education-item">
-                        <div class="degree">${edu.degree}</div>
-                        <div class="university">${edu.university}</div>
-                        <div class="thesis">${edu.thesis}</div>
-                    </div>
-                `;
-            });
-            
-            container.innerHTML = html;
-        }
-        
-        // Render projects section
-        function renderProjects(lang = 'pt') {
-            const container = document.getElementById('cv-projects');
-            if (!container) return;
-            
-            const projects = getText('projects', lang);
-            let html = '';
-            
-            projects.forEach(project => {
-                html += `
-                    <div class="project-item">
-                        <div class="project-title">${project.title}</div>
-                        <div class="project-description">${project.description}</div>
-                        <div style="margin-top: 15px;">
-                            ${renderTechTags(project.techs)}
-                        </div>
-                    </div>
-                `;
-            });
-            
-            container.innerHTML = html;
-        }
-    </script>
-
-    <!-- Dynamic Favicon System -->
+    <script src="../../assets/js/cv-texts.js"></script>
     <script src="../../assets/js/dynamic-favicon.js"></script>
+    <script>
+        function openEmailForm() { document.getElementById('emailModal').style.display = 'flex'; }
+        function closeEmailModal() { document.getElementById('emailModal').style.display = 'none'; }
+        function openPhoneForm() { document.getElementById('phoneModal').style.display = 'flex'; }
+        function closePhoneModal() { document.getElementById('phoneModal').style.display = 'none'; }
+        window.onclick = function(event) {
+            if (event.target == document.getElementById('emailModal')) closeEmailModal();
+            if (event.target == document.getElementById('phoneModal')) closePhoneModal();
+        };
+
+        document.addEventListener('DOMContentLoaded', function() {
+            var lang = 'pt';
+            initializeModalTexts(lang);
+            initializeBasicContent(lang);
+
+            var exp = document.getElementById('section-experience');
+            if (exp) exp.textContent = getText('sections.experience', lang);
+            var edu = document.getElementById('section-education');
+            if (edu) edu.textContent = getText('sections.education', lang);
+            var proj = document.getElementById('section-projects');
+            if (proj) proj.textContent = getText('sections.projects', lang);
+
+            renderSkills('skills-strategic', 'strategic', lang);
+            renderSkills('skills-tools', 'tools', lang);
+            renderSkills('skills-emerging', 'emerging', lang);
+            renderExperienceTimeline(lang);
+            renderEducation(lang);
+            renderProjects(lang);
+
+            // realce de borda nos inputs
+            document.querySelectorAll('input, textarea').forEach(function(input) {
+                input.addEventListener('focus', function() { this.style.borderColor = 'var(--renner-red)'; });
+                input.addEventListener('blur', function() { this.style.borderColor = '#e5e7eb'; });
+            });
+
+            // tooltips (toque no mobile)
+            var tips = document.querySelectorAll('.tooltip');
+            tips.forEach(function(t) {
+                t.addEventListener('click', function(e) {
+                    e.stopPropagation();
+                    tips.forEach(function(o) { if (o !== t) o.classList.remove('tooltip-active'); });
+                    t.classList.toggle('tooltip-active');
+                });
+            });
+            document.addEventListener('click', function() {
+                tips.forEach(function(t) { t.classList.remove('tooltip-active'); });
+            });
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Antes
Layout/design pesado e datado: hero vermelho chapado, nome vertical translúcido, logo "LOJAS RENNER S.A." girado e ilegível, tagline "Moda & Estilo Excelente", seções com pílulas e cards vermelhos poluídos.

## Depois — mesmo sistema editorial do PDF novo (EN + PT)
- **Papel creme**, **Playfair Display** (serif) + **Inter**, vermelho Renner **#D2001F** como acento; logo preto legível sobre o claro.
- **Masthead limpo**: nome em serif (2 linhas) + cargo + logo à direita; contatos em linha com ícones vermelhos.
- **Seções** com rótulo + filete vermelho e muito respiro; **Skills** em 3 colunas com nível em barra segmentada; **Experiência** em timeline com nós numerados + cards de conquista; **Formação/Projetos** em cards refinados.

## Preservado (funcional)
- **100% dinâmica** via API padrão do `cv-texts.js` (`initializeBasicContent`, `renderSkills`, `renderExperienceTimeline`, `renderEducation`, `renderProjects`) — conteúdo continua vindo da fonte única.
- **Toggle de idioma**, **FAB de PDF** (abre o PDF editorial do mesmo idioma), **modais** (Formspree + WhatsApp), **responsivo**.

## Validação
- `validate-project.py`: **0 erros / 0 avisos**.
- Render headless (Chrome) em EN e PT: conteúdo popula certo (skills, experiência, formação, projetos), sem vazamento de idioma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)