### PR TITLE
feat: adiciona botão de volta para a home nas páginas de empresa

### DIFF
--- a/templates/companies/accenture.html
+++ b/templates/companies/accenture.html
@@ -1272,6 +1272,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="accenture.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/accenture_pt.html
+++ b/templates/companies/accenture_pt.html
@@ -1272,6 +1272,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="accenture.html" class="language-option">
             <span id="lang-en">EN</span>

--- a/templates/companies/act.html
+++ b/templates/companies/act.html
@@ -1435,6 +1435,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="act.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/act_pt.html
+++ b/templates/companies/act_pt.html
@@ -1435,6 +1435,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="act.html" class="language-option">
             <span id="lang-en">EN</span>

--- a/templates/companies/allos.html
+++ b/templates/companies/allos.html
@@ -1776,6 +1776,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="allos.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/allos_pt.html
+++ b/templates/companies/allos_pt.html
@@ -1691,6 +1691,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="allos.html" class="language-option">
             <span>EN</span>

--- a/templates/companies/banco-bv.html
+++ b/templates/companies/banco-bv.html
@@ -2091,6 +2091,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="banco-bv.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/banco-bv_pt.html
+++ b/templates/companies/banco-bv_pt.html
@@ -2028,6 +2028,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="banco-bv.html" class="language-option">
             <span>EN</span>

--- a/templates/companies/boticario.html
+++ b/templates/companies/boticario.html
@@ -2228,6 +2228,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="boticario.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/boticario_pt.html
+++ b/templates/companies/boticario_pt.html
@@ -2357,6 +2357,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="boticario.html" class="language-option">
             <span id="lang-en">EN</span>

--- a/templates/companies/bradesco.html
+++ b/templates/companies/bradesco.html
@@ -1899,6 +1899,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="bradesco.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/bradesco_pt.html
+++ b/templates/companies/bradesco_pt.html
@@ -1899,6 +1899,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="bradesco.html" class="language-option">
             <span id="lang-en">EN</span>

--- a/templates/companies/cadastra.html
+++ b/templates/companies/cadastra.html
@@ -1880,6 +1880,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="cadastra.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/cadastra_pt.html
+++ b/templates/companies/cadastra_pt.html
@@ -1880,6 +1880,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="cadastra.html" class="language-option">
             <span>EN</span>

--- a/templates/companies/cea.html
+++ b/templates/companies/cea.html
@@ -1697,6 +1697,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="cea.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/cea_pt.html
+++ b/templates/companies/cea_pt.html
@@ -1697,6 +1697,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="cea.html" class="language-option">
             <span id="lang-en">EN</span>

--- a/templates/companies/cielo.html
+++ b/templates/companies/cielo.html
@@ -1595,6 +1595,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="cielo.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/cielo_pt.html
+++ b/templates/companies/cielo_pt.html
@@ -1595,6 +1595,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="cielo.html" class="language-option">
             <span>

--- a/templates/companies/cognitivo_ai.html
+++ b/templates/companies/cognitivo_ai.html
@@ -2073,6 +2073,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="cognitivo_ai.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/cognitivo_ai_pt.html
+++ b/templates/companies/cognitivo_ai_pt.html
@@ -1787,6 +1787,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="cognitivo_ai.html" class="language-option">
             <span id="lang-en">EN</span>

--- a/templates/companies/completebari.html
+++ b/templates/companies/completebari.html
@@ -1430,6 +1430,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="completebari.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/completebari_pt.html
+++ b/templates/companies/completebari_pt.html
@@ -1430,6 +1430,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="completebari.html" class="language-option">
             <span id="lang-en">EN</span>

--- a/templates/companies/contaazul.html
+++ b/templates/companies/contaazul.html
@@ -1540,6 +1540,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="contaazul.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/contaazul_pt.html
+++ b/templates/companies/contaazul_pt.html
@@ -1540,6 +1540,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="contaazul.html" class="language-option">
             <span>EN</span>

