### PR TITLE
feat: troca projeto Repo News por Carrera Campos

### DIFF
--- a/assets/js/cv-texts.js
+++ b/assets/js/cv-texts.js
@@ -326,9 +326,9 @@ const CVTexts = {
             // Projects
             projects: [
                 {
-                    title: "REPO NEWS",
-                    description: "Weekly insights selected with human curation and summarized by artificial intelligence — straight to the point, no noise.",
-                    techs: ["React", "TypeScript", "Tailwind CSS"]
+                    title: "CARRERA CAMPOS",
+                    description: "Website for a business law firm, featuring a free <a href=\"https://www.carreracampos.com.br/diagnostico\" target=\"_blank\">financial diagnostic tool</a> that estimates a company's financial health in about 4 minutes using academic crisis-prediction models (Altman Z-Score, Fleuriet, Kanitz).",
+                    techs: ["Next.js", "TypeScript", "Supabase"]
                 },
                 {
                     title: "VISUAL RECOGNITION",
@@ -692,9 +692,9 @@ const CVTexts = {
             // Projects
             projects: [
                 {
-                    title: "REPO NEWS",
-                    description: "Insights semanais selecionados com curadoria humana e resumidos por inteligência artificial — direto ao ponto, sem ruído.",
-                    techs: ["React", "TypeScript", "Tailwind CSS"]
+                    title: "CARRERA CAMPOS",
+                    description: "Site de escritório de advocacia empresarial, com uma <a href=\"https://www.carreracampos.com.br/diagnostico\" target=\"_blank\">ferramenta gratuita de diagnóstico financeiro</a> que estima em cerca de 4 minutos a saúde financeira de uma empresa usando modelos acadêmicos de predição de crise (Altman Z-Score, Fleuriet, Kanitz).",
+                    techs: ["Next.js", "TypeScript", "Supabase"]
                 },
                 {
                     title: "RECONHECIMENTO VISUAL",
@@ -1036,18 +1036,12 @@ function renderProjects(lang = 'en') {
     
     let html = '';
     projects.forEach(project => {
-        const repoNewsLink = project.title === 'REPO NEWS' ? 
-            `<a href="https://www.repo.news/" target="_blank" class="cta-button">
-                <i class="fas fa-external-link-alt"></i> Visit Repo News
-            </a>` : '';
-        
         html += `
             <div class="project-item">
                 <div class="project-title">${project.title}</div>
                 <div class="project-description">
                     ${project.description}
                 </div>
-                ${repoNewsLink}
                 <div style="margin-top: 15px;">
                     ${renderTechTags(project.techs)}
                 </div>

--- a/templates/companies/ifood_pt.html
+++ b/templates/companies/ifood_pt.html
@@ -1648,17 +1648,14 @@
             <h2 class="section-title" id="section-projects">PROJETOS &amp; INOVAÇÃO</h2>
             <div id="projects-container" class="projects-container">
                 <div class="project-item">
-                    <div class="project-title">REPO NEWS</div>
+                    <div class="project-title">CARRERA CAMPOS</div>
                     <div class="project-description">
-                        Insights semanais selecionados com curadoria humana e resumidos por inteligência artificial — direto ao ponto, sem ruído.
+                        Site de escritório de advocacia empresarial, com uma <a href="https://www.carreracampos.com.br/diagnostico" target="_blank">ferramenta gratuita de diagnóstico financeiro</a> que estima em cerca de 4 minutos a saúde financeira de uma empresa usando modelos acadêmicos de predição de crise (Altman Z-Score, Fleuriet, Kanitz).
                     </div>
-                    <a href="https://www.repo.news/" target="_blank" class="cta-button">
-                        <i class="fas fa-external-link-alt"></i> Visitar Repo News
-                    </a>
                     <div style="margin-top: 15px;">
-                        <span class="tech-tag">React</span>
+                        <span class="tech-tag">Next.js</span>
                         <span class="tech-tag">TypeScript</span>
-                        <span class="tech-tag">Tailwind CSS</span>
+                        <span class="tech-tag">Supabase</span>
                     </div>
                 </div>
                 

--- a/templates/companies/rdstation.html
+++ b/templates/companies/rdstation.html
@@ -1842,16 +1842,10 @@
             let html = '';
 
             projects.forEach(project => {
-                const isRepoNews = project.title === 'REPO NEWS';
                 html += `
                     <div class="project-item">
                         <div class="project-title">${project.title}</div>
                         <div class="project-description">${project.description}</div>
-                        ${isRepoNews ? `
-                            <a href="https://www.repo.news/" target="_blank" class="cta-button">
-                                <i class="fas fa-external-link-alt"></i> ${lang === 'en' ? 'Visit Repo News' : 'Visitar Repo News'}
-                            </a>
-                        ` : ''}
                         <div style="margin-top: 15px;">
                             ${renderTechTags(project.techs)}
                         </div>

--- a/templates/companies/rdstation_pt.html
+++ b/templates/companies/rdstation_pt.html
@@ -1842,16 +1842,10 @@
             let html = '';
 
             projects.forEach(project => {
-                const isRepoNews = project.title === 'REPO NEWS';
                 html += `
                     <div class="project-item">
                         <div class="project-title">${project.title}</div>
                         <div class="project-description">${project.description}</div>
-                        ${isRepoNews ? `
-                            <a href="https://www.repo.news/" target="_blank" class="cta-button">
-                                <i class="fas fa-external-link-alt"></i> Visitar Repo News
-                            </a>
-                        ` : ''}
                         <div style="margin-top: 15px;">
                             ${renderTechTags(project.techs)}
                         </div>


### PR DESCRIPTION
## Resumo
- Card de projeto "Repo News" → "Carrera Campos": site do escritório de advocacia empresarial, com destaque para a ferramenta pública de diagnóstico financeiro (Altman Z-Score, Fleuriet, Kanitz) em https://www.carreracampos.com.br/diagnostico.
- Link embutido no texto da descrição (não como botão CTA separado à parte), porque 64 das 82 páginas de empresa definem sua própria função JS local para renderizar projetos, com estruturas divergentes entre si — embutir no texto da descrição (injetado como HTML bruto em todas) foi a forma de garantir cobertura uniforme nas 82 páginas sem precisar corrigir cada implementação local individualmente.
- Corrigidas 3 cópias hardcoded que haviam ficado defasadas da fonte única `cv-texts.js` (`rdstation.html`, `rdstation_pt.html`, `ifood_pt.html`).

## Test plan
- [x] `python3 validate-project.py` → 0 erros, 0 avisos
- [x] Chrome headless em 7 páginas com estruturas variadas (`general`, `nubank`, `raio`, `rdstation`, `rdstation_pt`, `ifood_pt`, `act`) — link renderiza em todas
- [x] Screenshot visual conferido (card e link aparecem corretamente)
- [x] Grep completo por "Repo News" em todo HTML/JS → nenhuma ocorrência restante

🤖 Generated with [Claude Code](https://claude.com/claude-code)