--- a/templates/companies/general.html
+++ b/templates/companies/general.html
@@ -1352,6 +1352,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="general.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/general_pt.html
+++ b/templates/companies/general_pt.html
@@ -1411,6 +1411,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="general.html" class="language-option">
             <span>EN</span>

--- a/templates/companies/google.html
+++ b/templates/companies/google.html
@@ -1356,6 +1356,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="google.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/google_pt.html
+++ b/templates/companies/google_pt.html
@@ -1356,6 +1356,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="google.html" class="language-option">
             <span id="lang-en">EN</span>

--- a/templates/companies/grupo-rbs.html
+++ b/templates/companies/grupo-rbs.html
@@ -1504,6 +1504,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="grupo-rbs.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/grupo-rbs_pt.html
+++ b/templates/companies/grupo-rbs_pt.html
@@ -1504,6 +1504,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="grupo-rbs.html" class="language-option">
             <span id="lang-en">EN</span>

--- a/templates/companies/grupofleury.html
+++ b/templates/companies/grupofleury.html
@@ -2113,6 +2113,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="grupofleury.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/grupofleury_pt.html
+++ b/templates/companies/grupofleury_pt.html
@@ -1825,6 +1825,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="grupofleury.html" class="language-option">
             <span>EN</span>

--- a/templates/companies/hyland.html
+++ b/templates/companies/hyland.html
@@ -1410,6 +1410,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="hyland.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/hyland_pt.html
+++ b/templates/companies/hyland_pt.html
@@ -1410,6 +1410,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="hyland.html" class="language-option">
             <span id="lang-en">EN</span>

--- a/templates/companies/ifood.html
+++ b/templates/companies/ifood.html
@@ -1339,6 +1339,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="ifood.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/ifood_pt.html
+++ b/templates/companies/ifood_pt.html
@@ -1690,6 +1690,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="ifood.html" class="language-option">
             <span>EN</span>

--- a/templates/companies/itau.html
+++ b/templates/companies/itau.html
@@ -1447,6 +1447,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="itau.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/itau_pt.html
+++ b/templates/companies/itau_pt.html
@@ -1447,6 +1447,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="itau.html" class="language-option">
             <span id="lang-en">EN</span>

--- a/templates/companies/lisinski-law-firm.html
+++ b/templates/companies/lisinski-law-firm.html
@@ -1462,6 +1462,11 @@
     </button>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="lisinski-law-firm.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/lisinski-law-firm_pt.html
+++ b/templates/companies/lisinski-law-firm_pt.html
@@ -1462,6 +1462,11 @@
     </button>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="lisinski-law-firm.html" class="language-option">
             <span>EN</span>

--- a/templates/companies/macfor.html
+++ b/templates/companies/macfor.html
@@ -1660,6 +1660,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="macfor.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/macfor_pt.html
+++ b/templates/companies/macfor_pt.html
@@ -1660,6 +1660,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="macfor.html" class="language-option">
             <span id="lang-en">EN</span>

--- a/templates/companies/magalu.html
+++ b/templates/companies/magalu.html
@@ -1399,6 +1399,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="magalu.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/magalu_pt.html
+++ b/templates/companies/magalu_pt.html
@@ -1399,6 +1399,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="magalu.html" class="language-option">
             <span id="lang-en">EN</span>

--- a/templates/companies/magazineluiza.html
+++ b/templates/companies/magazineluiza.html
@@ -1606,6 +1606,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="magazineluiza.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/magazineluiza_pt.html
+++ b/templates/companies/magazineluiza_pt.html
@@ -1603,6 +1603,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="magazineluiza.html" class="language-option">
             <span>EN</span>

--- a/templates/companies/mercado-livre.html
+++ b/templates/companies/mercado-livre.html
@@ -1264,6 +1264,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="mercado-livre.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/mercado-livre_pt.html
+++ b/templates/companies/mercado-livre_pt.html
@@ -1264,6 +1264,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="mercado-livre.html" class="language-option">
             <span id="lang-en">EN</span>

--- a/templates/companies/meutudo.html
+++ b/templates/companies/meutudo.html
@@ -1348,6 +1348,11 @@
     </div>
     
     <!-- Language Toggle -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="meutudo.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/meutudo_pt.html
+++ b/templates/companies/meutudo_pt.html
@@ -1347,6 +1347,11 @@
     </div>
     
     <!-- Language Toggle -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="meutudo.html" class="language-option">
             <span>EN</span>

--- a/templates/companies/neogroup.html
+++ b/templates/companies/neogroup.html
@@ -1221,6 +1221,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="neogroup.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/neogroup_pt.html
+++ b/templates/companies/neogroup_pt.html
@@ -1221,6 +1221,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="neogroup.html" class="language-option">
             <span id="lang-en">EN</span>

--- a/templates/companies/nubank.html
+++ b/templates/companies/nubank.html
@@ -1229,6 +1229,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="nubank.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/nubank_pt.html
+++ b/templates/companies/nubank_pt.html
@@ -1229,6 +1229,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="nubank.html" class="language-option">
             <span id="lang-en">EN</span>

--- a/templates/companies/nuvemshop.html
+++ b/templates/companies/nuvemshop.html
@@ -2186,6 +2186,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="nuvemshop.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/nuvemshop_pt.html
+++ b/templates/companies/nuvemshop_pt.html
@@ -2186,6 +2186,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="nuvemshop.html" class="language-option">
             <span id="lang-en">EN</span>

--- a/templates/companies/quintoandar.html
+++ b/templates/companies/quintoandar.html
@@ -1339,6 +1339,11 @@
     </div>
     
     <!-- Language toggle -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="quintoandar.html" class="lang-option active">EN</a>
         <a href="quintoandar_pt.html" class="lang-option">PT</a>

--- a/templates/companies/quintoandar_pt.html
+++ b/templates/companies/quintoandar_pt.html
@@ -1316,6 +1316,11 @@
     </div>
     
     <!-- Language toggle -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="quintoandar.html" class="lang-option">EN</a>
         <a href="quintoandar_pt.html" class="lang-option active">PT</a>

--- a/templates/companies/raio.html
+++ b/templates/companies/raio.html
@@ -1270,6 +1270,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="raio.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/raio_pt.html
+++ b/templates/companies/raio_pt.html
@@ -1270,6 +1270,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="raio.html" class="language-option">
             <i class="fas fa-globe"></i>

--- a/templates/companies/rdstation.html
+++ b/templates/companies/rdstation.html
@@ -1621,6 +1621,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="rdstation.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/rdstation_pt.html
+++ b/templates/companies/rdstation_pt.html
@@ -1621,6 +1621,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="rdstation.html" class="language-option">
             <span id="lang-en">EN</span>

--- a/templates/companies/recarga-pay.html
+++ b/templates/companies/recarga-pay.html
@@ -2113,6 +2113,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="recarga-pay.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/recarga-pay_pt.html
+++ b/templates/companies/recarga-pay_pt.html
@@ -2143,6 +2143,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="recarga-pay.html" class="language-option">
             <span>EN</span>

--- a/templates/companies/renner.html
+++ b/templates/companies/renner.html
@@ -344,6 +344,11 @@
     </div>
 
     <!-- Toggle de idioma -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="renner.html" class="language-option active"><i class="fas fa-check-circle"></i><span id="lang-en">EN</span></a>
         <div class="language-divider"></div>

--- a/templates/companies/renner_pt.html
+++ b/templates/companies/renner_pt.html
@@ -344,6 +344,11 @@
     </div>
 
     <!-- Toggle de idioma -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="renner.html" class="language-option"><span id="lang-en">EN</span></a>
         <div class="language-divider"></div>

--- a/templates/companies/sicredi.html
+++ b/templates/companies/sicredi.html
@@ -2424,6 +2424,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="sicredi.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/sicredi_pt.html
+++ b/templates/companies/sicredi_pt.html
@@ -2424,6 +2424,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="sicredi.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/stone-co.html
+++ b/templates/companies/stone-co.html
@@ -1574,6 +1574,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="stone-co.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/stone-co_pt.html
+++ b/templates/companies/stone-co_pt.html
@@ -1573,6 +1573,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="stone-co.html" class="language-option">
             <span id="lang-en">EN</span>

--- a/templates/companies/the-heineken-company.html
+++ b/templates/companies/the-heineken-company.html
@@ -1661,6 +1661,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="the-heineken-company.html" class="language-option">
             <span>EN</span>

--- a/templates/companies/the-heineken-company_pt.html
+++ b/templates/companies/the-heineken-company_pt.html
@@ -1672,6 +1672,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="the-heineken-company.html" class="language-option">
             <span>EN</span>

--- a/templates/companies/tke.html
+++ b/templates/companies/tke.html
@@ -1369,6 +1369,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="tke.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/tke_pt.html
+++ b/templates/companies/tke_pt.html
@@ -1369,6 +1369,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="tke.html" class="language-option">
             <span id="lang-en">EN</span>

--- a/templates/companies/vibrafood.html
+++ b/templates/companies/vibrafood.html
@@ -1891,6 +1891,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="vibrafood.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/vibrafood_pt.html
+++ b/templates/companies/vibrafood_pt.html
@@ -1891,6 +1891,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="vibrafood.html" class="language-option">
             <span>EN</span>

--- a/templates/companies/vivo.html
+++ b/templates/companies/vivo.html
@@ -1260,6 +1260,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="vivo.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/vivo_pt.html
+++ b/templates/companies/vivo_pt.html
@@ -1260,6 +1260,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="vivo.html" class="language-option">
             <span id="lang-en">EN</span>

--- a/templates/companies/wehandle.html
+++ b/templates/companies/wehandle.html
@@ -1017,6 +1017,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="wehandle.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/wehandle_pt.html
+++ b/templates/companies/wehandle_pt.html
@@ -1017,6 +1017,11 @@
     </div>
 
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="wehandle.html" class="language-option">
             <i class="fas fa-globe"></i>

--- a/templates/companies/willbank.html
+++ b/templates/companies/willbank.html
@@ -2106,6 +2106,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="willbank.html" class="language-option active">
             <i class="fas fa-check-circle"></i>

--- a/templates/companies/willbank_pt.html
+++ b/templates/companies/willbank_pt.html
@@ -2106,6 +2106,11 @@
     </div>
     
     <!-- Language toggle button -->
+    <!-- Back to home button -->
+    <a href="../../index.html" title="Voltar para a selecao de empresa" style="position: fixed; bottom: 30px; left: 30px; z-index: 100; width: 60px; height: 60px; border-radius: 50%; background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); display: flex; align-items: center; justify-content: center; text-decoration: none; color: #333; font-size: 22px; transition: transform 0.2s ease;" onmouseover="this.style.transform='translateY(-2px)'" onmouseout="this.style.transform='translateY(0)'">
+        <i class="fas fa-house"></i>
+    </a>
+
     <div class="language-toggle">
         <a href="willbank.html" class="language-option">
             <span id="lang-en">EN</span>


### PR DESCRIPTION
## Resumo
- Nenhuma das 82 páginas de empresa (`templates/companies/*.html`) tinha navegação de volta para `index.html` — item pendente identificado na organização do repo (PR #21).
- Adiciona botão flutuante circular no canto inferior esquerdo (espelha o botão de impressão, já existente no canto inferior direito), com estilo inline para funcionar em qualquer paleta de marca sem depender do CSS específico de cada página.

## Test plan
- [x] `python3 validate-project.py` → 0 erros, 0 avisos
- [x] Screenshot via Chrome headless em 3 páginas com layouts bem diferentes (`general`, `renner` — editorial custom, `quintoandar` — layout diferenciado) — botão renderiza corretamente, sem sobrepor conteúdo
- [x] Link `../../index.html` resolve com HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)